### PR TITLE
Add composite camera view mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository is production-critical.
 - Follow existing style and patterns
 - Prioritize clarity over cleverness
 - Native Android client directory is `client-android/`
+- In `client-android/`, camera source switching is mode-based (`selfie -> world -> composite`) rather than binary front/back flip
 
 ## Documentation
 - Update all relevant documentation when making changes:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -80,6 +80,8 @@ From the project root on your local machine:
 ./deploy.sh
 ```
 
+`deploy.sh` also publishes the Android APK to `https://<your-domain>/tools/serenada.apk` by copying `client-android/app/build/outputs/apk/release/serenada.apk` into the built web assets (`client/dist/tools/serenada.apk`) before sync. If the release APK is missing, the script will attempt `./gradlew :app:assembleRelease` in `client-android/`. If that build fails, deployment continues and prints a warning instead of failing.
+
 ### 5. Android App Links (assetlinks.json)
 
 Android deep links require `/.well-known/assetlinks.json` to be served from your domain. The file lives at:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -93,6 +93,9 @@ Update it with your **release** signing certificate SHA-256 fingerprint before d
 ### 6. Advanced: Legacy Redirects
 If you need to support redirects from old domains (e.g. `connected.dowhile.fun`), you can create a template at `nginx/nginx.legacy.conf.template`. The deployment script will automatically generate an `extra` configuration for Nginx if this file exists.
 
+### 7. Android camera source modes
+The Android in-call camera source cycle (`selfie -> world -> composite`) is fully client-side and does not require server, TURN, or deployment configuration changes.
+
 ## Verification
 
 1.  Navigate to `https://your-domain.com`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple, privacy-focused 1:1 video calling application built with WebRTC. No ac
 - **Resilient signaling** – WebSocket with SSE fallback when WS is blocked
 - **Mobile-friendly** – Works on Android Chrome, iOS Safari, and desktop browsers
 - **Recent calls on home** – Web and Android home screens show your latest calls with live room occupancy (Android supports long-press remove)
+- **Android camera source cycle** – In-call source switch cycles through `selfie` (default) -> `world` -> `composite` (world feed with circular selfie overlay)
 - **Self-hostable** – Run your own instance with full control
 - **Optional join alerts** – Encrypted push notifications with snapshot previews (opt-in)
 

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -5,6 +5,7 @@ Native Android (Kotlin) client for Serenada 1:1 WebRTC calls. This app mirrors t
 ## Features
 - 1:1 WebRTC audio/video calls
 - WebSocket signaling (protocol v1)
+- In-call camera source cycle: `selfie` (default) -> `world` -> `composite` (world view with circular selfie overlay)
 - Recent calls on home (max 3, deduped) with live room occupancy status and long-press remove
 - Deep links for `https://serenada.app/call/*`
 - Foreground service to keep active calls running in the background
@@ -147,3 +148,4 @@ Server host is configurable in the in-app Settings screen (Join screen → Setti
 - WebSocket signaling only
 - No push notifications
 - No SSE fallback
+- Composite mode depends on device support for concurrent front+back camera capture; unsupported devices fall back to non-composite camera sources

--- a/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
@@ -263,7 +263,11 @@ class CompositeCameraCapturer(
         if (drawRadius <= 1) return
         val drawCenterX = left + drawWidth / 2
         val drawCenterY = top + drawHeight / 2
-        val drawRadiusSq = drawRadius * drawRadius
+        val outerRadiusSq = drawRadius.toFloat() * drawRadius.toFloat()
+        val edgeFeatherPx = (drawRadius * EDGE_FEATHER_RATIO).coerceIn(MIN_EDGE_FEATHER_PX, MAX_EDGE_FEATHER_PX)
+        val innerRadius = (drawRadius.toFloat() - edgeFeatherPx).coerceAtLeast(0.5f)
+        val innerRadiusSq = innerRadius * innerRadius
+        val edgeBlendDenominator = (outerRadiusSq - innerRadiusSq).coerceAtLeast(1f)
 
         val overlayBuffer = overlay.buffer
         val overlayDisplayWidth =
@@ -280,7 +284,14 @@ class CompositeCameraCapturer(
             val dy = displayY - drawCenterY
             for (displayX in left until right) {
                 val dx = displayX - drawCenterX
-                if (dx * dx + dy * dy > drawRadiusSq) {
+                val distSq = dx.toFloat() * dx.toFloat() + dy.toFloat() * dy.toFloat()
+                val edgeAlpha = edgeAlpha(
+                    distanceSq = distSq,
+                    innerRadiusSq = innerRadiusSq,
+                    outerRadiusSq = outerRadiusSq,
+                    edgeBlendDenominator = edgeBlendDenominator
+                )
+                if (edgeAlpha <= 0f) {
                     continue
                 }
 
@@ -311,12 +322,13 @@ class CompositeCameraCapturer(
                     x = srcBufferCoord.first,
                     y = srcBufferCoord.second
                 )
-                putPlaneValue(
+                blendPlaneValue(
                     plane = output.dataY,
                     stride = output.strideY,
                     x = outputCoord.first,
                     y = outputCoord.second,
-                    value = yValue
+                    overlayValue = yValue,
+                    alpha = edgeAlpha
                 )
             }
         }
@@ -332,7 +344,14 @@ class CompositeCameraCapturer(
             for (displayUvX in uvLeft until uvRight) {
                 val displayLumaX = displayUvX * 2 + 1
                 val dx = displayLumaX - drawCenterX
-                if (dx * dx + dy * dy > drawRadiusSq) {
+                val distSq = dx.toFloat() * dx.toFloat() + dy.toFloat() * dy.toFloat()
+                val edgeAlpha = edgeAlpha(
+                    distanceSq = distSq,
+                    innerRadiusSq = innerRadiusSq,
+                    outerRadiusSq = outerRadiusSq,
+                    edgeBlendDenominator = edgeBlendDenominator
+                )
+                if (edgeAlpha <= 0f) {
                     continue
                 }
 
@@ -377,19 +396,21 @@ class CompositeCameraCapturer(
                     x = srcUvX,
                     y = srcUvY
                 )
-                putPlaneValue(
+                blendPlaneValue(
                     plane = output.dataU,
                     stride = output.strideU,
                     x = outputUvX,
                     y = outputUvY,
-                    value = uValue
+                    overlayValue = uValue,
+                    alpha = edgeAlpha
                 )
-                putPlaneValue(
+                blendPlaneValue(
                     plane = output.dataV,
                     stride = output.strideV,
                     x = outputUvX,
                     y = outputUvY,
-                    value = vValue
+                    overlayValue = vValue,
+                    alpha = edgeAlpha
                 )
             }
         }
@@ -474,6 +495,36 @@ class CompositeCameraCapturer(
         plane.put(y * stride + x, value)
     }
 
+    private fun blendPlaneValue(
+        plane: ByteBuffer,
+        stride: Int,
+        x: Int,
+        y: Int,
+        overlayValue: Byte,
+        alpha: Float
+    ) {
+        if (alpha <= 0f) return
+        if (alpha >= 0.999f) {
+            putPlaneValue(plane, stride, x, y, overlayValue)
+            return
+        }
+        val base = getPlaneValueUnsigned(plane, stride, x, y)
+        val over = overlayValue.toInt() and 0xFF
+        val blended = (base + (over - base) * alpha).toInt().coerceIn(0, 255)
+        putPlaneValue(plane, stride, x, y, blended.toByte())
+    }
+
+    private fun edgeAlpha(
+        distanceSq: Float,
+        innerRadiusSq: Float,
+        outerRadiusSq: Float,
+        edgeBlendDenominator: Float
+    ): Float {
+        if (distanceSq <= innerRadiusSq) return 1f
+        if (distanceSq >= outerRadiusSq) return 0f
+        return ((outerRadiusSq - distanceSq) / edgeBlendDenominator).coerceIn(0f, 1f)
+    }
+
     private fun displayToBufferCoord(
         displayX: Int,
         displayY: Int,
@@ -529,5 +580,8 @@ class CompositeCameraCapturer(
         const val OVERLAY_DIAMETER_RATIO = 0.36f
         const val OVERLAY_BOTTOM_MARGIN_RATIO = 0.04f
         const val MIN_OVERLAY_SIZE = 72
+        const val EDGE_FEATHER_RATIO = 0.045f
+        const val MIN_EDGE_FEATHER_PX = 1.5f
+        const val MAX_EDGE_FEATHER_PX = 6f
     }
 }

--- a/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
@@ -1,0 +1,408 @@
+package app.serenada.android.call
+
+import android.content.Context
+import java.nio.ByteBuffer
+import kotlin.math.min
+import org.webrtc.CameraVideoCapturer
+import org.webrtc.CapturerObserver
+import org.webrtc.EglBase
+import org.webrtc.JavaI420Buffer
+import org.webrtc.SurfaceTextureHelper
+import org.webrtc.VideoCapturer
+import org.webrtc.VideoFrame
+
+class CompositeCameraCapturer(
+    context: Context,
+    private val eglContext: EglBase.Context,
+    private val mainCapturer: CameraVideoCapturer,
+    private val overlayCapturer: CameraVideoCapturer
+) : VideoCapturer {
+    private data class OverlayFrame(
+        val buffer: VideoFrame.I420Buffer,
+        val rotation: Int
+    )
+
+    private val appContext = context.applicationContext
+    private val frameLock = Any()
+
+    private var outputObserver: CapturerObserver? = null
+    private var overlayTextureHelper: SurfaceTextureHelper? = null
+    private var latestOverlayFrame: OverlayFrame? = null
+    private var started = false
+
+    private val mainObserver = object : CapturerObserver {
+        override fun onCapturerStarted(success: Boolean) = Unit
+
+        override fun onCapturerStopped() = Unit
+
+        override fun onFrameCaptured(frame: VideoFrame) {
+            val observer = outputObserver ?: return
+            val composed = composeFrame(frame)
+            observer.onFrameCaptured(composed)
+            composed.release()
+        }
+    }
+
+    private val overlayObserver = object : CapturerObserver {
+        override fun onCapturerStarted(success: Boolean) = Unit
+
+        override fun onCapturerStopped() = Unit
+
+        override fun onFrameCaptured(frame: VideoFrame) {
+            val converted = frame.buffer.toI420() ?: return
+            val overlayFrame = OverlayFrame(
+                buffer = converted,
+                rotation = normalizeRotation(frame.rotation)
+            )
+            synchronized(frameLock) {
+                latestOverlayFrame?.buffer?.release()
+                latestOverlayFrame = overlayFrame
+            }
+        }
+    }
+
+    override fun initialize(
+        surfaceTextureHelper: SurfaceTextureHelper?,
+        applicationContext: Context?,
+        capturerObserver: CapturerObserver?
+    ) {
+        requireNotNull(surfaceTextureHelper) { "surfaceTextureHelper is required" }
+        requireNotNull(capturerObserver) { "capturerObserver is required" }
+        outputObserver = capturerObserver
+        overlayTextureHelper = SurfaceTextureHelper.create("CaptureThreadOverlay", eglContext)
+        mainCapturer.initialize(surfaceTextureHelper, applicationContext ?: appContext, mainObserver)
+        overlayCapturer.initialize(
+            overlayTextureHelper,
+            applicationContext ?: appContext,
+            overlayObserver
+        )
+    }
+
+    override fun startCapture(width: Int, height: Int, framerate: Int) {
+        if (started) return
+        var mainStarted = false
+        var overlayStarted = false
+        try {
+            mainCapturer.startCapture(width, height, framerate)
+            mainStarted = true
+            overlayCapturer.startCapture(width, height, framerate)
+            overlayStarted = true
+            started = true
+            outputObserver?.onCapturerStarted(true)
+        } catch (e: Exception) {
+            if (overlayStarted) {
+                runCatching { overlayCapturer.stopCapture() }
+            }
+            if (mainStarted) {
+                runCatching { mainCapturer.stopCapture() }
+            }
+            outputObserver?.onCapturerStarted(false)
+            throw e
+        }
+    }
+
+    override fun stopCapture() {
+        if (!started) return
+        runCatching { overlayCapturer.stopCapture() }
+        runCatching { mainCapturer.stopCapture() }
+        started = false
+        outputObserver?.onCapturerStopped()
+    }
+
+    override fun changeCaptureFormat(width: Int, height: Int, framerate: Int) {
+        mainCapturer.changeCaptureFormat(width, height, framerate)
+        overlayCapturer.changeCaptureFormat(width, height, framerate)
+    }
+
+    override fun dispose() {
+        runCatching { stopCapture() }
+        mainCapturer.dispose()
+        overlayCapturer.dispose()
+        overlayTextureHelper?.dispose()
+        overlayTextureHelper = null
+        synchronized(frameLock) {
+            latestOverlayFrame?.buffer?.release()
+            latestOverlayFrame = null
+        }
+        outputObserver = null
+    }
+
+    override fun isScreencast(): Boolean = false
+
+    private fun composeFrame(mainFrame: VideoFrame): VideoFrame {
+        val mainI420 = requireNotNull(mainFrame.buffer.toI420())
+        val width = mainI420.width
+        val height = mainI420.height
+        val output = requireNotNull(JavaI420Buffer.allocate(width, height))
+        copyPlane(
+            src = mainI420.dataY,
+            srcStride = mainI420.strideY,
+            dst = output.dataY,
+            dstStride = output.strideY,
+            width = width,
+            height = height
+        )
+        copyPlane(
+            src = mainI420.dataU,
+            srcStride = mainI420.strideU,
+            dst = output.dataU,
+            dstStride = output.strideU,
+            width = width / 2,
+            height = height / 2
+        )
+        copyPlane(
+            src = mainI420.dataV,
+            srcStride = mainI420.strideV,
+            dst = output.dataV,
+            dstStride = output.strideV,
+            width = width / 2,
+            height = height / 2
+        )
+
+        val overlay = synchronized(frameLock) {
+            latestOverlayFrame?.let {
+                it.buffer.retain()
+                OverlayFrame(buffer = it.buffer, rotation = it.rotation)
+            }
+        }
+
+        if (overlay != null) {
+            drawCircularOverlay(
+                output = output,
+                outputRotation = normalizeRotation(mainFrame.rotation),
+                overlay = overlay
+            )
+            overlay.buffer.release()
+        }
+        mainI420.release()
+        return VideoFrame(output, mainFrame.rotation, mainFrame.timestampNs)
+    }
+
+    private fun drawCircularOverlay(
+        output: JavaI420Buffer,
+        outputRotation: Int,
+        overlay: OverlayFrame
+    ) {
+        val outputWidth = output.width
+        val outputHeight = output.height
+        val outputDisplayWidth = if (outputRotation % 180 == 0) outputWidth else outputHeight
+        val outputDisplayHeight = if (outputRotation % 180 == 0) outputHeight else outputWidth
+
+        val diameter = (min(outputDisplayWidth, outputDisplayHeight) * OVERLAY_DIAMETER_RATIO).toInt()
+            .coerceAtLeast(MIN_OVERLAY_SIZE)
+            .coerceAtMost(min(outputDisplayWidth, outputDisplayHeight) - 2)
+        if (diameter <= 2) return
+
+        val radius = diameter / 2
+        val margin = (outputDisplayHeight * OVERLAY_BOTTOM_MARGIN_RATIO).toInt().coerceAtLeast(8)
+        val centerX = outputDisplayWidth / 2
+        val centerY = (outputDisplayHeight - margin - radius).coerceAtLeast(radius + 1)
+        val left = (centerX - radius).coerceAtLeast(0)
+        val top = (centerY - radius).coerceAtLeast(0)
+        val right = (centerX + radius).coerceAtMost(outputDisplayWidth)
+        val bottom = (centerY + radius).coerceAtMost(outputDisplayHeight)
+        val drawWidth = right - left
+        val drawHeight = bottom - top
+        if (drawWidth <= 2 || drawHeight <= 2) return
+
+        val drawRadius = min(drawWidth, drawHeight) / 2
+        if (drawRadius <= 1) return
+        val drawCenterX = left + drawWidth / 2
+        val drawCenterY = top + drawHeight / 2
+        val drawRadiusSq = drawRadius * drawRadius
+
+        val overlayBuffer = overlay.buffer
+        val overlayDisplayWidth =
+            if (overlay.rotation % 180 == 0) overlayBuffer.width else overlayBuffer.height
+        val overlayDisplayHeight =
+            if (overlay.rotation % 180 == 0) overlayBuffer.height else overlayBuffer.width
+
+        val srcSize = min(overlayDisplayWidth, overlayDisplayHeight)
+        val srcLeft = (overlayDisplayWidth - srcSize) / 2
+        val srcTop = (overlayDisplayHeight - srcSize) / 2
+        if (srcSize <= 1) return
+
+        for (displayY in top until bottom) {
+            val dy = displayY - drawCenterY
+            for (displayX in left until right) {
+                val dx = displayX - drawCenterX
+                if (dx * dx + dy * dy > drawRadiusSq) {
+                    continue
+                }
+
+                val outputCoord = displayToBufferCoord(
+                    displayX = displayX,
+                    displayY = displayY,
+                    bufferWidth = outputWidth,
+                    bufferHeight = outputHeight,
+                    rotation = outputRotation
+                ) ?: continue
+
+                val srcDisplayX =
+                    srcLeft + ((displayX - left) * srcSize / drawWidth).coerceIn(0, srcSize - 1)
+                val srcDisplayY =
+                    srcTop + ((displayY - top) * srcSize / drawHeight).coerceIn(0, srcSize - 1)
+                val srcBufferCoord = displayToBufferCoord(
+                    displayX = srcDisplayX,
+                    displayY = srcDisplayY,
+                    bufferWidth = overlayBuffer.width,
+                    bufferHeight = overlayBuffer.height,
+                    rotation = overlay.rotation
+                ) ?: continue
+                val yValue = getPlaneValue(
+                    plane = overlayBuffer.dataY,
+                    stride = overlayBuffer.strideY,
+                    x = srcBufferCoord.first,
+                    y = srcBufferCoord.second
+                )
+                putPlaneValue(
+                    plane = output.dataY,
+                    stride = output.strideY,
+                    x = outputCoord.first,
+                    y = outputCoord.second,
+                    value = yValue
+                )
+            }
+        }
+
+        if (srcSize / 2 <= 0) return
+        val uvLeft = left / 2
+        val uvTop = top / 2
+        val uvRight = right / 2
+        val uvBottom = bottom / 2
+        for (displayUvY in uvTop until uvBottom) {
+            val displayLumaY = displayUvY * 2 + 1
+            val dy = displayLumaY - drawCenterY
+            for (displayUvX in uvLeft until uvRight) {
+                val displayLumaX = displayUvX * 2 + 1
+                val dx = displayLumaX - drawCenterX
+                if (dx * dx + dy * dy > drawRadiusSq) {
+                    continue
+                }
+
+                val outputLumaCoord = displayToBufferCoord(
+                    displayX = displayLumaX,
+                    displayY = displayLumaY,
+                    bufferWidth = outputWidth,
+                    bufferHeight = outputHeight,
+                    rotation = outputRotation
+                ) ?: continue
+                val outputUvX = (outputLumaCoord.first / 2).coerceIn(0, (outputWidth / 2) - 1)
+                val outputUvY = (outputLumaCoord.second / 2).coerceIn(0, (outputHeight / 2) - 1)
+
+                val srcDisplayLumaX =
+                    srcLeft + ((displayLumaX - left) * srcSize / drawWidth).coerceIn(0, srcSize - 1)
+                val srcDisplayLumaY =
+                    srcTop + ((displayLumaY - top) * srcSize / drawHeight).coerceIn(0, srcSize - 1)
+                val srcLumaCoord = displayToBufferCoord(
+                    displayX = srcDisplayLumaX,
+                    displayY = srcDisplayLumaY,
+                    bufferWidth = overlayBuffer.width,
+                    bufferHeight = overlayBuffer.height,
+                    rotation = overlay.rotation
+                ) ?: continue
+
+                val srcUvX = (srcLumaCoord.first / 2).coerceIn(0, (overlayBuffer.width / 2) - 1)
+                val srcUvY = (srcLumaCoord.second / 2).coerceIn(0, (overlayBuffer.height / 2) - 1)
+
+                val uValue = getPlaneValue(
+                    plane = overlayBuffer.dataU,
+                    stride = overlayBuffer.strideU,
+                    x = srcUvX,
+                    y = srcUvY
+                )
+                val vValue = getPlaneValue(
+                    plane = overlayBuffer.dataV,
+                    stride = overlayBuffer.strideV,
+                    x = srcUvX,
+                    y = srcUvY
+                )
+                putPlaneValue(
+                    plane = output.dataU,
+                    stride = output.strideU,
+                    x = outputUvX,
+                    y = outputUvY,
+                    value = uValue
+                )
+                putPlaneValue(
+                    plane = output.dataV,
+                    stride = output.strideV,
+                    x = outputUvX,
+                    y = outputUvY,
+                    value = vValue
+                )
+            }
+        }
+    }
+
+    private fun copyPlane(
+        src: ByteBuffer,
+        srcStride: Int,
+        dst: ByteBuffer,
+        dstStride: Int,
+        width: Int,
+        height: Int
+    ) {
+        val srcRow = src.duplicate()
+        val dstRow = dst.duplicate()
+        for (row in 0 until height) {
+            val srcOffset = row * srcStride
+            srcRow.position(srcOffset)
+            srcRow.limit(srcOffset + width)
+            dstRow.position(row * dstStride)
+            dstRow.put(srcRow)
+            srcRow.limit(srcRow.capacity())
+        }
+    }
+
+    private fun getPlaneValue(
+        plane: ByteBuffer,
+        stride: Int,
+        x: Int,
+        y: Int
+    ): Byte = plane.get(y * stride + x)
+
+    private fun putPlaneValue(
+        plane: ByteBuffer,
+        stride: Int,
+        x: Int,
+        y: Int,
+        value: Byte
+    ) {
+        plane.put(y * stride + x, value)
+    }
+
+    private fun displayToBufferCoord(
+        displayX: Int,
+        displayY: Int,
+        bufferWidth: Int,
+        bufferHeight: Int,
+        rotation: Int
+    ): Pair<Int, Int>? {
+        val coord = when (rotation) {
+            0 -> Pair(displayX, displayY)
+            90 -> Pair(displayY, bufferHeight - 1 - displayX)
+            180 -> Pair(bufferWidth - 1 - displayX, bufferHeight - 1 - displayY)
+            270 -> Pair(bufferWidth - 1 - displayY, displayX)
+            else -> Pair(displayX, displayY)
+        }
+        if (coord.first !in 0 until bufferWidth || coord.second !in 0 until bufferHeight) {
+            return null
+        }
+        return coord
+    }
+
+    private fun normalizeRotation(rotation: Int): Int {
+        val normalized = ((rotation % 360) + 360) % 360
+        return when (normalized) {
+            0, 90, 180, 270 -> normalized
+            else -> 0
+        }
+    }
+
+    private companion object {
+        const val OVERLAY_DIAMETER_RATIO = 0.30f
+        const val OVERLAY_BOTTOM_MARGIN_RATIO = 0.04f
+        const val MIN_OVERLAY_SIZE = 72
+    }
+}

--- a/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
@@ -2,6 +2,7 @@ package app.serenada.android.call
 
 import android.content.Context
 import java.nio.ByteBuffer
+import kotlin.math.floor
 import kotlin.math.min
 import org.webrtc.CameraVideoCapturer
 import org.webrtc.CapturerObserver
@@ -292,19 +293,21 @@ class CompositeCameraCapturer(
                 ) ?: continue
 
                 val srcDisplayX =
-                    srcLeft + ((displayX - left) * srcSize / drawWidth).coerceIn(0, srcSize - 1)
+                    srcLeft + (((displayX - left) + 0.5f) * srcSize / drawWidth.toFloat()) - 0.5f
                 val srcDisplayY =
-                    srcTop + ((displayY - top) * srcSize / drawHeight).coerceIn(0, srcSize - 1)
-                val srcBufferCoord = displayToBufferCoord(
+                    srcTop + (((displayY - top) + 0.5f) * srcSize / drawHeight.toFloat()) - 0.5f
+                val srcBufferCoord = displayToBufferCoordFloat(
                     displayX = srcDisplayX,
                     displayY = srcDisplayY,
                     bufferWidth = overlayBuffer.width,
                     bufferHeight = overlayBuffer.height,
                     rotation = overlay.rotation
                 ) ?: continue
-                val yValue = getPlaneValue(
+                val yValue = samplePlaneBilinear(
                     plane = overlayBuffer.dataY,
                     stride = overlayBuffer.strideY,
+                    width = overlayBuffer.width,
+                    height = overlayBuffer.height,
                     x = srcBufferCoord.first,
                     y = srcBufferCoord.second
                 )
@@ -344,10 +347,10 @@ class CompositeCameraCapturer(
                 val outputUvY = (outputLumaCoord.second / 2).coerceIn(0, (outputHeight / 2) - 1)
 
                 val srcDisplayLumaX =
-                    srcLeft + ((displayLumaX - left) * srcSize / drawWidth).coerceIn(0, srcSize - 1)
+                    srcLeft + (((displayLumaX - left) + 0.5f) * srcSize / drawWidth.toFloat()) - 0.5f
                 val srcDisplayLumaY =
-                    srcTop + ((displayLumaY - top) * srcSize / drawHeight).coerceIn(0, srcSize - 1)
-                val srcLumaCoord = displayToBufferCoord(
+                    srcTop + (((displayLumaY - top) + 0.5f) * srcSize / drawHeight.toFloat()) - 0.5f
+                val srcLumaCoord = displayToBufferCoordFloat(
                     displayX = srcDisplayLumaX,
                     displayY = srcDisplayLumaY,
                     bufferWidth = overlayBuffer.width,
@@ -355,18 +358,22 @@ class CompositeCameraCapturer(
                     rotation = overlay.rotation
                 ) ?: continue
 
-                val srcUvX = (srcLumaCoord.first / 2).coerceIn(0, (overlayBuffer.width / 2) - 1)
-                val srcUvY = (srcLumaCoord.second / 2).coerceIn(0, (overlayBuffer.height / 2) - 1)
+                val srcUvX = srcLumaCoord.first / 2f
+                val srcUvY = srcLumaCoord.second / 2f
 
-                val uValue = getPlaneValue(
+                val uValue = samplePlaneBilinear(
                     plane = overlayBuffer.dataU,
                     stride = overlayBuffer.strideU,
+                    width = overlayBuffer.width / 2,
+                    height = overlayBuffer.height / 2,
                     x = srcUvX,
                     y = srcUvY
                 )
-                val vValue = getPlaneValue(
+                val vValue = samplePlaneBilinear(
                     plane = overlayBuffer.dataV,
                     stride = overlayBuffer.strideV,
+                    width = overlayBuffer.width / 2,
+                    height = overlayBuffer.height / 2,
                     x = srcUvX,
                     y = srcUvY
                 )
@@ -415,6 +422,48 @@ class CompositeCameraCapturer(
         y: Int
     ): Byte = plane.get(y * stride + x)
 
+    private fun getPlaneValueUnsigned(
+        plane: ByteBuffer,
+        stride: Int,
+        x: Int,
+        y: Int
+    ): Int = plane.get(y * stride + x).toInt() and 0xFF
+
+    private fun samplePlaneBilinear(
+        plane: ByteBuffer,
+        stride: Int,
+        width: Int,
+        height: Int,
+        x: Float,
+        y: Float
+    ): Byte {
+        if (width <= 0 || height <= 0) return 0
+        if (width == 1 || height == 1) {
+            val px = x.toInt().coerceIn(0, width - 1)
+            val py = y.toInt().coerceIn(0, height - 1)
+            return getPlaneValue(plane, stride, px, py)
+        }
+
+        val xClamped = x.coerceIn(0f, (width - 1).toFloat())
+        val yClamped = y.coerceIn(0f, (height - 1).toFloat())
+        val x0 = floor(xClamped).toInt().coerceIn(0, width - 1)
+        val y0 = floor(yClamped).toInt().coerceIn(0, height - 1)
+        val x1 = (x0 + 1).coerceAtMost(width - 1)
+        val y1 = (y0 + 1).coerceAtMost(height - 1)
+        val fx = xClamped - x0
+        val fy = yClamped - y0
+
+        val v00 = getPlaneValueUnsigned(plane, stride, x0, y0)
+        val v10 = getPlaneValueUnsigned(plane, stride, x1, y0)
+        val v01 = getPlaneValueUnsigned(plane, stride, x0, y1)
+        val v11 = getPlaneValueUnsigned(plane, stride, x1, y1)
+
+        val top = v00 + (v10 - v00) * fx
+        val bottom = v01 + (v11 - v01) * fx
+        val value = (top + (bottom - top) * fy).toInt().coerceIn(0, 255)
+        return value.toByte()
+    }
+
     private fun putPlaneValue(
         plane: ByteBuffer,
         stride: Int,
@@ -445,6 +494,29 @@ class CompositeCameraCapturer(
         return coord
     }
 
+    private fun displayToBufferCoordFloat(
+        displayX: Float,
+        displayY: Float,
+        bufferWidth: Int,
+        bufferHeight: Int,
+        rotation: Int
+    ): Pair<Float, Float>? {
+        val coord = when (rotation) {
+            0 -> Pair(displayX, displayY)
+            90 -> Pair(displayY, (bufferHeight - 1).toFloat() - displayX)
+            180 -> Pair((bufferWidth - 1).toFloat() - displayX, (bufferHeight - 1).toFloat() - displayY)
+            270 -> Pair((bufferWidth - 1).toFloat() - displayY, displayX)
+            else -> Pair(displayX, displayY)
+        }
+        if (
+            coord.first < 0f || coord.first > (bufferWidth - 1).toFloat() ||
+                coord.second < 0f || coord.second > (bufferHeight - 1).toFloat()
+        ) {
+            return null
+        }
+        return coord
+    }
+
     private fun normalizeRotation(rotation: Int): Int {
         val normalized = ((rotation % 360) + 360) % 360
         return when (normalized) {
@@ -454,7 +526,7 @@ class CompositeCameraCapturer(
     }
 
     private companion object {
-        const val OVERLAY_DIAMETER_RATIO = 0.30f
+        const val OVERLAY_DIAMETER_RATIO = 0.36f
         const val OVERLAY_BOTTOM_MARGIN_RATIO = 0.04f
         const val MIN_OVERLAY_SIZE = 72
     }

--- a/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CompositeCameraCapturer.kt
@@ -15,8 +15,14 @@ class CompositeCameraCapturer(
     context: Context,
     private val eglContext: EglBase.Context,
     private val mainCapturer: CameraVideoCapturer,
-    private val overlayCapturer: CameraVideoCapturer
+    private val overlayCapturer: CameraVideoCapturer,
+    private val onStartFailure: (() -> Unit)? = null
 ) : VideoCapturer {
+    private enum class ChildCapturer {
+        MAIN,
+        OVERLAY
+    }
+
     private data class OverlayFrame(
         val buffer: VideoFrame.I420Buffer,
         val rotation: Int
@@ -28,10 +34,15 @@ class CompositeCameraCapturer(
     private var outputObserver: CapturerObserver? = null
     private var overlayTextureHelper: SurfaceTextureHelper? = null
     private var latestOverlayFrame: OverlayFrame? = null
+    private var mainStartResult: Boolean? = null
+    private var overlayStartResult: Boolean? = null
+    private var startReported = false
     private var started = false
 
     private val mainObserver = object : CapturerObserver {
-        override fun onCapturerStarted(success: Boolean) = Unit
+        override fun onCapturerStarted(success: Boolean) {
+            onChildCapturerStarted(ChildCapturer.MAIN, success)
+        }
 
         override fun onCapturerStopped() = Unit
 
@@ -44,7 +55,9 @@ class CompositeCameraCapturer(
     }
 
     private val overlayObserver = object : CapturerObserver {
-        override fun onCapturerStarted(success: Boolean) = Unit
+        override fun onCapturerStarted(success: Boolean) {
+            onChildCapturerStarted(ChildCapturer.OVERLAY, success)
+        }
 
         override fun onCapturerStopped() = Unit
 
@@ -80,6 +93,10 @@ class CompositeCameraCapturer(
 
     override fun startCapture(width: Int, height: Int, framerate: Int) {
         if (started) return
+        started = true
+        mainStartResult = null
+        overlayStartResult = null
+        startReported = false
         var mainStarted = false
         var overlayStarted = false
         try {
@@ -87,8 +104,6 @@ class CompositeCameraCapturer(
             mainStarted = true
             overlayCapturer.startCapture(width, height, framerate)
             overlayStarted = true
-            started = true
-            outputObserver?.onCapturerStarted(true)
         } catch (e: Exception) {
             if (overlayStarted) {
                 runCatching { overlayCapturer.stopCapture() }
@@ -96,7 +111,7 @@ class CompositeCameraCapturer(
             if (mainStarted) {
                 runCatching { mainCapturer.stopCapture() }
             }
-            outputObserver?.onCapturerStarted(false)
+            notifyStartFailed()
             throw e
         }
     }
@@ -106,6 +121,9 @@ class CompositeCameraCapturer(
         runCatching { overlayCapturer.stopCapture() }
         runCatching { mainCapturer.stopCapture() }
         started = false
+        mainStartResult = null
+        overlayStartResult = null
+        startReported = false
         outputObserver?.onCapturerStopped()
     }
 
@@ -128,6 +146,41 @@ class CompositeCameraCapturer(
     }
 
     override fun isScreencast(): Boolean = false
+
+    private fun onChildCapturerStarted(capturer: ChildCapturer, success: Boolean) {
+        if (!started) return
+        if (!success) {
+            notifyStartFailed()
+            return
+        }
+        var notifySuccess = false
+        synchronized(frameLock) {
+            if (!started || startReported) return
+            when (capturer) {
+                ChildCapturer.MAIN -> mainStartResult = true
+                ChildCapturer.OVERLAY -> overlayStartResult = true
+            }
+            if (mainStartResult == true && overlayStartResult == true) {
+                startReported = true
+                notifySuccess = true
+            }
+        }
+        if (notifySuccess) {
+            outputObserver?.onCapturerStarted(true)
+        }
+    }
+
+    private fun notifyStartFailed() {
+        synchronized(frameLock) {
+            if (!started || startReported) return
+            startReported = true
+        }
+        started = false
+        runCatching { overlayCapturer.stopCapture() }
+        runCatching { mainCapturer.stopCapture() }
+        outputObserver?.onCapturerStarted(false)
+        onStartFailure?.invoke()
+    }
 
     private fun composeFrame(mainFrame: VideoFrame): VideoFrame {
         val mainI420 = requireNotNull(mainFrame.buffer.toI420())

--- a/client-android/app/src/main/java/app/serenada/android/call/WebRtcEngine.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/WebRtcEngine.kt
@@ -1,6 +1,8 @@
 package app.serenada.android.call
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import java.util.Collections
 import java.util.WeakHashMap
@@ -59,6 +61,7 @@ class WebRtcEngine(
     private var audioSource: AudioSource? = null
     private var surfaceTextureHelper: SurfaceTextureHelper? = null
     private var currentCameraSource = LocalCameraSource.SELFIE
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     private var localSink: VideoSink? = null
     private var remoteSink: VideoSink? = null
@@ -631,12 +634,24 @@ class WebRtcEngine(
                                 context = appContext,
                                 eglContext = eglBase.eglBaseContext,
                                 mainCapturer = mainCapturer,
-                                overlayCapturer = overlayCapturer
+                                overlayCapturer = overlayCapturer,
+                                onStartFailure = { onCompositeStartFailure() }
                             ),
                             isFrontFacing = false
                         )
                     }
                 }
+            }
+        }
+    }
+
+    private fun onCompositeStartFailure() {
+        mainHandler.post {
+            if (currentCameraSource != LocalCameraSource.COMPOSITE) return@post
+            if (videoCapturer !is CompositeCameraCapturer) return@post
+            Log.w("WebRtcEngine", "Composite source failed to start; falling back to selfie")
+            if (restartVideoCapturer(LocalCameraSource.SELFIE)) {
+                Log.w("WebRtcEngine", "Camera source fallback applied: ${LocalCameraSource.SELFIE}")
             }
         }
     }

--- a/client-android/app/src/main/java/app/serenada/android/call/WebRtcEngine.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/WebRtcEngine.kt
@@ -6,7 +6,6 @@ import java.util.Collections
 import java.util.WeakHashMap
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
-import org.webrtc.CameraVideoCapturer
 import org.webrtc.Camera2Enumerator
 import org.webrtc.DefaultVideoDecoderFactory
 import org.webrtc.DefaultVideoEncoderFactory
@@ -37,6 +36,17 @@ class WebRtcEngine(
     private val onCameraFacingChanged: (Boolean) -> Unit,
     private var isRemoteBlackFrameAnalysisEnabled: Boolean = true
 ) {
+    private enum class LocalCameraSource {
+        SELFIE,
+        WORLD,
+        COMPOSITE
+    }
+
+    private data class CapturerSelection(
+        val capturer: VideoCapturer,
+        val isFrontFacing: Boolean
+    )
+
     private val appContext = context.applicationContext
     private val eglBase: EglBase = EglBase.create()
     private val peerConnectionFactory: PeerConnectionFactory
@@ -48,6 +58,7 @@ class WebRtcEngine(
     private var videoSource: VideoSource? = null
     private var audioSource: AudioSource? = null
     private var surfaceTextureHelper: SurfaceTextureHelper? = null
+    private var currentCameraSource = LocalCameraSource.SELFIE
 
     private var localSink: VideoSink? = null
     private var remoteSink: VideoSink? = null
@@ -85,19 +96,17 @@ class WebRtcEngine(
         localAudioTrack = peerConnectionFactory.createAudioTrack("ARDAMSa0", audioSource)
         applyAudioTrackHints()
 
-        val capturer = createVideoCapturer() ?: run {
-            Log.w("WebRtcEngine", "No camera capturer available")
-            return
-        }
-        videoCapturer = capturer
-        val textureHelper = SurfaceTextureHelper.create("CaptureThread", eglBase.eglBaseContext)
-        surfaceTextureHelper = textureHelper
         videoSource = peerConnectionFactory.createVideoSource(false)
-        capturer.initialize(textureHelper, appContext, videoSource?.capturerObserver)
-        try {
-            capturer.startCapture(640, 480, 30)
-        } catch (e: Exception) {
-            Log.w("WebRtcEngine", "Failed to start capture", e)
+        currentCameraSource = LocalCameraSource.SELFIE
+        if (!restartVideoCapturer(currentCameraSource)) {
+            Log.w("WebRtcEngine", "No camera capturer available for $currentCameraSource")
+            videoSource?.dispose()
+            videoSource = null
+            localAudioTrack?.setEnabled(false)
+            localAudioTrack = null
+            audioSource?.dispose()
+            audioSource = null
+            return
         }
         localVideoTrack = peerConnectionFactory.createVideoTrack("ARDAMSv0", videoSource)
         localVideoTrack?.setEnabled(true)
@@ -110,15 +119,7 @@ class WebRtcEngine(
     fun stopLocalMedia() {
         localVideoTrack?.setEnabled(false)
         localAudioTrack?.setEnabled(false)
-        try {
-            videoCapturer?.stopCapture()
-        } catch (e: Exception) {
-            Log.w("WebRtcEngine", "Failed to stop capture", e)
-        }
-        videoCapturer?.dispose()
-        videoCapturer = null
-        surfaceTextureHelper?.dispose()
-        surfaceTextureHelper = null
+        disposeVideoCapturer()
         videoSource?.dispose()
         videoSource = null
         audioSource?.dispose()
@@ -175,17 +176,24 @@ class WebRtcEngine(
     }
 
     fun flipCamera() {
-        val capturer = videoCapturer as? CameraVideoCapturer ?: return
-        capturer.switchCamera(object : CameraVideoCapturer.CameraSwitchHandler {
-            override fun onCameraSwitchDone(isFrontCamera: Boolean) {
-                Log.d("WebRtcEngine", "Camera switched. Front=$isFrontCamera")
-                onCameraFacingChanged(isFrontCamera)
-            }
-
-            override fun onCameraSwitchError(errorDescription: String?) {
-                Log.w("WebRtcEngine", "Camera switch failed: $errorDescription")
-            }
-        })
+        if (videoSource == null) return
+        val target = when (currentCameraSource) {
+            LocalCameraSource.SELFIE -> LocalCameraSource.WORLD
+            LocalCameraSource.WORLD -> LocalCameraSource.COMPOSITE
+            LocalCameraSource.COMPOSITE -> LocalCameraSource.SELFIE
+        }
+        if (restartVideoCapturer(target)) {
+            return
+        }
+        Log.w("WebRtcEngine", "Failed to switch camera source to $target")
+        val fallback = if (target == LocalCameraSource.COMPOSITE) {
+            LocalCameraSource.SELFIE
+        } else {
+            currentCameraSource
+        }
+        if (fallback != target && restartVideoCapturer(fallback)) {
+            Log.w("WebRtcEngine", "Camera source fallback applied: $fallback")
+        }
     }
 
     fun createOffer(
@@ -544,21 +552,93 @@ class WebRtcEngine(
         }
     }
 
-    private fun createVideoCapturer(): VideoCapturer? {
+    private fun restartVideoCapturer(source: LocalCameraSource): Boolean {
+        val observer = videoSource?.capturerObserver ?: return false
+        disposeVideoCapturer()
+        val selection = createVideoCapturer(source) ?: return false
+        val textureHelper = SurfaceTextureHelper.create("CaptureThread", eglBase.eglBaseContext)
+        try {
+            selection.capturer.initialize(textureHelper, appContext, observer)
+            selection.capturer.startCapture(CAPTURE_WIDTH, CAPTURE_HEIGHT, CAPTURE_FPS)
+        } catch (e: Exception) {
+            Log.w("WebRtcEngine", "Failed to start capture for $source", e)
+            runCatching { selection.capturer.dispose() }
+            runCatching { textureHelper.dispose() }
+            return false
+        }
+        videoCapturer = selection.capturer
+        surfaceTextureHelper = textureHelper
+        currentCameraSource = source
+        onCameraFacingChanged(selection.isFrontFacing)
+        Log.d("WebRtcEngine", "Camera source active: $source")
+        return true
+    }
+
+    private fun disposeVideoCapturer() {
+        try {
+            videoCapturer?.stopCapture()
+        } catch (e: Exception) {
+            Log.w("WebRtcEngine", "Failed to stop capture", e)
+        }
+        runCatching { videoCapturer?.dispose() }
+        videoCapturer = null
+        runCatching { surfaceTextureHelper?.dispose() }
+        surfaceTextureHelper = null
+    }
+
+    private fun createVideoCapturer(source: LocalCameraSource): CapturerSelection? {
         val enumerator = Camera2Enumerator(appContext)
-        for (deviceName in enumerator.deviceNames) {
-            if (enumerator.isFrontFacing(deviceName)) {
-                onCameraFacingChanged(true)
-                return enumerator.createCapturer(deviceName, null)
+        val front = enumerator.deviceNames.firstOrNull { enumerator.isFrontFacing(it) }
+        val back = enumerator.deviceNames.firstOrNull { enumerator.isBackFacing(it) }
+        return when (source) {
+            LocalCameraSource.SELFIE -> {
+                if (front != null) {
+                    enumerator.createCapturer(front, null)?.let {
+                        CapturerSelection(capturer = it, isFrontFacing = true)
+                    }
+                } else if (back != null) {
+                    enumerator.createCapturer(back, null)?.let {
+                        CapturerSelection(capturer = it, isFrontFacing = false)
+                    }
+                } else {
+                    null
+                }
+            }
+
+            LocalCameraSource.WORLD -> {
+                if (back == null) {
+                    null
+                } else {
+                    enumerator.createCapturer(back, null)?.let {
+                        CapturerSelection(capturer = it, isFrontFacing = false)
+                    }
+                }
+            }
+
+            LocalCameraSource.COMPOSITE -> {
+                if (front == null || back == null) {
+                    null
+                } else {
+                    val mainCapturer = enumerator.createCapturer(back, null)
+                    val overlayCapturer = enumerator.createCapturer(front, null)
+                    if (mainCapturer == null || overlayCapturer == null) {
+                        mainCapturer?.dispose()
+                        overlayCapturer?.dispose()
+                        null
+                    } else {
+                        CapturerSelection(
+                            capturer = CompositeCameraCapturer(
+                                context = appContext,
+                                eglContext = eglBase.eglBaseContext,
+                                mainCapturer = mainCapturer,
+                                overlayCapturer = overlayCapturer
+                            ),
+                            isFrontFacing = false
+                        )
+                    }
+                }
             }
         }
-        for (deviceName in enumerator.deviceNames) {
-            if (enumerator.isBackFacing(deviceName)) {
-                onCameraFacingChanged(false)
-                return enumerator.createCapturer(deviceName, null)
-            }
-        }
-        return null
     }
 
     private fun onRemoteVideoFrame(frame: org.webrtc.VideoFrame) {
@@ -574,5 +654,11 @@ class WebRtcEngine(
                 "[RemoteVideo] syntheticBlack=$syntheticBlackNow trackEnabled=${remoteVideoTrack?.enabled()} analyzerEnabled=$isRemoteBlackFrameAnalysisEnabled"
             )
         }
+    }
+
+    private companion object {
+        const val CAPTURE_WIDTH = 640
+        const val CAPTURE_HEIGHT = 480
+        const val CAPTURE_FPS = 30
     }
 }

--- a/push-notifications.md
+++ b/push-notifications.md
@@ -5,6 +5,7 @@
 - Keep the server blind to snapshot contents (no plaintext stored or processed).
 - Preserve multi-subscriber delivery (one snapshot can be shared across multiple recipients).
 - Keep snapshots short-lived (10 minute TTL).
+- Keep push flow independent from in-call camera source modes (including Android composite mode).
 
 ## Architecture (Server-blind)
 ### Key material (per subscriber)

--- a/serenada_protocol_v1.md
+++ b/serenada_protocol_v1.md
@@ -10,7 +10,7 @@
 - Room capacity enforcement (max 2)
 - Basic error handling
 
-**Out of scope:** analytics, auth accounts, multi-party calling, chat, recording, presence across devices, etc.
+**Out of scope:** analytics, auth accounts, multi-party calling, chat, recording, presence across devices, client-local camera source/compositing modes, etc.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a composite camera source mode for Android calls (selfie -> world -> composite)
- add `CompositeCameraCapturer` and wire it into `WebRtcEngine`
- update docs for camera source mode behavior and deployment/protocol notes

## Why this PR is focused
This branch is created from current `main` and contains a single feature commit only, avoiding unrelated Android directory history differences.

## Testing
- Not run in CI from this environment
