### PR TITLE
Fix iOS join snapshots not appearing in push notifications

### DIFF
--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -1575,10 +1575,6 @@ final class CallManager: ObservableObject {
 
         startRemoteVideoStatePolling()
 
-        pendingJoinRoom = roomId
-        if !hasJoinSignalStartedForAttempt {
-            ensureSignalingConnection()
-        }
         prepareJoinSnapshotAndConnect(roomId: roomId, joinAttempt: joinAttempt)
     }
 
@@ -1597,15 +1593,7 @@ final class CallManager: ObservableObject {
                 guard self.isJoinAttemptActive(roomId: roomId, joinAttempt: joinAttempt) else { return }
                 self.debugTrace("joinSnapshot ready rid=\(roomId) hasSnapshot=\(snapshotId == nil ? "no" : "yes")")
                 self.pendingJoinSnapshotId = snapshotId
-                let shouldEnsure =
-                    !self.hasJoinSignalStartedForAttempt ||
-                    self.pendingJoinRoom != nil ||
-                    !self.signalingClient.isConnected()
-                if shouldEnsure {
-                    self.ensureSignalingConnection()
-                } else {
-                    self.debugTrace("joinSnapshot skipEnsure rid=\(roomId) reason=join-already-started")
-                }
+                self.ensureSignalingConnection()
             }
         )
     }

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -1575,6 +1575,7 @@ final class CallManager: ObservableObject {
 
         startRemoteVideoStatePolling()
 
+        clearJoinConnectKickstart()
         prepareJoinSnapshotAndConnect(roomId: roomId, joinAttempt: joinAttempt)
     }
 

--- a/client-ios/Sources/Core/Push/JoinSnapshotFeature.swift
+++ b/client-ios/Sources/Core/Push/JoinSnapshotFeature.swift
@@ -145,10 +145,13 @@ final class JoinSnapshotFeature {
             renderer = LocalFrameSnapshotRenderer { [weak self] frame in
                 guard let self else {
                     finish(nil)
-                    return
+                    return true
                 }
-                let image = self.encodeSnapshot(frame: frame)
+                guard let image = self.encodeSnapshot(frame: frame) else {
+                    return false // black frame — skip, try next
+                }
                 finish(image)
+                return true
             }
 
             if let renderer {
@@ -366,11 +369,11 @@ final class JoinSnapshotFeature {
 
 #if canImport(WebRTC)
 private final class LocalFrameSnapshotRenderer: NSObject, RTCVideoRenderer {
-    private let onFrame: (RTCVideoFrame) -> Void
+    private let onFrame: (RTCVideoFrame) -> Bool
     private let lock = NSLock()
     private var consumed = false
 
-    init(onFrame: @escaping (RTCVideoFrame) -> Void) {
+    init(onFrame: @escaping (RTCVideoFrame) -> Bool) {
         self.onFrame = onFrame
     }
 
@@ -379,14 +382,17 @@ private final class LocalFrameSnapshotRenderer: NSObject, RTCVideoRenderer {
     func renderFrame(_ frame: RTCVideoFrame?) {
         guard let frame else { return }
         lock.lock()
-        let shouldConsume = !consumed
-        if shouldConsume {
-            consumed = true
+        if consumed {
+            lock.unlock()
+            return
         }
         lock.unlock()
 
-        guard shouldConsume else { return }
-        onFrame(frame)
+        if onFrame(frame) {
+            lock.lock()
+            consumed = true
+            lock.unlock()
+        }
     }
 }
 #endif

--- a/client-ios/Sources/Core/Push/JoinSnapshotFeature.swift
+++ b/client-ios/Sources/Core/Push/JoinSnapshotFeature.swift
@@ -263,7 +263,7 @@ final class JoinSnapshotFeature {
         }
 
         let ephemeralPrivate = P256.KeyAgreement.PrivateKey()
-        let ephemeralPublicRaw = ephemeralPrivate.publicKey.rawRepresentation
+        let ephemeralPublicRaw = ephemeralPrivate.publicKey.x963Representation
         let salt = randomBytes(Constants.saltBytes)
         let info = Data(Constants.hkdfInfo.utf8)
 
@@ -323,7 +323,7 @@ final class JoinSnapshotFeature {
         var raw = Data([0x04])
         raw.append(x)
         raw.append(y)
-        return try? P256.KeyAgreement.PublicKey(rawRepresentation: raw)
+        return try? P256.KeyAgreement.PublicKey(x963Representation: raw)
     }
 
     private func encryptAESGCM(plaintext: Data, keyData: Data, iv: Data) -> Data? {


### PR DESCRIPTION
## Summary
- **P-256 key format fix**: iOS used CryptoKit's `rawRepresentation` (64-byte x||y) instead of `x963Representation` (65-byte 0x04||x||y) for both the ephemeral public key export and recipient public key import. This caused silent encryption failure since Web Crypto and Android expect the standard uncompressed point format.
- **Join sequence fix**: Removed eager `ensureSignalingConnection()` call that sent join before snapshot prep completed. The snapshot callback is now the sole trigger for connecting and sending join (matching Android).
- **Black frame skip**: The snapshot renderer now skips black camera frames (common during initialization) instead of giving up. Callback returns `Bool` — `false` retries with the next frame, `true` consumes.
- **Kickstart race fix**: Cancel the 1.2s kickstart timer before starting snapshot preparation to prevent it from sending join without snapshotId.

## Test plan
- [x] Built and installed on iPhone
- [x] Verified end-to-end: snapshot captured (176KB JPEG), encrypted, uploaded, included in join message, delivered via push
- [x] Confirmed server receives `snapshotId` in join payload
- [x] Confirmed push notification includes snapshot metadata for recipients
- [x] Verified snapshot decrypts correctly on receiving device

🤖 Generated with [Claude Code](https://claude.com/claude-code)