### PR TITLE
Extract SDK logging into SerenadaLogger interface

### DIFF
--- a/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
@@ -25,6 +25,7 @@ import app.serenada.core.RoomOccupancy
 import app.serenada.core.RoomWatcher
 import app.serenada.core.RoomWatcherDelegate
 import app.serenada.core.SerenadaConfig
+import app.serenada.core.AndroidSerenadaLogger
 import app.serenada.core.SerenadaCore
 import app.serenada.core.SerenadaSession
 import app.serenada.core.SerenadaTransport
@@ -134,7 +135,7 @@ class CallManager(context: Context) : RoomWatcherDelegate {
             } else {
                 listOf(SerenadaTransport.WS, SerenadaTransport.SSE)
             }
-        return SerenadaCore(
+        val core = SerenadaCore(
             config = SerenadaConfig(
                 serverHost = host,
                 defaultAudioEnabled = settingsStore.isDefaultMicrophoneEnabled,
@@ -144,6 +145,8 @@ class CallManager(context: Context) : RoomWatcherDelegate {
             ),
             context = appContext,
         )
+        core.logger = AndroidSerenadaLogger()
+        return core
     }
 
     private fun beginSdkSession(session: SerenadaSession, hostOverride: String? = null) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -19,6 +19,7 @@ class SerenadaCore(
     private val context: Context,
 ) {
     var delegate: SerenadaCoreDelegate? = null
+    var logger: SerenadaLogger? = null
 
     private val okHttpClient = OkHttpClient.Builder().build()
     private val apiClient = CoreApiClient(okHttpClient)
@@ -44,6 +45,7 @@ class SerenadaCore(
             context = context,
             delegate = { delegate },
             okHttpClient = okHttpClient,
+            logger = logger,
         )
         session.start()
         return session
@@ -63,6 +65,7 @@ class SerenadaCore(
             context = context,
             delegate = { delegate },
             okHttpClient = okHttpClient,
+            logger = logger,
         )
         session.start()
         return session
@@ -94,6 +97,7 @@ class SerenadaCore(
             context = context,
             delegate = { delegate },
             okHttpClient = okHttpClient,
+            logger = logger,
         )
         session.start()
         return CreateRoomResult(roomId = roomId, roomUrl = roomUrl, session = session)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaLogger.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaLogger.kt
@@ -1,0 +1,20 @@
+package app.serenada.core
+
+import android.util.Log
+
+enum class SerenadaLogLevel { DEBUG, INFO, WARNING, ERROR }
+
+interface SerenadaLogger {
+    fun log(level: SerenadaLogLevel, tag: String, message: String)
+}
+
+class AndroidSerenadaLogger : SerenadaLogger {
+    override fun log(level: SerenadaLogLevel, tag: String, message: String) {
+        when (level) {
+            SerenadaLogLevel.DEBUG -> Log.d(tag, message)
+            SerenadaLogLevel.INFO -> Log.i(tag, message)
+            SerenadaLogLevel.WARNING -> Log.w(tag, message)
+            SerenadaLogLevel.ERROR -> Log.e(tag, message)
+        }
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -65,6 +65,7 @@ class SerenadaSession internal constructor(
     audioController: SessionAudioController? = null,
     mediaEngine: SessionMediaEngine? = null,
     clock: SessionClock? = null,
+    private val logger: SerenadaLogger? = null,
 ) {
     private val appContext = context.applicationContext
     private val handler = Handler(Looper.getMainLooper())
@@ -246,6 +247,7 @@ class SerenadaSession internal constructor(
                 if (next != current) updateDiagnostics(next)
             },
             onConnectionStatusUpdate = { updateConnectionStatusFromSignals() },
+            logger = logger,
         )
     }
 
@@ -264,9 +266,10 @@ class SerenadaSession internal constructor(
         context = appContext,
         handler = handler,
         onProximityChanged = { near ->
-            Log.d(TAG, "Proximity sensor changed: ${if (near) "NEAR" else "FAR"}")
+            logger?.log(SerenadaLogLevel.DEBUG, "Session", "Proximity sensor changed: ${if (near) "NEAR" else "FAR"}")
         },
-        onAudioEnvironmentChanged = { applyLocalVideoPreference() }
+        onAudioEnvironmentChanged = { applyLocalVideoPreference() },
+        logger = logger,
     )
 
     private val forceSse = config.transports == listOf(SerenadaTransport.SSE)
@@ -310,7 +313,7 @@ class SerenadaSession internal constructor(
     }
 
     private val signalingClient: SessionSignaling = (signaling ?: SignalingClient(
-        okHttpClient, handler, signalingListener, forceSse = forceSse,
+        okHttpClient, handler, signalingListener, forceSse = forceSse, logger = logger,
     )).also { it.listener = signalingListener }
 
     // --- Public API ---
@@ -360,7 +363,7 @@ class SerenadaSession internal constructor(
         assertMainThread()
         if (_diagnostics.value.isScreenSharing) return
         if (!webRtcEngine.startScreenShare(intent)) {
-            Log.w(TAG, "Failed to start screen sharing")
+            logger?.log(SerenadaLogLevel.WARNING, "Session", "Failed to start screen sharing")
             return
         }
         updateDiagnostics(_diagnostics.value.copy(isScreenSharing = true))
@@ -372,7 +375,7 @@ class SerenadaSession internal constructor(
         assertMainThread()
         if (!_diagnostics.value.isScreenSharing) return
         if (!webRtcEngine.stopScreenShare()) {
-            Log.w(TAG, "Failed to stop screen sharing")
+            logger?.log(SerenadaLogLevel.WARNING, "Session", "Failed to stop screen sharing")
             return
         }
         updateDiagnostics(_diagnostics.value.copy(isScreenSharing = false))
@@ -631,7 +634,8 @@ class SerenadaSession internal constructor(
                     setFeatureDegradation(degradation)
                 }
             },
-            isHdVideoExperimentalEnabled = config.isHdVideoExperimentalEnabled
+            isHdVideoExperimentalEnabled = config.isHdVideoExperimentalEnabled,
+            logger = logger,
         )
     }
 
@@ -684,7 +688,7 @@ class SerenadaSession internal constructor(
     }
 
     private fun sendMessage(type: String, payload: JSONObject?, to: String? = null) {
-        Log.d(TAG, "TX $type")
+        logger?.log(SerenadaLogLevel.DEBUG, "Session", "TX $type")
         val msg = SignalingMessage(
             type = type,
             rid = roomId,
@@ -697,7 +701,7 @@ class SerenadaSession internal constructor(
     }
 
     private fun handleSignalingMessage(msg: SignalingMessage) {
-        Log.d(TAG, "RX ${msg.type}")
+        logger?.log(SerenadaLogLevel.DEBUG, "Session", "RX ${msg.type}")
         when (msg.type) {
             "joined" -> handleJoined(msg)
             "room_state" -> handleRoomState(msg)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -9,7 +9,6 @@ import android.net.NetworkRequest
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
-import android.util.Log
 import app.serenada.core.call.ConnectionStatusTracker
 import app.serenada.core.call.JoinTimer
 import app.serenada.core.call.LiveSessionClock

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
@@ -12,7 +12,6 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
 import android.os.Handler
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
@@ -13,12 +13,15 @@ import android.media.AudioManager
 import android.os.Build
 import android.os.Handler
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 
 class CallAudioSessionController(
     context: Context,
     private val handler: Handler,
     private val onProximityChanged: (Boolean) -> Unit,
-    private val onAudioEnvironmentChanged: () -> Unit
+    private val onAudioEnvironmentChanged: () -> Unit,
+    private val logger: SerenadaLogger? = null,
 ) : SessionAudioController {
     private val appContext = context.applicationContext
     private val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -37,7 +40,7 @@ class CallAudioSessionController(
     private var bluetoothScoActive = false
 
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
-        Log.d("CallManager", "Audio focus changed: $focusChange")
+        logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio focus changed: $focusChange")
     }
 
     private val audioDeviceCallback = object : AudioDeviceCallback() {
@@ -80,12 +83,13 @@ class CallAudioSessionController(
             applyCallAudioRouting()
             onAudioEnvironmentChanged()
         }.onSuccess {
-            Log.d(
-                "CallManager",
+            logger?.log(
+                SerenadaLogLevel.DEBUG,
+                "Audio",
                 "Audio session activated (prevMode=$previousAudioMode, focusGranted=$audioFocusGranted)"
             )
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to activate audio session", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to activate audio session: ${error.message}")
         }
     }
 
@@ -106,9 +110,9 @@ class CallAudioSessionController(
             setSpeakerphoneEnabled(previousSpeakerphoneOn)
             audioManager.mode = previousAudioMode
         }.onSuccess {
-            Log.d("CallManager", "Audio session restored (mode=$previousAudioMode)")
+            logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio session restored (mode=$previousAudioMode)")
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to restore audio session", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to restore audio session: ${error.message}")
         }
         abandonAudioFocus()
     }
@@ -138,7 +142,7 @@ class CallAudioSessionController(
                 handler
             )
         }.getOrElse { error ->
-            Log.w("CallManager", "Failed to register proximity listener", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to register proximity listener: ${error.message}")
             false
         }
         if (registered) {
@@ -155,7 +159,7 @@ class CallAudioSessionController(
         runCatching {
             sensorManager?.unregisterListener(proximitySensorListener)
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to unregister proximity listener", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to unregister proximity listener: ${error.message}")
         }
         proximityMonitoringActive = false
         isProximityNear = false
@@ -167,7 +171,7 @@ class CallAudioSessionController(
             audioManager.registerAudioDeviceCallback(audioDeviceCallback, handler)
             audioDeviceMonitoringActive = true
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to register audio device callback", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to register audio device callback: ${error.message}")
         }
     }
 
@@ -176,7 +180,7 @@ class CallAudioSessionController(
         runCatching {
             audioManager.unregisterAudioDeviceCallback(audioDeviceCallback)
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to unregister audio device callback", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to unregister audio device callback: ${error.message}")
         }
         audioDeviceMonitoringActive = false
     }
@@ -198,7 +202,7 @@ class CallAudioSessionController(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val bluetoothDevice = findBluetoothCommunicationDevice()
             if (bluetoothDevice == null || !audioManager.setCommunicationDevice(bluetoothDevice)) {
-                Log.w("CallManager", "Failed to route audio to Bluetooth headset")
+                logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to route audio to Bluetooth headset")
                 routeAudioToSpeaker()
             }
             return
@@ -295,7 +299,7 @@ class CallAudioSessionController(
                     it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
                 }
                 if (speaker == null || !audioManager.setCommunicationDevice(speaker)) {
-                    Log.w("CallManager", "Failed to route audio to built-in speaker")
+                    logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to route audio to built-in speaker")
                 }
             } else {
                 audioManager.clearCommunicationDevice()
@@ -334,7 +338,7 @@ class CallAudioSessionController(
             ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
         }
         audioFocusGranted = granted
-        Log.d("CallManager", "Audio focus request granted=$granted")
+        logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio focus request granted=$granted")
     }
 
     private fun abandonAudioFocus() {
@@ -352,9 +356,9 @@ class CallAudioSessionController(
             }
             Unit
         }.onSuccess {
-            Log.d("CallManager", "Audio focus abandoned")
+            logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio focus abandoned")
         }.onFailure { error ->
-            Log.w("CallManager", "Failed to abandon audio focus", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to abandon audio focus: ${error.message}")
         }
     }
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
@@ -15,6 +15,8 @@ import android.util.Log
 import android.util.Range
 import app.serenada.core.FeatureDegradation
 import app.serenada.core.FeatureDegradationState
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
@@ -38,6 +40,7 @@ internal class CameraCaptureController(
     private val onFlashlightStateChanged: (Boolean, Boolean) -> Unit,
     private val onFeatureDegradation: (FeatureDegradationState) -> Unit,
     private val onVideoSenderParametersChanged: () -> Unit,
+    private val logger: SerenadaLogger? = null,
 ) {
     internal enum class LocalCameraSource {
         SELFIE,
@@ -113,7 +116,7 @@ internal class CameraCaptureController(
                 selection.captureProfile.fps
             )
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to start capture for $source", e)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to start capture for $source: ${e.message}")
             runCatching { selection.capturer.dispose() }
             runCatching { textureHelper.dispose() }
             return false
@@ -134,8 +137,9 @@ internal class CameraCaptureController(
             applyZoomForCurrentMode()
         }
         onVideoSenderParametersChanged()
-        Log.d(
-            TAG,
+        logger?.log(
+            SerenadaLogLevel.DEBUG,
+            "Camera",
             "Camera source active: $source (${selection.captureProfile.width}x${selection.captureProfile.height}@${selection.captureProfile.fps}fps)"
         )
         return true
@@ -145,7 +149,7 @@ internal class CameraCaptureController(
         try {
             videoCapturer?.stopCapture()
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to stop capture", e)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to stop capture: ${e.message}")
         }
         runCatching { videoCapturer?.dispose() }
         videoCapturer = null
@@ -163,12 +167,12 @@ internal class CameraCaptureController(
         )
         val target = cameraSourceFromMode(targetMode)
         if (!compositeAvailable && targetMode == LocalCameraMode.SELFIE && currentCameraSource == LocalCameraSource.WORLD) {
-            Log.w(TAG, "Transitioning from WORLD to SELFIE (COMPOSITE unavailable)")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Transitioning from WORLD to SELFIE (COMPOSITE unavailable)")
         }
         if (restartVideoCapturer(target, videoSource)) {
             return
         }
-        Log.w(TAG, "Failed to switch camera source to $target")
+        logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to switch camera source to $target")
         val fallback = if (targetMode == LocalCameraMode.COMPOSITE) {
             compositeDisabledAfterFailure = true
             reportCompositeCameraUnavailable("Composite camera switch failed")
@@ -177,7 +181,7 @@ internal class CameraCaptureController(
             currentCameraSource
         }
         if (fallback != target && restartVideoCapturer(fallback, videoSource)) {
-            Log.w(TAG, "Camera source fallback applied: $fallback")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Camera source fallback applied: $fallback")
         }
     }
 
@@ -200,8 +204,9 @@ internal class CameraCaptureController(
     fun toggleFlashlight(): Boolean {
         if (!isTorchAvailableForCurrentMode()) return false
         isTorchPreferenceEnabled = !isTorchPreferenceEnabled
-        Log.d(
-            TAG,
+        logger?.log(
+            SerenadaLogLevel.DEBUG,
+            "Camera",
             "Flash toggle requested: preference=$isTorchPreferenceEnabled mode=${activeVideoModeLabel()} torchCamera=$activeTorchCameraId"
         )
         if (applyTorchForCurrentMode()) {
@@ -220,7 +225,7 @@ internal class CameraCaptureController(
         isHdVideoExperimentalEnabled = enabled
         if (!isScreenSharing && localVideoTrack != null && videoSource != null) {
             if (!restartVideoCapturer(currentCameraSource, videoSource)) {
-                Log.w(TAG, "Failed to apply HD video setting by restarting capturer")
+                logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to apply HD video setting by restarting capturer")
             }
         }
         onVideoSenderParametersChanged()
@@ -451,7 +456,8 @@ internal class CameraCaptureController(
                                 eglContext = eglBase.eglBaseContext,
                                 mainCapturer = mainCapturer,
                                 overlayCapturer = overlayCapturer,
-                                onStartFailure = { onCompositeStartFailure() }
+                                onStartFailure = { onCompositeStartFailure() },
+                                logger = logger,
                             ),
                             isFrontFacing = false,
                             captureProfile = profile,
@@ -530,10 +536,10 @@ internal class CameraCaptureController(
             if (currentCameraSource != LocalCameraSource.COMPOSITE) return@post
             if (videoCapturer !is CompositeCameraCapturer) return@post
             compositeDisabledAfterFailure = true
-            Log.w(TAG, "Composite source failed; disabling composite and falling back to selfie")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Composite source failed; disabling composite and falling back to selfie")
             reportCompositeCameraUnavailable("Composite source failed to start")
             if (restartVideoCapturer(LocalCameraSource.SELFIE, videoSourceProvider())) {
-                Log.w(TAG, "Camera source fallback applied: ${LocalCameraSource.SELFIE}")
+                logger?.log(SerenadaLogLevel.WARNING, "Camera", "Camera source fallback applied: ${LocalCameraSource.SELFIE}")
             }
         }
     }
@@ -564,7 +570,7 @@ internal class CameraCaptureController(
                     .get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL)
             }.getOrNull()
             if (frontLevel !in capable || backLevel !in capable) {
-                Log.d(TAG,
+                logger?.log(SerenadaLogLevel.DEBUG, "Camera",
                     "Composite source skipped on API <30: hardware level insufficient (front=$frontLevel back=$backLevel)")
                 return false
             }
@@ -584,8 +590,9 @@ internal class CameraCaptureController(
         }.getOrDefault(false)
         compositeSupportCache = Pair(cacheKey, supported)
         if (!supported) {
-            Log.w(
-                TAG,
+            logger?.log(
+                SerenadaLogLevel.WARNING,
+                "Camera",
                 "Composite source unsupported by concurrent camera constraints. front=$frontDevice back=$backDevice"
             )
         }
@@ -602,7 +609,7 @@ internal class CameraCaptureController(
                 hasFlash && lensFacing == CameraCharacteristics.LENS_FACING_BACK
             }
         }.onFailure { error ->
-            Log.w(TAG, "Failed to query torch camera id", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to query torch camera id: ${error.message}")
         }.getOrNull()
     }
 
@@ -612,7 +619,7 @@ internal class CameraCaptureController(
             manager.getCameraCharacteristics(cameraId)
                 .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
         }.onFailure { error ->
-            Log.w(TAG, "Failed to query flash availability for camera=$cameraId", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to query flash availability for camera=$cameraId: ${error.message}")
         }.getOrDefault(false)
     }
 
@@ -668,7 +675,7 @@ internal class CameraCaptureController(
                 )
             }
         }.onFailure { error ->
-            Log.w(TAG, "Failed to query zoom capabilities for camera=$activeCameraId", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to query zoom capabilities for camera=$activeCameraId: ${error.message}")
         }.getOrNull()
     }
 
@@ -707,7 +714,7 @@ internal class CameraCaptureController(
                     appliedCameraZoomRatio = targetZoomRatio
                 }
             }.onFailure { error ->
-                Log.w(TAG, "Failed to apply zoom via capture request", error)
+                logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to apply zoom via capture request: ${error.message}")
             }
         }
         return true
@@ -727,8 +734,9 @@ internal class CameraCaptureController(
         if (applyTorchViaCaptureRequest(enabled, requestedZoomRatioForCurrentMode())) {
             isTorchEnabled = enabled
             torchSyncRequired = false
-            Log.d(
-                TAG,
+            logger?.log(
+                SerenadaLogLevel.DEBUG,
+                "Camera",
                 "Torch mode set via capture request: enabled=$enabled mode=${activeVideoModeLabel()} camera=$activeTorchCameraId"
             )
             if (notify) {
@@ -757,20 +765,20 @@ internal class CameraCaptureController(
                 }
                 return true
             }
-            Log.w(TAG, "Torch unavailable. managerPresent=${manager != null} cameraId=$cameraId")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Torch unavailable. managerPresent=${manager != null} cameraId=$cameraId")
             return false
         }
         return try {
             manager.setTorchMode(cameraId, enabled)
             isTorchEnabled = enabled
             torchSyncRequired = false
-            Log.d(TAG, "Torch mode set: enabled=$enabled cameraId=$cameraId")
+            logger?.log(SerenadaLogLevel.DEBUG, "Camera", "Torch mode set: enabled=$enabled cameraId=$cameraId")
             if (notify) {
                 notifyCameraModeAndFlash()
             }
             true
         } catch (error: CameraAccessException) {
-            Log.w(TAG, "Failed to set torch mode", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to set torch mode: ${error.message}")
             if (!enabled) {
                 isTorchEnabled = false
                 torchSyncRequired = false
@@ -780,7 +788,7 @@ internal class CameraCaptureController(
             }
             false
         } catch (error: SecurityException) {
-            Log.w(TAG, "Torch permission denied", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Torch permission denied: ${error.message}")
             if (!enabled) {
                 isTorchEnabled = false
                 torchSyncRequired = false
@@ -790,7 +798,7 @@ internal class CameraCaptureController(
             }
             false
         } catch (error: IllegalArgumentException) {
-            Log.w(TAG, "Torch camera id invalid", error)
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Torch camera id invalid: ${error.message}")
             if (!enabled) {
                 isTorchEnabled = false
                 torchSyncRequired = false
@@ -857,13 +865,13 @@ internal class CameraCaptureController(
                 )
             }
                 .onFailure { error ->
-                    Log.w(TAG, "Failed to apply torch via capture request", error)
+                    logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to apply torch via capture request: ${error.message}")
                 }
                 .getOrDefault(false)
             latch.countDown()
         }
         if (!latch.await(750, TimeUnit.MILLISECONDS)) {
-            Log.w(TAG, "Timed out waiting for torch capture request")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Timed out waiting for torch capture request")
             return false
         }
         if (applied && isZoomAvailableForCurrentMode()) {
@@ -915,10 +923,10 @@ internal class CameraCaptureController(
                 builder.set(CaptureRequest.CONTROL_ZOOM_RATIO, clampedZoom)
                 true
             }.onFailure { error ->
-                Log.w(
-                    TAG,
-                    "Failed to apply CONTROL_ZOOM_RATIO; falling back to SCALER_CROP_REGION",
-                    error
+                logger?.log(
+                    SerenadaLogLevel.WARNING,
+                    "Camera",
+                    "Failed to apply CONTROL_ZOOM_RATIO; falling back to SCALER_CROP_REGION: ${error.message}"
                 )
             }.getOrDefault(false)
             if (appliedViaRatio) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
@@ -11,7 +11,6 @@ import android.hardware.camera2.CaptureRequest
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.util.Range
 import app.serenada.core.FeatureDegradation
 import app.serenada.core.FeatureDegradationState

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CompositeCameraCapturer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CompositeCameraCapturer.kt
@@ -2,6 +2,8 @@ package app.serenada.core.call
 
 import android.content.Context
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -26,7 +28,8 @@ class CompositeCameraCapturer(
     private val eglContext: EglBase.Context,
     private val mainCapturer: CameraVideoCapturer,
     private val overlayCapturer: CameraVideoCapturer,
-    private val onStartFailure: (() -> Unit)? = null
+    private val onStartFailure: (() -> Unit)? = null,
+    private val logger: SerenadaLogger? = null,
 ) : VideoCapturer {
     private enum class ChildCapturer {
         MAIN,
@@ -145,7 +148,7 @@ class CompositeCameraCapturer(
     override fun dispose() {
         runCatching { stopCapture() }
         if (childStopTimedOut) {
-            Log.w("CompositeCameraCapturer", "Skipping synchronous child dispose after stop timeout")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Skipping synchronous child dispose after stop timeout")
         } else {
             mainCapturer.dispose()
             overlayCapturer.dispose()
@@ -223,7 +226,7 @@ class CompositeCameraCapturer(
             mainThread.interrupt()
             runCatching { overlayThread.join(STOP_INTERRUPT_GRACE_MS) }
             runCatching { mainThread.join(STOP_INTERRUPT_GRACE_MS) }
-            Log.w("CompositeCameraCapturer", "Timed out waiting for child capturers to stop")
+            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Timed out waiting for child capturers to stop")
         }
         return stopped
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CompositeCameraCapturer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CompositeCameraCapturer.kt
@@ -1,7 +1,6 @@
 package app.serenada.core.call
 
 import android.content.Context
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import java.nio.ByteBuffer

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -1,6 +1,5 @@
 package app.serenada.core.call
 
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import org.webrtc.AudioTrack

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -1,6 +1,8 @@
 package app.serenada.core.call
 
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import org.webrtc.AudioTrack
 import org.webrtc.IceCandidate
 import org.webrtc.MediaConstraints
@@ -32,6 +34,7 @@ class PeerConnectionSlot(
     private val applyAudioSenderParameters: (PeerConnection) -> Unit,
     private val currentVideoSenderPolicy: () -> WebRtcEngine.VideoSenderPolicy,
     private val isRemoteBlackFrameAnalysisEnabled: () -> Boolean,
+    private val logger: SerenadaLogger? = null,
 ) : PeerConnectionSlotProtocol {
     private data class MediaTotals(
         var inboundPacketsReceived: Long = 0L,
@@ -131,8 +134,9 @@ class PeerConnectionSlot(
             blackFrameAnalysisEnabled = isRemoteBlackFrameAnalysisEnabled()
         )
         if (stateChanged) {
-            Log.d(
-                "PeerConnectionSlot",
+            logger?.log(
+                SerenadaLogLevel.DEBUG,
+                "PeerConnection",
                 "[RemoteVideo][$remoteCid] syntheticBlack=${remoteBlackFrameAnalyzer.isSyntheticBlackDetected()} trackEnabled=${remoteVideoTrack?.enabled()}"
             )
         }
@@ -156,7 +160,7 @@ class PeerConnectionSlot(
             }
 
             override fun onConnectionChange(newState: PeerConnection.PeerConnectionState) {
-                Log.d("PeerConnectionSlot", "[$remoteCid] Connection state: $newState")
+                logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] Connection state: $newState")
                 onConnectionStateChange(remoteCid, newState)
             }
 
@@ -174,12 +178,12 @@ class PeerConnectionSlot(
             }
 
             override fun onSignalingChange(newState: PeerConnection.SignalingState) {
-                Log.d("PeerConnectionSlot", "[$remoteCid] Signaling state: $newState")
+                logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] Signaling state: $newState")
                 onSignalingStateChange(remoteCid, newState)
             }
 
             override fun onIceConnectionChange(newState: PeerConnection.IceConnectionState) {
-                Log.d("PeerConnectionSlot", "[$remoteCid] ICE state: $newState")
+                logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] ICE state: $newState")
                 onIceConnectionStateChange(remoteCid, newState)
             }
 
@@ -271,14 +275,14 @@ class PeerConnectionSlot(
                     }
 
                     override fun onSetFailure(error: String?) {
-                        Log.w("PeerConnectionSlot", "[$remoteCid] Failed to set local offer: $error")
+                        logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set local offer: $error")
                         onComplete?.invoke(false)
                     }
                 }, desc)
             }
 
             override fun onCreateFailure(error: String?) {
-                Log.w("PeerConnectionSlot", "[$remoteCid] Offer creation failed: $error")
+                logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Offer creation failed: $error")
                 onComplete?.invoke(false)
             }
         }, constraints)
@@ -311,14 +315,14 @@ class PeerConnectionSlot(
                     }
 
                     override fun onSetFailure(error: String?) {
-                        Log.w("PeerConnectionSlot", "[$remoteCid] Failed to set local answer: $error")
+                        logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set local answer: $error")
                         onComplete?.invoke(false)
                     }
                 }, desc)
             }
 
             override fun onCreateFailure(error: String?) {
-                Log.w("PeerConnectionSlot", "[$remoteCid] Answer creation failed: $error")
+                logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Answer creation failed: $error")
                 onComplete?.invoke(false)
             }
         }, constraints)
@@ -342,7 +346,7 @@ class PeerConnectionSlot(
             }
 
             override fun onSetFailure(error: String?) {
-                Log.w("PeerConnectionSlot", "[$remoteCid] Failed to set remote description ($type): $error")
+                logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set remote description ($type): $error")
             }
         }, desc)
     }
@@ -376,7 +380,7 @@ class PeerConnectionSlot(
             }
 
             override fun onSetFailure(error: String?) {
-                Log.w("PeerConnectionSlot", "[$remoteCid] Failed to rollback local description: $error")
+                logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to rollback local description: $error")
                 onComplete?.invoke(false)
             }
         }, desc)
@@ -446,7 +450,7 @@ class PeerConnectionSlot(
             encodings[0].maxFramerate = policy.maxFramerate
             sender.setParameters(params)
         } catch (e: Exception) {
-            Log.w("PeerConnectionSlot", "[$remoteCid] Failed to apply video sender parameters", e)
+            logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to apply video sender parameters: ${e.message}")
         }
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -1,7 +1,6 @@
 package app.serenada.core.call
 
 import android.os.Handler
-import android.util.Log
 import app.serenada.core.IceConnectionState
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -3,6 +3,8 @@ package app.serenada.core.call
 import android.os.Handler
 import android.util.Log
 import app.serenada.core.IceConnectionState
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import app.serenada.core.PeerConnectionState
 import app.serenada.core.RtcSignalingState
 import org.webrtc.IceCandidate
@@ -41,6 +43,7 @@ class PeerNegotiationEngine(
     private val onRemoteParticipantsChanged: () -> Unit,
     private val onAggregatePeerStateChanged: (IceConnectionState, PeerConnectionState, RtcSignalingState) -> Unit,
     private val onConnectionStatusUpdate: () -> Unit,
+    private val logger: SerenadaLogger? = null,
 ) {
     companion object {
         private const val TAG = "PeerNegotiationEngine"
@@ -338,7 +341,7 @@ class PeerNegotiationEngine(
         val slot = getSlot(remoteCid) ?: return
         if (!canOffer(slot)) { slot.markPendingIceRestart(); return }
         if (slot.isMakingOffer) { slot.markPendingIceRestart(); return }
-        Log.w(TAG, "ICE restart triggered for $remoteCid ($reason)")
+        logger?.log(SerenadaLogLevel.WARNING, "Negotiation", "ICE restart triggered for $remoteCid ($reason)")
         slot.recordIceRestart(clock.nowMs())
         maybeSendOffer(slot, force = true, iceRestart = true)
     }
@@ -352,7 +355,7 @@ class PeerNegotiationEngine(
         val runnable = Runnable {
             slot.clearNonHostFallbackTask()
             slot.incrementNonHostFallbackAttempts()
-            Log.w(TAG, "Non-host offer fallback for $remoteCid ($reason)")
+            logger?.log(SerenadaLogLevel.WARNING, "Negotiation", "Non-host offer fallback for $remoteCid ($reason)")
             maybeSendNonHostFallbackOffer(remoteCid)
         }
         slot.setNonHostFallbackTask(runnable)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
@@ -9,6 +9,8 @@ import android.os.Handler
 import android.os.Looper
 import android.util.DisplayMetrics
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import kotlin.math.min
 import kotlin.math.roundToInt
 import org.webrtc.EglBase
@@ -23,6 +25,7 @@ internal class ScreenShareController(
     private val videoSourceProvider: () -> org.webrtc.VideoSource?,
     private val onScreenShareStopped: () -> Unit,
     private val onStateChanged: (Boolean) -> Unit,
+    private val logger: SerenadaLogger? = null,
 ) {
     var isScreenSharing: Boolean = false
         private set
@@ -55,14 +58,15 @@ internal class ScreenShareController(
             isScreenSharing = true
             cameraController.isScreenSharing = true
             onStateChanged(true)
-            Log.d(
-                TAG,
+            logger?.log(
+                SerenadaLogLevel.DEBUG,
+                "ScreenShare",
                 "Screen share capture profile: ${captureProfile.width}x${captureProfile.height}@${captureProfile.fps}fps"
             )
             cameraController.applyTorchForCurrentMode()
             true
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to start screen sharing", e)
+            logger?.log(SerenadaLogLevel.WARNING, "ScreenShare", "Failed to start screen sharing: ${e.message}")
             runCatching { capturer.dispose() }
             runCatching { textureHelper.dispose() }
             val videoSource = videoSourceProvider()
@@ -83,7 +87,7 @@ internal class ScreenShareController(
         val videoSource = videoSourceProvider()
         if (!cameraController.restartVideoCapturer(sourceToRestore, videoSource) &&
             !cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)) {
-            Log.w(TAG, "Failed to restore camera after screen sharing stop")
+            logger?.log(SerenadaLogLevel.WARNING, "ScreenShare", "Failed to restore camera after screen sharing stop")
         }
         return true
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.DisplayMetrics
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import kotlin.math.min

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
@@ -1,7 +1,6 @@
 package app.serenada.core.call
 
 import android.os.Handler
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import okhttp3.OkHttpClient

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
@@ -2,13 +2,16 @@ package app.serenada.core.call
 
 import android.os.Handler
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import okhttp3.OkHttpClient
 
 class SignalingClient(
     private val okHttpClient: OkHttpClient,
     private val handler: Handler,
     initialListener: SessionSignaling.Listener? = null,
-    private val forceSse: Boolean = false
+    private val forceSse: Boolean = false,
+    private val logger: SerenadaLogger? = null,
 ) : SessionSignaling {
     enum class TransportKind(val wireName: String) {
         WS("ws"),
@@ -29,8 +32,8 @@ class SignalingClient(
         TransportKind.SSE to false
     )
 
-    private val wsTransport = WebSocketSignalingTransport(okHttpClient)
-    private val sseTransport = SseSignalingTransport(okHttpClient)
+    private val wsTransport = WebSocketSignalingTransport(okHttpClient, logger = logger)
+    private val sseTransport = SseSignalingTransport(okHttpClient, logger = logger)
     private val transports = listOf<SignalingTransport>(wsTransport, sseTransport)
 
     @Volatile private var connected = false
@@ -55,7 +58,7 @@ class SignalingClient(
             return
         }
         if (forceSse) {
-            Log.i(TAG, "FORCE_SSE_SIGNALING is enabled; using SSE only")
+            logger?.log(SerenadaLogLevel.INFO, "Signaling", "FORCE_SSE_SIGNALING is enabled; using SSE only")
         }
         resetTransportState()
         if (normalized != normalizedHost) {
@@ -187,7 +190,7 @@ class SignalingClient(
         if (kind == TransportKind.WS) wsConsecutiveFailures = 0
         lastPongAt = System.currentTimeMillis()
         missedPongs = 0
-        Log.i(TAG, "Signaling connected via ${kind.wireName}")
+        logger?.log(SerenadaLogLevel.INFO, "Signaling", "Signaling connected via ${kind.wireName}")
         handler.post { listener?.onOpen(kind.wireName) }
         startPing()
     }
@@ -228,8 +231,9 @@ class SignalingClient(
         val current = transportOrder.getOrNull(transportIndex) ?: return false
         val nextIndex = transportIndex + 1
         val next = transportOrder.getOrNull(nextIndex) ?: return false
-        Log.w(
-            TAG,
+        logger?.log(
+            SerenadaLogLevel.WARNING,
+            "Signaling",
             "Transport ${current.wireName} failed ($reason), falling back to ${next.wireName}"
         )
         transportIndex = nextIndex

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SseSignalingTransport.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SseSignalingTransport.kt
@@ -1,6 +1,8 @@
 package app.serenada.core.call
 
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Call
 import okhttp3.Callback
@@ -15,7 +17,8 @@ import java.security.SecureRandom
 import java.util.concurrent.TimeUnit
 
 internal class SseSignalingTransport(
-    private val okHttpClient: OkHttpClient
+    private val okHttpClient: OkHttpClient,
+    private val logger: SerenadaLogger? = null,
 ) : SignalingTransport {
     override val kind: SignalingClient.TransportKind = SignalingClient.TransportKind.SSE
 
@@ -167,7 +170,7 @@ internal class SseSignalingTransport(
         val msg = try {
             SignalingMessage.fromJson(payload)
         } catch (e: RuntimeException) {
-            Log.w(TAG, "Failed to parse signaling message from SSE stream", e)
+            logger?.log(SerenadaLogLevel.WARNING, "Transport", "Failed to parse signaling message from SSE stream: ${e.message}")
             null
         } ?: return
         onMessageCallback?.invoke(msg)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SseSignalingTransport.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SseSignalingTransport.kt
@@ -1,6 +1,5 @@
 package app.serenada.core.call
 
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -6,7 +6,6 @@ import android.hardware.camera2.CameraManager
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.MediaRecorder
-import android.util.Log
 import app.serenada.core.FeatureDegradationState
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -8,6 +8,8 @@ import android.media.AudioFormat
 import android.media.MediaRecorder
 import android.util.Log
 import app.serenada.core.FeatureDegradationState
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import java.util.Collections
 import java.util.WeakHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -37,7 +39,8 @@ class WebRtcEngine(
     private val onScreenShareStopped: () -> Unit,
     private val onFeatureDegradation: (FeatureDegradationState) -> Unit = {},
     private var isHdVideoExperimentalEnabled: Boolean = false,
-    private var isRemoteBlackFrameAnalysisEnabled: Boolean = true
+    private var isRemoteBlackFrameAnalysisEnabled: Boolean = true,
+    private val logger: SerenadaLogger? = null,
 ) : SessionMediaEngine {
 
     data class VideoSenderPolicy(
@@ -77,6 +80,7 @@ class WebRtcEngine(
         onFlashlightStateChanged = onFlashlightStateChanged,
         onFeatureDegradation = onFeatureDegradation,
         onVideoSenderParametersChanged = { applyVideoSenderParameters() },
+        logger = logger,
     )
 
     private val screenShareController = ScreenShareController(
@@ -92,6 +96,7 @@ class WebRtcEngine(
                 onCameraFacingChanged(false)
             }
         },
+        logger = logger,
     )
 
     init {
@@ -100,7 +105,7 @@ class WebRtcEngine(
             .createInitializationOptions()
         PeerConnectionFactory.initialize(initOptions)
         enableVerboseWebRtcLoggingIfDebug()
-        Log.i("WebRtcEngine", "WebRTC initialized")
+        logger?.log(SerenadaLogLevel.INFO, "WebRTC", "WebRTC initialized")
 
         // Keep VP8 hardware support enabled, but disable H264 high profile to reduce encode latency
         // regressions seen on some Android devices with constrained hardware encoders.
@@ -120,9 +125,9 @@ class WebRtcEngine(
             Logging.enableLogThreads()
             Logging.enableLogTimeStamps()
             Logging.enableLogToDebugOutput(Logging.Severity.LS_VERBOSE)
-            Log.i("WebRtcEngine", "Verbose native WebRTC logging enabled")
+            logger?.log(SerenadaLogLevel.INFO, "WebRTC", "Verbose native WebRTC logging enabled")
         }.onFailure { error ->
-            Log.w("WebRtcEngine", "Failed to enable WebRTC verbose logging", error)
+            logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "Failed to enable WebRTC verbose logging: ${error.message}")
         }
     }
 
@@ -151,36 +156,36 @@ class WebRtcEngine(
             .setAudioTrackErrorCallback(
                 object : JavaAudioDeviceModule.AudioTrackErrorCallback {
                     override fun onWebRtcAudioTrackInitError(errorMessage: String?) {
-                        Log.w("WebRtcEngine", "AudioTrack init error: $errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioTrack init error: $errorMessage")
                     }
 
                     override fun onWebRtcAudioTrackStartError(
                         errorCode: JavaAudioDeviceModule.AudioTrackStartErrorCode?,
                         errorMessage: String?
                     ) {
-                        Log.w("WebRtcEngine", "AudioTrack start error: code=$errorCode message=$errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioTrack start error: code=$errorCode message=$errorMessage")
                     }
 
                     override fun onWebRtcAudioTrackError(errorMessage: String?) {
-                        Log.w("WebRtcEngine", "AudioTrack runtime error: $errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioTrack runtime error: $errorMessage")
                     }
                 }
             )
             .setAudioRecordErrorCallback(
                 object : JavaAudioDeviceModule.AudioRecordErrorCallback {
                     override fun onWebRtcAudioRecordInitError(errorMessage: String?) {
-                        Log.w("WebRtcEngine", "AudioRecord init error: $errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioRecord init error: $errorMessage")
                     }
 
                     override fun onWebRtcAudioRecordStartError(
                         errorCode: JavaAudioDeviceModule.AudioRecordStartErrorCode?,
                         errorMessage: String?
                     ) {
-                        Log.w("WebRtcEngine", "AudioRecord start error: code=$errorCode message=$errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioRecord start error: code=$errorCode message=$errorMessage")
                     }
 
                     override fun onWebRtcAudioRecordError(errorMessage: String?) {
-                        Log.w("WebRtcEngine", "AudioRecord runtime error: $errorMessage")
+                        logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "AudioRecord runtime error: $errorMessage")
                     }
                 }
             )
@@ -200,7 +205,7 @@ class WebRtcEngine(
         videoSource = peerConnectionFactory.createVideoSource(false)
         cameraController.resetCameraSourceToSelfie()
         if (!cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)) {
-            Log.w("WebRtcEngine", "No camera capturer available for ${CameraCaptureController.LocalCameraSource.SELFIE}")
+            logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "No camera capturer available for ${CameraCaptureController.LocalCameraSource.SELFIE}")
             videoSource?.dispose()
             videoSource = null
             localAudioTrack?.setEnabled(false)
@@ -249,7 +254,7 @@ class WebRtcEngine(
 
     override fun setIceServers(servers: List<PeerConnection.IceServer>) {
         if (released) return
-        Log.d("WebRtcEngine", "ICE servers set: ${servers.size}")
+        logger?.log(SerenadaLogLevel.DEBUG, "WebRTC", "ICE servers set: ${servers.size}")
         iceServers = servers
         peerSlots.forEach { slot ->
             slot.setIceServers(servers)
@@ -320,6 +325,7 @@ class WebRtcEngine(
             applyAudioSenderParameters = ::applyAudioSenderParameters,
             currentVideoSenderPolicy = ::activeVideoSenderPolicy,
             isRemoteBlackFrameAnalysisEnabled = { isRemoteBlackFrameAnalysisEnabled },
+            logger = logger,
         )
         peerSlots.add(slot)
         if (!iceServers.isNullOrEmpty()) {
@@ -371,7 +377,7 @@ class WebRtcEngine(
             val method = track.javaClass.getMethod("setContentHint", String::class.java)
             method.invoke(track, "speech")
         }.onFailure {
-            Log.d("WebRtcEngine", "Audio content hint not supported")
+            logger?.log(SerenadaLogLevel.DEBUG, "WebRTC", "Audio content hint not supported")
         }
     }
 
@@ -384,9 +390,9 @@ class WebRtcEngine(
             if (encodings[0].maxBitrateBps == null) return
             encodings[0].maxBitrateBps = null
             sender.setParameters(params)
-            Log.d("WebRtcEngine", "Cleared audio sender max bitrate cap")
+            logger?.log(SerenadaLogLevel.DEBUG, "WebRTC", "Cleared audio sender max bitrate cap")
         } catch (e: Exception) {
-            Log.w("WebRtcEngine", "Failed to apply audio sender parameters", e)
+            logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "Failed to apply audio sender parameters: ${e.message}")
         }
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebSocketSignalingTransport.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebSocketSignalingTransport.kt
@@ -1,6 +1,8 @@
 package app.serenada.core.call
 
 import android.util.Log
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -9,7 +11,8 @@ import okhttp3.WebSocketListener
 import okio.ByteString
 
 internal class WebSocketSignalingTransport(
-    private val okHttpClient: OkHttpClient
+    private val okHttpClient: OkHttpClient,
+    private val logger: SerenadaLogger? = null,
 ) : SignalingTransport {
     override val kind: SignalingClient.TransportKind = SignalingClient.TransportKind.WS
 
@@ -34,7 +37,7 @@ internal class WebSocketSignalingTransport(
                     val msg = try {
                         SignalingMessage.fromJson(text)
                     } catch (e: RuntimeException) {
-                        Log.w(TAG, "Failed to parse signaling message from WebSocket", e)
+                        logger?.log(SerenadaLogLevel.WARNING, "Transport", "Failed to parse signaling message from WebSocket: ${e.message}")
                         null
                     } ?: return
                     onMessage(msg)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebSocketSignalingTransport.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebSocketSignalingTransport.kt
@@ -1,6 +1,5 @@
 package app.serenada.core.call
 
-import android.util.Log
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import okhttp3.OkHttpClient

--- a/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
@@ -6,6 +6,7 @@ import UIKit
 public final class CallAudioSessionController: SessionAudioController {
     private var onProximityChanged: (Bool) -> Void
     private var onAudioEnvironmentChanged: () -> Void
+    private let logger: SerenadaLogger?
 
     private let audioSession = AVAudioSession.sharedInstance()
 
@@ -15,10 +16,12 @@ public final class CallAudioSessionController: SessionAudioController {
 
     public init(
         onProximityChanged: @escaping (Bool) -> Void,
-        onAudioEnvironmentChanged: @escaping () -> Void
+        onAudioEnvironmentChanged: @escaping () -> Void,
+        logger: SerenadaLogger? = nil
     ) {
         self.onProximityChanged = onProximityChanged
         self.onAudioEnvironmentChanged = onAudioEnvironmentChanged
+        self.logger = logger
     }
 
     public func setOnProximityChanged(_ handler: @escaping (Bool) -> Void) {
@@ -41,7 +44,7 @@ public final class CallAudioSessionController: SessionAudioController {
             )
             try audioSession.setActive(true)
         } catch {
-            print("[CallAudioSessionController] failed to activate audio session: \(error)")
+            logger?.log(.error, tag: "Audio", "failed to activate audio session: \(error)")
         }
 
         startMonitoring()
@@ -61,7 +64,7 @@ public final class CallAudioSessionController: SessionAudioController {
         do {
             try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
         } catch {
-            print("[CallAudioSessionController] failed to deactivate audio session: \(error)")
+            logger?.log(.error, tag: "Audio", "failed to deactivate audio session: \(error)")
         }
     }
 
@@ -124,7 +127,7 @@ public final class CallAudioSessionController: SessionAudioController {
             do {
                 try audioSession.overrideOutputAudioPort(.none)
             } catch {
-                print("[CallAudioSessionController] bluetooth route apply failed: \(error)")
+                logger?.log(.error, tag: "Audio", "bluetooth route apply failed: \(error)")
             }
             return
         }
@@ -133,7 +136,7 @@ public final class CallAudioSessionController: SessionAudioController {
             do {
                 try audioSession.overrideOutputAudioPort(.none)
             } catch {
-                print("[CallAudioSessionController] earpiece route apply failed: \(error)")
+                logger?.log(.error, tag: "Audio", "earpiece route apply failed: \(error)")
             }
             return
         }
@@ -141,7 +144,7 @@ public final class CallAudioSessionController: SessionAudioController {
         do {
             try audioSession.overrideOutputAudioPort(.speaker)
         } catch {
-            print("[CallAudioSessionController] speaker route apply failed: \(error)")
+            logger?.log(.error, tag: "Audio", "speaker route apply failed: \(error)")
         }
     }
 

--- a/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
@@ -1,14 +1,12 @@
 import AVFoundation
 import CoreImage
 import Foundation
-import os.log
 #if canImport(WebRTC)
 import WebRTC
 #endif
 
 @MainActor
 final class CameraCaptureController {
-    private static let log = OSLog(subsystem: "app.serenada.ios", category: "CameraCaptureController")
 
     private enum Constants {
         static let maxCaptureZoom: CGFloat = 4
@@ -56,7 +54,7 @@ final class CameraCaptureController {
     private var onFlashlightStateChanged: (Bool, Bool) -> Void
     private var onZoomFactorChanged: (Double) -> Void
     private var onFeatureDegradation: (FeatureDegradationState) -> Void
-    private var onDebugTrace: ((String) -> Void)?
+    private let logger: SerenadaLogger?
 
     /// Called by switchVideoCapturer's async completion to verify the video track
     /// is still alive before restarting the capturer. Provided by WebRtcEngine.
@@ -73,7 +71,7 @@ final class CameraCaptureController {
         onFlashlightStateChanged: @escaping (Bool, Bool) -> Void,
         onZoomFactorChanged: @escaping (Double) -> Void,
         onFeatureDegradation: @escaping (FeatureDegradationState) -> Void,
-        onDebugTrace: ((String) -> Void)?
+        logger: SerenadaLogger? = nil
     ) {
         self.localVideoSource = localVideoSource
         self.isHdVideoExperimentalEnabled = isHdVideoExperimentalEnabled
@@ -82,7 +80,7 @@ final class CameraCaptureController {
         self.onFlashlightStateChanged = onFlashlightStateChanged
         self.onZoomFactorChanged = onZoomFactorChanged
         self.onFeatureDegradation = onFeatureDegradation
-        self.onDebugTrace = onDebugTrace
+        self.logger = logger
     }
 #else
     init(
@@ -92,7 +90,7 @@ final class CameraCaptureController {
         onFlashlightStateChanged: @escaping (Bool, Bool) -> Void,
         onZoomFactorChanged: @escaping (Double) -> Void,
         onFeatureDegradation: @escaping (FeatureDegradationState) -> Void,
-        onDebugTrace: ((String) -> Void)?
+        logger: SerenadaLogger? = nil
     ) {
         self.isHdVideoExperimentalEnabled = isHdVideoExperimentalEnabled
         self.onCameraFacingChanged = onCameraFacingChanged
@@ -100,7 +98,7 @@ final class CameraCaptureController {
         self.onFlashlightStateChanged = onFlashlightStateChanged
         self.onZoomFactorChanged = onZoomFactorChanged
         self.onFeatureDegradation = onFeatureDegradation
-        self.onDebugTrace = onDebugTrace
+        self.logger = logger
     }
 #endif
 
@@ -127,7 +125,7 @@ final class CameraCaptureController {
     }
 
     func setOnDebugTrace(_ handler: ((String) -> Void)?) {
-        onDebugTrace = handler
+        // Legacy no-op; logging is now done via SerenadaLogger.
     }
 
 #if canImport(WebRTC)
@@ -279,11 +277,7 @@ final class CameraCaptureController {
         if source == .composite {
             let compositeCapturer = CompositeCameraVideoCapturer(
                 delegate: localVideoSource,
-                onDebugTrace: { [weak self] message in
-                    Task { @MainActor in
-                        self?.debugTrace(message)
-                    }
-                }
+                logger: logger
             )
             guard compositeCapturer.startCapture() else {
                 compositeDisabledAfterFailure = true
@@ -495,9 +489,7 @@ final class CameraCaptureController {
     }
 
     private func debugTrace(_ message: String) {
-#if DEBUG
-        onDebugTrace?(message)
-#endif
+        logger?.log(.debug, tag: "Camera", message)
     }
 
     private func reportCompositeCameraUnavailable(reason: String) {

--- a/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
@@ -124,8 +124,8 @@ final class CameraCaptureController {
         onFeatureDegradation = handler
     }
 
+    @available(*, deprecated, message: "Use SerenadaLogger instead. This method is a no-op.")
     func setOnDebugTrace(_ handler: ((String) -> Void)?) {
-        // Legacy no-op; logging is now done via SerenadaLogger.
     }
 
 #if canImport(WebRTC)

--- a/client-ios/SerenadaCore/Sources/Call/CompositeCameraVideoCapturer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CompositeCameraVideoCapturer.swift
@@ -26,7 +26,7 @@ final class CompositeCameraVideoCapturer: RTCVideoCapturer, AVCaptureVideoDataOu
     private let session = AVCaptureMultiCamSession()
     private let backOutput = AVCaptureVideoDataOutput()
     private let frontOutput = AVCaptureVideoDataOutput()
-    private let onDebugTrace: ((String) -> Void)?
+    private let logger: SerenadaLogger?
 
     private var configured = false
     private var isRunning = false
@@ -45,8 +45,8 @@ final class CompositeCameraVideoCapturer: RTCVideoCapturer, AVCaptureVideoDataOu
 
     private(set) var primaryCaptureDevice: AVCaptureDevice?
 
-    init(delegate: RTCVideoCapturerDelegate, onDebugTrace: ((String) -> Void)? = nil) {
-        self.onDebugTrace = onDebugTrace
+    init(delegate: RTCVideoCapturerDelegate, logger: SerenadaLogger? = nil) {
+        self.logger = logger
         super.init(delegate: delegate)
         captureQueue.setSpecific(key: queueKey, value: ())
     }
@@ -564,9 +564,7 @@ final class CompositeCameraVideoCapturer: RTCVideoCapturer, AVCaptureVideoDataOu
     }
 
     private func debugTrace(_ message: String) {
-#if DEBUG
-        onDebugTrace?(message)
-#endif
+        logger?.log(.debug, tag: "Camera", message)
     }
 
     private func runOnCaptureQueueSync(_ block: () -> Void) {

--- a/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
@@ -1,12 +1,10 @@
 import Foundation
-import os.log
 #if canImport(WebRTC)
 import WebRTC
 #endif
 
 @MainActor
 final class ScreenShareController {
-    private static let log = OSLog(subsystem: "app.serenada.ios", category: "ScreenShareController")
 
     private(set) var isScreenSharing = false
 
@@ -29,6 +27,7 @@ final class ScreenShareController {
     private let setLocalVideoTrackEnabled: (Bool) -> Void
     var onScreenShareStopped: () -> Void
     private let onStateChanged: (Bool) -> Void
+    private let logger: SerenadaLogger?
 
     // MARK: - Init
 
@@ -39,7 +38,8 @@ final class ScreenShareController {
         isLocalVideoTrackEnabled: @escaping () -> Bool,
         setLocalVideoTrackEnabled: @escaping (Bool) -> Void,
         onScreenShareStopped: @escaping () -> Void,
-        onStateChanged: @escaping (Bool) -> Void
+        onStateChanged: @escaping (Bool) -> Void,
+        logger: SerenadaLogger? = nil
     ) {
         self.cameraController = cameraController
         self.localVideoSourceProvider = localVideoSourceProvider
@@ -47,18 +47,21 @@ final class ScreenShareController {
         self.setLocalVideoTrackEnabled = setLocalVideoTrackEnabled
         self.onScreenShareStopped = onScreenShareStopped
         self.onStateChanged = onStateChanged
+        self.logger = logger
     }
 #else
     init(
         cameraController: CameraCaptureController,
         setLocalVideoTrackEnabled: @escaping (Bool) -> Void,
         onScreenShareStopped: @escaping () -> Void,
-        onStateChanged: @escaping (Bool) -> Void
+        onStateChanged: @escaping (Bool) -> Void,
+        logger: SerenadaLogger? = nil
     ) {
         self.cameraController = cameraController
         self.setLocalVideoTrackEnabled = setLocalVideoTrackEnabled
         self.onScreenShareStopped = onScreenShareStopped
         self.onStateChanged = onStateChanged
+        self.logger = logger
     }
 #endif
 
@@ -80,7 +83,7 @@ final class ScreenShareController {
 
     #if BROADCAST_EXTENSION
         // Defer camera teardown until broadcast actually starts (user confirms picker)
-        os_log("startScreenShare: BROADCAST_EXTENSION path, creating BroadcastFrameReader", log: Self.log, type: .info)
+        logger?.log(.info, tag: "ScreenShare", "startScreenShare: BROADCAST_EXTENSION path, creating BroadcastFrameReader")
         let reader = BroadcastFrameReader(delegate: localVideoSource)
         broadcastFrameReader = reader
 
@@ -88,29 +91,29 @@ final class ScreenShareController {
 
         reader.onBroadcastStarted = { [weak self] in
             Task { @MainActor in
-                os_log("startScreenShare: onBroadcastStarted callback fired", log: ScreenShareController.log, type: .info)
+                self?.logger?.log(.info, tag: "ScreenShare", "startScreenShare: onBroadcastStarted callback fired")
                 startTimeoutTask?.cancel()
                 guard let self else { return }
                 guard self.broadcastFrameReader === reader else {
-                    os_log("startScreenShare: reader mismatch, ignoring", log: ScreenShareController.log, type: .error)
+                    self.logger?.log(.error, tag: "ScreenShare", "startScreenShare: reader mismatch, ignoring")
                     return
                 }
                 // Now tear down camera — broadcast is confirmed
-                os_log("startScreenShare: tearing down camera, setting isScreenSharing=true", log: ScreenShareController.log, type: .info)
+                self.logger?.log(.info, tag: "ScreenShare", "startScreenShare: tearing down camera, setting isScreenSharing=true")
                 self.cameraController.stopAllCapturers()
                 self.isScreenSharing = true
                 self.cameraController.isScreenSharing = true
                 self.cameraController.notifyCameraModeAndFlash()
                 self.setLocalVideoTrackEnabled(true)
                 self.onStateChanged(true)
-                os_log("startScreenShare: calling onComplete(true)", log: ScreenShareController.log, type: .info)
+                self.logger?.log(.info, tag: "ScreenShare", "startScreenShare: calling onComplete(true)")
                 onComplete?(true)
             }
         }
 
         reader.onBroadcastFinished = { [weak self] in
             Task { @MainActor in
-                os_log("startScreenShare: onBroadcastFinished callback fired", log: ScreenShareController.log, type: .info)
+                self?.logger?.log(.info, tag: "ScreenShare", "startScreenShare: onBroadcastFinished callback fired")
                 guard let self else { return }
                 guard self.broadcastFrameReader === reader else { return }
                 _ = self.stopScreenShare()

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -1,7 +1,6 @@
 import AVFoundation
 import CoreImage
 import Foundation
-import os.log
 import UIKit
 #if canImport(WebRTC)
 import WebRTC
@@ -102,9 +101,7 @@ public enum SessionDescriptionType {
 
 @MainActor
 public final class WebRtcEngine: SessionMediaEngine {
-    private static let log = OSLog(subsystem: "app.serenada.ios", category: "WebRtcEngine")
-
-    private var onDebugTrace: ((String) -> Void)?
+    private let logger: SerenadaLogger?
 
     private let cameraController: CameraCaptureController
     private var screenShareController: ScreenShareController!
@@ -135,10 +132,10 @@ public final class WebRtcEngine: SessionMediaEngine {
         onScreenShareStopped: @escaping () -> Void,
         onZoomFactorChanged: @escaping (Double) -> Void,
         onFeatureDegradation: @escaping (FeatureDegradationState) -> Void = { _ in },
-        onDebugTrace: ((String) -> Void)? = nil,
+        logger: SerenadaLogger? = nil,
         isHdVideoExperimentalEnabled: Bool
     ) {
-        self.onDebugTrace = onDebugTrace
+        self.logger = logger
 
 #if canImport(WebRTC)
         self.cameraController = CameraCaptureController(
@@ -149,7 +146,7 @@ public final class WebRtcEngine: SessionMediaEngine {
             onFlashlightStateChanged: onFlashlightStateChanged,
             onZoomFactorChanged: onZoomFactorChanged,
             onFeatureDegradation: onFeatureDegradation,
-            onDebugTrace: onDebugTrace
+            logger: logger
         )
 #else
         self.cameraController = CameraCaptureController(
@@ -159,7 +156,7 @@ public final class WebRtcEngine: SessionMediaEngine {
             onFlashlightStateChanged: onFlashlightStateChanged,
             onZoomFactorChanged: onZoomFactorChanged,
             onFeatureDegradation: onFeatureDegradation,
-            onDebugTrace: onDebugTrace
+            logger: logger
         )
 #endif
 
@@ -177,14 +174,16 @@ public final class WebRtcEngine: SessionMediaEngine {
             isLocalVideoTrackEnabled: { [weak self] in self?.localVideoTrack?.isEnabled == true },
             setLocalVideoTrackEnabled: { [weak self] enabled in self?.localVideoTrack?.isEnabled = enabled },
             onScreenShareStopped: onScreenShareStopped,
-            onStateChanged: { _ in }
+            onStateChanged: { _ in },
+            logger: logger
         )
 #else
         self.screenShareController = ScreenShareController(
             cameraController: cameraController,
             setLocalVideoTrackEnabled: { _ in },
             onScreenShareStopped: onScreenShareStopped,
-            onStateChanged: { _ in }
+            onStateChanged: { _ in },
+            logger: logger
         )
 #endif
 
@@ -220,8 +219,7 @@ public final class WebRtcEngine: SessionMediaEngine {
     }
 
     public func setOnDebugTrace(_ handler: ((String) -> Void)?) {
-        onDebugTrace = handler
-        cameraController.setOnDebugTrace(handler)
+        // Legacy no-op; logging is now done via SerenadaLogger.
     }
 
     public func startLocalMedia(preferVideo: Bool = true) {

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -218,8 +218,8 @@ public final class WebRtcEngine: SessionMediaEngine {
         cameraController.setOnFeatureDegradation(handler)
     }
 
+    @available(*, deprecated, message: "Use SerenadaLogger instead. This method is a no-op.")
     public func setOnDebugTrace(_ handler: ((String) -> Void)?) {
-        // Legacy no-op; logging is now done via SerenadaLogger.
     }
 
     public func startLocalMedia(preferVideo: Bool = true) {

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -37,6 +37,7 @@ public final class SerenadaCore {
 
     public let config: SerenadaConfig
     public weak var delegate: SerenadaCoreDelegate?
+    public var logger: SerenadaLogger?
 
     public init(config: SerenadaConfig) {
         self.config = config
@@ -53,7 +54,8 @@ public final class SerenadaCore {
             roomUrl: url,
             serverHost: serverHost,
             config: config,
-            delegateProvider: { [weak self] in self?.delegate }
+            delegateProvider: { [weak self] in self?.delegate },
+            logger: logger
         )
         return session
     }
@@ -66,7 +68,8 @@ public final class SerenadaCore {
             roomUrl: url,
             serverHost: config.serverHost,
             config: config,
-            delegateProvider: { [weak self] in self?.delegate }
+            delegateProvider: { [weak self] in self?.delegate },
+            logger: logger
         )
         return session
     }
@@ -85,7 +88,8 @@ public final class SerenadaCore {
             roomUrl: url,
             serverHost: serverHost,
             config: config,
-            delegateProvider: { [weak self] in self?.delegate }
+            delegateProvider: { [weak self] in self?.delegate },
+            logger: logger
         )
         return CreateRoomResult(url: url, roomId: roomId, session: session)
     }

--- a/client-ios/SerenadaCore/Sources/SerenadaLogger.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaLogger.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum SerenadaLogLevel: Int, Comparable, Sendable {
+    case debug = 0, info, warning, error
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+public protocol SerenadaLogger: AnyObject, Sendable {
+    func log(_ level: SerenadaLogLevel, tag: String, _ message: String)
+}
+
+public final class PrintSerenadaLogger: SerenadaLogger {
+    public init() {}
+
+    public func log(_ level: SerenadaLogLevel, tag: String, _ message: String) {
+        let levelLabel: String
+        switch level {
+        case .debug: levelLabel = "DEBUG"
+        case .info: levelLabel = "INFO"
+        case .warning: levelLabel = "WARN"
+        case .error: levelLabel = "ERROR"
+        }
+        print("[\(levelLabel)] [\(tag)] \(message)")
+    }
+}

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -56,6 +56,7 @@ public final class SerenadaSession: ObservableObject {
 
     private let config: SerenadaConfig
     private let delegateProvider: (() -> SerenadaCoreDelegate?)?
+    private let logger: SerenadaLogger?
     private let pathMonitor = NWPathMonitor()
     private let pathMonitorQueue = DispatchQueue(label: "SerenadaSession.PathMonitor")
 
@@ -96,7 +97,8 @@ public final class SerenadaSession: ObservableObject {
         roomUrl: URL? = nil,
         serverHost: String,
         config: SerenadaConfig,
-        delegateProvider: (() -> SerenadaCoreDelegate?)? = nil
+        delegateProvider: (() -> SerenadaCoreDelegate?)? = nil,
+        logger: SerenadaLogger? = nil
     ) {
         self.init(
             roomId: roomId,
@@ -104,6 +106,7 @@ public final class SerenadaSession: ObservableObject {
             serverHost: serverHost,
             config: config,
             delegateProvider: delegateProvider,
+            logger: logger,
             signaling: nil,
             apiClient: nil,
             audioController: nil,
@@ -118,6 +121,7 @@ public final class SerenadaSession: ObservableObject {
         serverHost: String,
         config: SerenadaConfig,
         delegateProvider: (() -> SerenadaCoreDelegate?)? = nil,
+        logger: SerenadaLogger? = nil,
         signaling: SessionSignaling? = nil,
         apiClient: SessionAPIClient? = nil,
         audioController: SessionAudioController? = nil,
@@ -129,12 +133,14 @@ public final class SerenadaSession: ObservableObject {
         self.serverHost = serverHost
         self.config = config
         self.delegateProvider = delegateProvider
+        self.logger = logger
         self.clock = clock ?? LiveSessionClock()
         self.signalingClient = signaling ?? SignalingClient(forceSseSignaling: !config.transports.contains(.ws))
         self.apiClient = apiClient ?? CoreAPIClient()
         self.callAudioSessionController = audioController ?? CallAudioSessionController(
             onProximityChanged: { _ in },
-            onAudioEnvironmentChanged: {}
+            onAudioEnvironmentChanged: {},
+            logger: logger
         )
         self.webRtcEngine = mediaEngine ?? WebRtcEngine(
             onCameraFacingChanged: { _ in },
@@ -143,7 +149,7 @@ public final class SerenadaSession: ObservableObject {
             onScreenShareStopped: {},
             onZoomFactorChanged: { _ in },
             onFeatureDegradation: { _ in },
-            onDebugTrace: nil,
+            logger: logger,
             isHdVideoExperimentalEnabled: false
         )
 

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		AD701F4DE41EA9DFCC2125CE /* JoinScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */; };
 		B402B3581D8D647DC2D139A7 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
 		BC3AE1438258D205BFE66CD2 /* SerenadaiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */; };
+		BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */; };
 		C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */; };
 		C8363EE39A1335203566D71B /* RoomStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */; };
 		CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AA70D76623801E762E2DB /* ErrorScreen.swift */; };
@@ -184,6 +185,7 @@
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = Vendor/WebRTC/WebRTC.xcframework; sourceTree = "<group>"; };
+		E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 			isa = PBXGroup;
 			children = (
 				D0BE7FF0C166694E0F58114A /* Assets.xcassets */,
+				E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */,
 				E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */,
 				EA93F28D0C87ABED6B756036 /* Localizable.strings */,
 			);
@@ -676,6 +679,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
+				BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -54,7 +54,6 @@
 		AD701F4DE41EA9DFCC2125CE /* JoinScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */; };
 		B402B3581D8D647DC2D139A7 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
 		BC3AE1438258D205BFE66CD2 /* SerenadaiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */; };
-		BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */; };
 		C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */; };
 		C8363EE39A1335203566D71B /* RoomStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */; };
 		CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AA70D76623801E762E2DB /* ErrorScreen.swift */; };
@@ -185,7 +184,6 @@
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = Vendor/WebRTC/WebRTC.xcframework; sourceTree = "<group>"; };
-		E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -355,7 +353,6 @@
 			isa = PBXGroup;
 			children = (
 				D0BE7FF0C166694E0F58114A /* Assets.xcassets */,
-				E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */,
 				E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */,
 				EA93F28D0C87ABED6B756036 /* Localizable.strings */,
 			);
@@ -679,7 +676,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
-				BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -371,13 +371,15 @@ final class CallManager: ObservableObject {
     }
 
     private func makeSerenadaCore(host: String) -> SerenadaCore {
-        SerenadaCore(
+        let core = SerenadaCore(
             config: SerenadaConfig(
                 serverHost: host,
                 defaultAudioEnabled: settingsStore.isDefaultMicrophoneEnabled,
                 defaultVideoEnabled: settingsStore.isDefaultCameraEnabled
             )
         )
+        core.logger = PrintSerenadaLogger()
+        return core
     }
 
     private func activateSession(_ session: SerenadaSession) {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5100,7 +5100,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@serenada/core": "0.1.0"
+        "@serenada/core": "0.1.0",
+        "react-qr-code": "^2.0.17"
       },
       "peerDependencies": {
         "lucide-react": ">=0.300.0",

--- a/client/packages/core/src/ConsoleLogger.ts
+++ b/client/packages/core/src/ConsoleLogger.ts
@@ -1,0 +1,13 @@
+import type { SerenadaLogLevel, SerenadaLogger } from './types.js';
+
+export class ConsoleSerenadaLogger implements SerenadaLogger {
+    log(level: SerenadaLogLevel, tag: string, message: string): void {
+        const formatted = `[${tag}] ${message}`;
+        switch (level) {
+            case 'debug': console.debug(formatted); break;
+            case 'info': console.info(formatted); break;
+            case 'warning': console.warn(formatted); break;
+            case 'error': console.error(formatted); break;
+        }
+    }
+}

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -47,14 +47,15 @@ export class SerenadaSession implements SerenadaSessionHandle {
             wsUrl: urls.wsUrl,
             httpBaseUrl: urls.httpBaseUrl,
             transports: config.transports,
+            logger: config.logger,
         });
 
         this.media = new MediaEngine(
-            { serverHost: config.serverHost, turnsOnly: config.turnsOnly },
+            { serverHost: config.serverHost, turnsOnly: config.turnsOnly, logger: config.logger },
             (type, payload, to) => this.signaling.sendMessage(type, payload, to),
         );
 
-        this.statsCollector = new CallStatsCollector();
+        this.statsCollector = new CallStatsCollector(config.logger);
 
         // Wire signaling events to media engine
         this.unsubSignalingMessages = this.signaling.subscribeToMessages((msg) => {

--- a/client/packages/core/src/formatError.ts
+++ b/client/packages/core/src/formatError.ts
@@ -1,0 +1,5 @@
+/** Safely extract a human-readable message from an unknown catch-block value. */
+export function formatError(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
+}

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -38,7 +38,11 @@ export type {
     IceProbeReport,
     RoomOccupancy,
     RoomWatcherState,
+    SerenadaLogLevel,
+    SerenadaLogger,
 } from './types.js';
+
+export { ConsoleSerenadaLogger } from './ConsoleLogger.js';
 
 // Public utilities
 export {

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -1,5 +1,5 @@
 import type { RoomState, SignalingMessage } from '../signaling/types.js';
-import type { ConnectionStatus } from '../types.js';
+import type { ConnectionStatus, SerenadaLogger } from '../types.js';
 import {
     OFFER_TIMEOUT_MS,
     ICE_RESTART_COOLDOWN_MS,
@@ -38,6 +38,7 @@ interface PeerState {
 export interface MediaEngineConfig {
     serverHost: string;
     turnsOnly?: boolean;
+    logger?: SerenadaLogger;
 }
 
 export class MediaEngine {
@@ -73,6 +74,7 @@ export class MediaEngine {
     private appliedTurnToken: string | null = null;
     private serverHost: string;
     private turnsOnly: boolean;
+    private logger?: SerenadaLogger;
 
     // Injected dependencies
     private sendSignalingMessage: (type: string, payload?: Record<string, unknown>, to?: string) => void;
@@ -87,6 +89,7 @@ export class MediaEngine {
     ) {
         this.serverHost = config.serverHost;
         this.turnsOnly = config.turnsOnly ?? false;
+        this.logger = config.logger;
         this.sendSignalingMessage = sendMessage;
         this.setupEventListeners();
     }
@@ -152,7 +155,7 @@ export class MediaEngine {
                     break;
             }
         } catch (err) {
-            console.error(`[WebRTC] Error processing message ${type}:`, err);
+            this.logger?.log('error', 'WebRTC', `Error processing message ${type}: ${err}`);
         }
     }
 
@@ -208,7 +211,7 @@ export class MediaEngine {
             this.notifyChange();
             return stream;
         } catch (err) {
-            console.error("Error accessing media", err);
+            this.logger?.log('error', 'WebRTC', `Error accessing media: ${err}`);
             this.requestingMedia = false;
             return null;
         }
@@ -259,7 +262,7 @@ export class MediaEngine {
             this.sendSignalingMessage('content_state', { active: true, contentType: 'screenShare' });
             this.notifyChange();
         } catch (err) {
-            console.error('[WebRTC] Failed to start screen share', err);
+            this.logger?.log('error', 'WebRTC', `Failed to start screen share: ${err}`);
         }
     }
 
@@ -284,7 +287,7 @@ export class MediaEngine {
             const cameraTrack = await this.acquireCameraTrack(this.facingMode, wasVideoEnabled);
             await this.swapLocalVideoTrack(cameraTrack, previousVideoTrack);
         } catch (err) {
-            console.error('[WebRTC] Failed to stop screen share and restore camera', err);
+            this.logger?.log('error', 'WebRTC', `Failed to stop screen share and restore camera: ${err}`);
             await this.swapLocalVideoTrack(null, previousVideoTrack);
         } finally {
             this.isScreenSharing = false;
@@ -308,7 +311,7 @@ export class MediaEngine {
             await this.swapLocalVideoTrack(newVideoTrack, oldVideoTrack);
             this.notifyChange();
         } catch (err) {
-            console.error('[WebRTC] Failed to flip camera', err);
+            this.logger?.log('error', 'WebRTC', `Failed to flip camera: ${err}`);
         }
     }
 
@@ -355,7 +358,7 @@ export class MediaEngine {
         const myId = this.clientId;
         if (!this.roomState || !myId) {
             if (this.peers.size > 0) {
-                console.log('[WebRTC] Room state cleared, cleaning up all peers');
+                this.logger?.log('debug', 'WebRTC', 'Room state cleared, cleaning up all peers');
                 this.cleanupAllPeers();
             }
             return;
@@ -366,7 +369,7 @@ export class MediaEngine {
 
         for (const [cid] of this.peers) {
             if (!remoteCids.has(cid)) {
-                console.log(`[WebRTC] Participant ${cid} left, cleaning up peer`);
+                this.logger?.log('debug', 'WebRTC', `Participant ${cid} left, cleaning up peer`);
                 this.cleanupPeer(cid);
             }
         }
@@ -406,7 +409,7 @@ export class MediaEngine {
         }
 
         pc.ontrack = (event) => {
-            console.log(`[WebRTC][${remoteCid}] Remote track received`);
+            this.logger?.log('debug', 'WebRTC', `[${remoteCid}] Remote track received`);
             let remoteStream: MediaStream;
             if (event.streams?.[0]) {
                 remoteStream = event.streams[0];
@@ -422,7 +425,7 @@ export class MediaEngine {
         };
 
         pc.oniceconnectionstatechange = () => {
-            console.log(`[WebRTC][${remoteCid}] ICE: ${pc.iceConnectionState}`);
+            this.logger?.log('debug', 'WebRTC', `[${remoteCid}] ICE: ${pc.iceConnectionState}`);
             this.updateAggregateState();
             if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') {
                 if (peerState.iceRestartTimer) { window.clearTimeout(peerState.iceRestartTimer); peerState.iceRestartTimer = null; }
@@ -437,7 +440,7 @@ export class MediaEngine {
         };
 
         pc.onconnectionstatechange = () => {
-            console.log(`[WebRTC][${remoteCid}] Connection: ${pc.connectionState}`);
+            this.logger?.log('debug', 'WebRTC', `[${remoteCid}] Connection: ${pc.connectionState}`);
             this.updateAggregateState();
             if (pc.connectionState === 'connected') {
                 if (peerState.iceRestartTimer) { window.clearTimeout(peerState.iceRestartTimer); peerState.iceRestartTimer = null; }
@@ -531,18 +534,18 @@ export class MediaEngine {
                 peer.offerTimeout = null;
                 const currentPeer = this.peers.get(remoteCid);
                 if (!currentPeer) return;
-                console.warn(`[WebRTC][${remoteCid}] Offer timeout`);
+                this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Offer timeout`);
                 currentPeer.pendingIceRestart = true;
                 if (currentPeer.pc.signalingState === 'have-local-offer') {
                     currentPeer.pc.setLocalDescription({ type: 'rollback' } as RTCSessionDescriptionInit)
-                        .catch(err => console.warn(`[WebRTC][${remoteCid}] Rollback failed`, err))
+                        .catch(err => this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Rollback failed: ${err}`))
                         .finally(() => this.scheduleIceRestart(remoteCid, 'offer-timeout', 0));
                 } else {
                     this.scheduleIceRestart(remoteCid, 'offer-timeout-unexpected-state', 0);
                 }
             }, OFFER_TIMEOUT_MS);
         } catch (err) {
-            console.error(`[WebRTC][${remoteCid}] Error creating offer:`, err);
+            this.logger?.log('error', 'WebRTC', `[${remoteCid}] Error creating offer: ${err}`);
         } finally {
             peer.isMakingOffer = false;
             if (peer.pendingIceRestart) {
@@ -572,7 +575,7 @@ export class MediaEngine {
         if (peer.isMakingOffer) { peer.pendingIceRestart = true; return; }
         peer.lastIceRestartAt = Date.now();
         peer.pendingIceRestart = false;
-        console.warn(`[WebRTC] ICE restart triggered for ${remoteCid} (${reason})`);
+        this.logger?.log('warning', 'WebRTC', `ICE restart triggered for ${remoteCid} (${reason})`);
         await this.createOfferTo(remoteCid, { iceRestart: true });
     }
 
@@ -592,7 +595,7 @@ export class MediaEngine {
             if (!this.isSignalingConnected) return;
 
             currentPeer.nonHostFallbackAttempts++;
-            console.warn(`[WebRTC][${remoteCid}] Non-host fallback offer (attempt ${currentPeer.nonHostFallbackAttempts})`);
+            this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Non-host fallback offer (attempt ${currentPeer.nonHostFallbackAttempts})`);
             try {
                 const offer = await currentPeer.pc.createOffer();
                 await currentPeer.pc.setLocalDescription(offer as RTCSessionDescriptionInit);
@@ -605,12 +608,12 @@ export class MediaEngine {
                     if (!p) return;
                     if (p.pc.signalingState === 'have-local-offer') {
                         try { await p.pc.setLocalDescription({ type: 'rollback' } as RTCSessionDescriptionInit); }
-                        catch (err) { console.warn(`[WebRTC][${remoteCid}] Non-host rollback failed`, err); }
+                        catch (err) { this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Non-host rollback failed: ${err}`); }
                     }
                     this.scheduleNonHostFallback(remoteCid);
                 }, OFFER_TIMEOUT_MS);
             } catch (err) {
-                console.error(`[WebRTC][${remoteCid}] Non-host fallback offer failed`, err);
+                this.logger?.log('error', 'WebRTC', `[${remoteCid}] Non-host fallback offer failed: ${err}`);
                 this.scheduleNonHostFallback(remoteCid);
             }
         }, NON_HOST_FALLBACK_DELAY_MS);
@@ -630,7 +633,7 @@ export class MediaEngine {
             await peer.pc.setLocalDescription(answer);
             this.sendSignalingMessage('answer', { sdp: answer.sdp }, fromCid);
         } catch (err) {
-            console.error(`[WebRTC][${fromCid}] Error handling offer:`, err);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling offer: ${err}`);
         }
     }
 
@@ -642,7 +645,7 @@ export class MediaEngine {
             await peer.pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp }));
             if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
         } catch (err) {
-            console.error(`[WebRTC][${fromCid}] Error handling answer:`, err);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling answer: ${err}`);
         }
     }
 
@@ -656,7 +659,7 @@ export class MediaEngine {
                 peer.iceBuffer.push(candidate);
             }
         } catch (err) {
-            console.error(`[WebRTC][${fromCid}] Error handling ICE candidate:`, err);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling ICE candidate: ${err}`);
         }
     }
 
@@ -745,7 +748,7 @@ export class MediaEngine {
                 return true;
             }
         } catch (err) {
-            if (!signal.aborted) console.error('[WebRTC] Error fetching ICE servers:', err);
+            if (!signal.aborted) this.logger?.log('error', 'WebRTC', `Error fetching ICE servers: ${err}`);
         } finally {
             clearTimeout(timeoutTimer);
             signal.removeEventListener('abort', onExternalAbort);
@@ -779,7 +782,7 @@ export class MediaEngine {
             };
             await sender.setParameters(nextParams);
         } catch (err) {
-            console.warn('[WebRTC] Failed to apply audio sender parameters', err);
+            this.logger?.log('warning', 'WebRTC', `Failed to apply audio sender parameters: ${err}`);
         }
     }
 
@@ -805,7 +808,7 @@ export class MediaEngine {
                 const sender = peer.pc.getSenders().find(s => s.track?.kind === 'video');
                 if (sender) {
                     try { await sender.replaceTrack(newTrack); }
-                    catch (err) { console.warn('[WebRTC] Failed to replace track on peer', err); }
+                    catch (err) { this.logger?.log('warning', 'WebRTC', `Failed to replace track on peer: ${err}`); }
                 }
             })
         );
@@ -853,10 +856,10 @@ export class MediaEngine {
         try {
             const nextTrack = await this.acquireCameraTrack(this.facingMode, currentVideoTrack?.enabled ?? true);
             await this.swapLocalVideoTrack(nextTrack, currentVideoTrack);
-            console.info(`[WebRTC] Refreshed local video track (${reason})`);
+            this.logger?.log('info', 'WebRTC', `Refreshed local video track (${reason})`);
             return true;
         } catch (err) {
-            console.error(`[WebRTC] Failed to refresh local video track (${reason})`, err);
+            this.logger?.log('error', 'WebRTC', `Failed to refresh local video track (${reason}): ${err}`);
             return false;
         } finally {
             this.cameraRecoveryInFlight = false;

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -1,5 +1,6 @@
 import type { RoomState, SignalingMessage } from '../signaling/types.js';
 import type { ConnectionStatus, SerenadaLogger } from '../types.js';
+import { formatError } from '../formatError.js';
 import {
     OFFER_TIMEOUT_MS,
     ICE_RESTART_COOLDOWN_MS,
@@ -155,7 +156,7 @@ export class MediaEngine {
                     break;
             }
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Error processing message ${type}: ${err}`);
+            this.logger?.log('error', 'WebRTC', `Error processing message ${type}: ${formatError(err)}`);
         }
     }
 
@@ -211,7 +212,7 @@ export class MediaEngine {
             this.notifyChange();
             return stream;
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Error accessing media: ${err}`);
+            this.logger?.log('error', 'WebRTC', `Error accessing media: ${formatError(err)}`);
             this.requestingMedia = false;
             return null;
         }
@@ -262,7 +263,7 @@ export class MediaEngine {
             this.sendSignalingMessage('content_state', { active: true, contentType: 'screenShare' });
             this.notifyChange();
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Failed to start screen share: ${err}`);
+            this.logger?.log('error', 'ScreenShare', `Failed to start screen share: ${formatError(err)}`);
         }
     }
 
@@ -287,7 +288,7 @@ export class MediaEngine {
             const cameraTrack = await this.acquireCameraTrack(this.facingMode, wasVideoEnabled);
             await this.swapLocalVideoTrack(cameraTrack, previousVideoTrack);
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Failed to stop screen share and restore camera: ${err}`);
+            this.logger?.log('error', 'ScreenShare', `Failed to stop screen share and restore camera: ${formatError(err)}`);
             await this.swapLocalVideoTrack(null, previousVideoTrack);
         } finally {
             this.isScreenSharing = false;
@@ -311,7 +312,7 @@ export class MediaEngine {
             await this.swapLocalVideoTrack(newVideoTrack, oldVideoTrack);
             this.notifyChange();
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Failed to flip camera: ${err}`);
+            this.logger?.log('error', 'Camera', `Failed to flip camera: ${formatError(err)}`);
         }
     }
 
@@ -538,14 +539,14 @@ export class MediaEngine {
                 currentPeer.pendingIceRestart = true;
                 if (currentPeer.pc.signalingState === 'have-local-offer') {
                     currentPeer.pc.setLocalDescription({ type: 'rollback' } as RTCSessionDescriptionInit)
-                        .catch(err => this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Rollback failed: ${err}`))
+                        .catch(err => this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Rollback failed: ${formatError(err)}`))
                         .finally(() => this.scheduleIceRestart(remoteCid, 'offer-timeout', 0));
                 } else {
                     this.scheduleIceRestart(remoteCid, 'offer-timeout-unexpected-state', 0);
                 }
             }, OFFER_TIMEOUT_MS);
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `[${remoteCid}] Error creating offer: ${err}`);
+            this.logger?.log('error', 'WebRTC', `[${remoteCid}] Error creating offer: ${formatError(err)}`);
         } finally {
             peer.isMakingOffer = false;
             if (peer.pendingIceRestart) {
@@ -608,12 +609,12 @@ export class MediaEngine {
                     if (!p) return;
                     if (p.pc.signalingState === 'have-local-offer') {
                         try { await p.pc.setLocalDescription({ type: 'rollback' } as RTCSessionDescriptionInit); }
-                        catch (err) { this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Non-host rollback failed: ${err}`); }
+                        catch (err) { this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Non-host rollback failed: ${formatError(err)}`); }
                     }
                     this.scheduleNonHostFallback(remoteCid);
                 }, OFFER_TIMEOUT_MS);
             } catch (err) {
-                this.logger?.log('error', 'WebRTC', `[${remoteCid}] Non-host fallback offer failed: ${err}`);
+                this.logger?.log('error', 'WebRTC', `[${remoteCid}] Non-host fallback offer failed: ${formatError(err)}`);
                 this.scheduleNonHostFallback(remoteCid);
             }
         }, NON_HOST_FALLBACK_DELAY_MS);
@@ -633,7 +634,7 @@ export class MediaEngine {
             await peer.pc.setLocalDescription(answer);
             this.sendSignalingMessage('answer', { sdp: answer.sdp }, fromCid);
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling offer: ${err}`);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling offer: ${formatError(err)}`);
         }
     }
 
@@ -645,7 +646,7 @@ export class MediaEngine {
             await peer.pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp }));
             if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling answer: ${err}`);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling answer: ${formatError(err)}`);
         }
     }
 
@@ -659,7 +660,7 @@ export class MediaEngine {
                 peer.iceBuffer.push(candidate);
             }
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling ICE candidate: ${err}`);
+            this.logger?.log('error', 'WebRTC', `[${fromCid}] Error handling ICE candidate: ${formatError(err)}`);
         }
     }
 
@@ -748,7 +749,7 @@ export class MediaEngine {
                 return true;
             }
         } catch (err) {
-            if (!signal.aborted) this.logger?.log('error', 'WebRTC', `Error fetching ICE servers: ${err}`);
+            if (!signal.aborted) this.logger?.log('error', 'WebRTC', `Error fetching ICE servers: ${formatError(err)}`);
         } finally {
             clearTimeout(timeoutTimer);
             signal.removeEventListener('abort', onExternalAbort);
@@ -782,7 +783,7 @@ export class MediaEngine {
             };
             await sender.setParameters(nextParams);
         } catch (err) {
-            this.logger?.log('warning', 'WebRTC', `Failed to apply audio sender parameters: ${err}`);
+            this.logger?.log('warning', 'WebRTC', `Failed to apply audio sender parameters: ${formatError(err)}`);
         }
     }
 
@@ -808,7 +809,7 @@ export class MediaEngine {
                 const sender = peer.pc.getSenders().find(s => s.track?.kind === 'video');
                 if (sender) {
                     try { await sender.replaceTrack(newTrack); }
-                    catch (err) { this.logger?.log('warning', 'WebRTC', `Failed to replace track on peer: ${err}`); }
+                    catch (err) { this.logger?.log('warning', 'WebRTC', `Failed to replace track on peer: ${formatError(err)}`); }
                 }
             })
         );
@@ -859,7 +860,7 @@ export class MediaEngine {
             this.logger?.log('info', 'WebRTC', `Refreshed local video track (${reason})`);
             return true;
         } catch (err) {
-            this.logger?.log('error', 'WebRTC', `Failed to refresh local video track (${reason}): ${err}`);
+            this.logger?.log('error', 'WebRTC', `Failed to refresh local video track (${reason}): ${formatError(err)}`);
             return false;
         } finally {
             this.cameraRecoveryInFlight = false;

--- a/client/packages/core/src/media/callStats.ts
+++ b/client/packages/core/src/media/callStats.ts
@@ -1,4 +1,4 @@
-import type { CallStats } from '../types.js';
+import type { CallStats, SerenadaLogger } from '../types.js';
 
 interface MediaTotals {
     inboundPacketsReceived: number;
@@ -84,6 +84,11 @@ export class CallStatsCollector {
     private timer: number | null = null;
     private _stats: CallStats | null = null;
     private onChange: (() => void) | null = null;
+    private logger?: SerenadaLogger;
+
+    constructor(logger?: SerenadaLogger) {
+        this.logger = logger;
+    }
 
     get stats(): CallStats | null { return this._stats; }
 
@@ -249,7 +254,7 @@ export class CallStatsCollector {
 
             this.onChange?.();
         } catch (err) {
-            console.warn('[CallStats] Failed to collect realtime stats', err);
+            this.logger?.log('warning', 'Stats', `Failed to collect realtime stats: ${err}`);
         }
     }
 }

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -1,6 +1,7 @@
 import type { RoomState, SignalingMessage } from './types.js';
 import type { RoomStatuses } from './roomStatuses.js';
 import type { SignalingTransport, TransportKind } from './transports/types.js';
+import type { SerenadaLogger } from '../types.js';
 import { createSignalingTransport } from './transports/index.js';
 import { mergeRoomStatusesPayload, mergeRoomStatusUpdatePayload } from './roomStatuses.js';
 import {
@@ -19,6 +20,7 @@ export interface SignalingEngineConfig {
     wsUrl: string;
     httpBaseUrl: string;
     transports?: TransportKind[];
+    logger?: SerenadaLogger;
 }
 
 export type SignalingStateListener = () => void;
@@ -68,6 +70,9 @@ export class SignalingEngine {
     private connecting = false;
     private lastCreateMaxParticipants: number | undefined = undefined;
 
+    // Logger
+    private logger?: SerenadaLogger;
+
     // Listeners
     private messageListeners: SignalingMessageListener[] = [];
     private stateListeners: SignalingStateListener[] = [];
@@ -76,6 +81,7 @@ export class SignalingEngine {
         this.wsUrl = config.wsUrl;
         this.httpBaseUrl = config.httpBaseUrl;
         this.transportOrder = config.transports ?? ['ws', 'sse'];
+        this.logger = config.logger;
         this.loadReconnectStorage();
     }
 
@@ -110,12 +116,12 @@ export class SignalingEngine {
             };
             this.transport.send(msg);
         } else {
-            console.warn('Signaling transport not connected');
+            this.logger?.log('warning', 'Signaling', 'Transport not connected');
         }
     }
 
     joinRoom(roomId: string, options?: { createMaxParticipants?: number }): void {
-        console.log(`[Signaling] joinRoom call for ${roomId}`);
+        this.logger?.log('debug', 'Signaling', `joinRoom call for ${roomId}`);
         this.error = null;
         this.clearJoinTimers();
         this.needsRejoin = false;
@@ -151,27 +157,27 @@ export class SignalingEngine {
             this.joinKickstartTimer = window.setTimeout(() => {
                 this.joinKickstartTimer = null;
                 if (this.joinAttemptId !== attemptId || this.joinAcked) return;
-                console.log('[Signaling] Join kickstart: re-sending join');
+                this.logger?.log('debug', 'Signaling', 'Join kickstart: re-sending join');
                 doSendJoin();
             }, JOIN_CONNECT_KICKSTART_MS);
 
             this.joinRecoveryTimer = window.setTimeout(() => {
                 this.joinRecoveryTimer = null;
                 if (this.joinAttemptId !== attemptId || this.joinAcked) return;
-                console.log('[Signaling] Join recovery: re-sending join');
+                this.logger?.log('debug', 'Signaling', 'Join recovery: re-sending join');
                 doSendJoin();
             }, JOIN_RECOVERY_MS);
 
             this.joinHardTimeout = window.setTimeout(() => {
                 this.joinHardTimeout = null;
                 if (this.joinAttemptId !== attemptId || this.joinAcked) return;
-                console.error('[Signaling] Join hard timeout reached');
+                this.logger?.log('error', 'Signaling', 'Join hard timeout reached');
                 this.clearJoinTimers();
                 this.error = 'Join timed out';
                 this.notifyStateChange();
             }, JOIN_HARD_TIMEOUT_MS);
         } else {
-            console.log('[Signaling] Transport not ready, buffering join');
+            this.logger?.log('debug', 'Signaling', 'Transport not ready, buffering join');
             this.pendingJoin = roomId;
         }
         this.notifyStateChange();
@@ -263,7 +269,7 @@ export class SignalingEngine {
                         this.turnTokenTTLMs = msg.payload.turnTokenTTLMs as number;
                         this.scheduleTurnRefresh();
                     }
-                    console.log('[Signaling] TURN credentials refreshed');
+                    this.logger?.log('debug', 'Signaling', 'TURN credentials refreshed');
                 }
                 break;
             case 'pong':
@@ -344,7 +350,7 @@ export class SignalingEngine {
                         this.pendingJoin = null;
                         this.joinRoom(roomId);
                     } else if (this.needsRejoin && this.currentRoomId) {
-                        console.log(`[Signaling] Auto-rejoining room ${this.currentRoomId}`);
+                        this.logger?.log('debug', 'Signaling', `Auto-rejoining room ${this.currentRoomId}`);
                         this.needsRejoin = false;
                         this.joinRoom(this.currentRoomId);
                     }
@@ -355,7 +361,7 @@ export class SignalingEngine {
                 if (connectionId !== this.transportId) return;
                 this.connecting = false;
                 if (this.closedByDestroy) return;
-                console.error(`[Signaling] Disconnected via ${reason}`, err);
+                this.logger?.log('error', 'Signaling', `Disconnected via ${reason}${err ? `: ${err}` : ''}`);
                 this.isConnected = false;
                 this.activeTransport = null;
                 this.clearPingInterval();
@@ -384,6 +390,7 @@ export class SignalingEngine {
             wsUrl: this.wsUrl,
             httpBaseUrl: this.httpBaseUrl,
             sseSid: this.sseSid || undefined,
+            logger: this.logger,
         });
 
         this.transport = transport;
@@ -391,7 +398,7 @@ export class SignalingEngine {
             transport.connect();
         } catch (err) {
             this.connecting = false;
-            console.error(`[Signaling] Transport connect() threw`, err);
+            this.logger?.log('error', 'Signaling', `Transport connect() threw: ${err}`);
             this.scheduleReconnect();
         }
     }
@@ -402,7 +409,7 @@ export class SignalingEngine {
         if (reason === 'unsupported' || reason === 'timeout') return true;
         if (!this.transportConnectedOnce[kind]) return true;
         if (kind === 'ws' && this.wsConsecutiveFailures >= WS_FALLBACK_CONSECUTIVE_FAILURES) {
-            console.warn(`[Signaling] ${this.wsConsecutiveFailures} consecutive WS failures, allowing SSE fallback`);
+            this.logger?.log('warning', 'Signaling', `${this.wsConsecutiveFailures} consecutive WS failures, allowing SSE fallback`);
             return true;
         }
         return false;
@@ -411,7 +418,7 @@ export class SignalingEngine {
     private tryNextTransport(reason: string): boolean {
         const nextIndex = this.transportIndex + 1;
         if (nextIndex >= this.transportOrder.length) return false;
-        console.warn(`[Signaling] ${this.transportOrder[this.transportIndex]} failed (${reason}), trying ${this.transportOrder[nextIndex]}`);
+        this.logger?.log('warning', 'Signaling', `${this.transportOrder[this.transportIndex]} failed (${reason}), trying ${this.transportOrder[nextIndex]}`);
         this.reconnectAttempts = 0;
         this.doConnect(nextIndex);
         return true;
@@ -442,7 +449,7 @@ export class SignalingEngine {
             if (elapsed > PING_INTERVAL_MS) {
                 this.missedPongs++;
                 if (this.missedPongs >= PONG_MISS_THRESHOLD) {
-                    console.warn(`[Signaling] ${this.missedPongs} missed pongs, treating connection as dead`);
+                    this.logger?.log('warning', 'Signaling', `${this.missedPongs} missed pongs, treating connection as dead`);
                     this.missedPongs = 0;
                     if (this.transport) {
                         if (this.transport.forceClose) {
@@ -463,11 +470,11 @@ export class SignalingEngine {
         if (!this.isConnected || !this.turnTokenTTLMs || !this.currentRoomId) return;
 
         const refreshDelay = this.turnTokenTTLMs * TURN_REFRESH_TRIGGER_RATIO;
-        console.log(`[Signaling] Scheduling TURN refresh in ${Math.round(refreshDelay / 1000)}s`);
+        this.logger?.log('debug', 'Signaling', `Scheduling TURN refresh in ${Math.round(refreshDelay / 1000)}s`);
         this.turnRefreshTimer = window.setTimeout(() => {
             this.turnRefreshTimer = null;
             if (this.isConnected && this.currentRoomId) {
-                console.log('[Signaling] Sending turn-refresh request');
+                this.logger?.log('debug', 'Signaling', 'Sending turn-refresh request');
                 this.sendMessage('turn-refresh');
             }
         }, refreshDelay);
@@ -509,14 +516,14 @@ export class SignalingEngine {
             const storedTokenRoom = window.sessionStorage.getItem(this.storageKeyReconnectTokenRoom);
             if (storedTokenRoom && !this.reconnectTokenRoomId) this.reconnectTokenRoomId = storedTokenRoom;
         } catch (err) {
-            console.warn('[Signaling] Failed to load reconnectCid', err);
+            this.logger?.log('warning', 'Signaling', `Failed to load reconnectCid: ${err}`);
         }
     }
 
     private persistClientId(): void {
         if (this.clientId) {
             try { window.sessionStorage.setItem(this.storageKeyClientId, this.clientId); }
-            catch (err) { console.warn('[Signaling] Failed to persist reconnectCid', err); }
+            catch (err) { this.logger?.log('warning', 'Signaling', `Failed to persist reconnectCid: ${err}`); }
         }
     }
 
@@ -529,7 +536,7 @@ export class SignalingEngine {
                 window.sessionStorage.setItem(this.storageKeyReconnectTokenRoom, this.reconnectTokenRoomId);
             }
         } catch (err) {
-            console.warn('[Signaling] Failed to persist reconnectToken', err);
+            this.logger?.log('warning', 'Signaling', `Failed to persist reconnectToken: ${err}`);
         }
     }
 
@@ -539,7 +546,7 @@ export class SignalingEngine {
             window.sessionStorage.removeItem(this.storageKeyReconnectToken);
             window.sessionStorage.removeItem(this.storageKeyReconnectTokenRoom);
         } catch (err) {
-            console.warn('[Signaling] Failed to clear reconnectCid', err);
+            this.logger?.log('warning', 'Signaling', `Failed to clear reconnectCid: ${err}`);
         }
         this.reconnectToken = null;
         this.reconnectTokenRoomId = null;

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -4,6 +4,7 @@ import type { SignalingTransport, TransportKind } from './transports/types.js';
 import type { SerenadaLogger } from '../types.js';
 import { createSignalingTransport } from './transports/index.js';
 import { mergeRoomStatusesPayload, mergeRoomStatusUpdatePayload } from './roomStatuses.js';
+import { formatError } from '../formatError.js';
 import {
     RECONNECT_BACKOFF_BASE_MS,
     RECONNECT_BACKOFF_CAP_MS,
@@ -361,7 +362,7 @@ export class SignalingEngine {
                 if (connectionId !== this.transportId) return;
                 this.connecting = false;
                 if (this.closedByDestroy) return;
-                this.logger?.log('error', 'Signaling', `Disconnected via ${reason}${err ? `: ${err}` : ''}`);
+                this.logger?.log('error', 'Signaling', `Disconnected via ${reason}${err ? `: ${formatError(err)}` : ''}`);
                 this.isConnected = false;
                 this.activeTransport = null;
                 this.clearPingInterval();
@@ -398,7 +399,7 @@ export class SignalingEngine {
             transport.connect();
         } catch (err) {
             this.connecting = false;
-            this.logger?.log('error', 'Signaling', `Transport connect() threw: ${err}`);
+            this.logger?.log('error', 'Signaling', `Transport connect() threw: ${formatError(err)}`);
             this.scheduleReconnect();
         }
     }

--- a/client/packages/core/src/signaling/transports/index.ts
+++ b/client/packages/core/src/signaling/transports/index.ts
@@ -1,3 +1,4 @@
+import type { SerenadaLogger } from '../../types.js';
 import type { SignalingTransport, TransportHandlers, TransportKind } from './types.js';
 import { WebSocketTransport } from './ws.js';
 import { SseTransport } from './sse.js';
@@ -10,6 +11,7 @@ export interface CreateTransportOptions {
     wsUrl: string;
     httpBaseUrl: string;
     sseSid?: string;
+    logger?: SerenadaLogger;
 }
 
 export const createSignalingTransport = (
@@ -18,7 +20,7 @@ export const createSignalingTransport = (
     options: CreateTransportOptions,
 ): SignalingTransport => {
     if (kind === 'sse') {
-        return new SseTransport(handlers, options.httpBaseUrl, { sid: options.sseSid });
+        return new SseTransport(handlers, options.httpBaseUrl, { sid: options.sseSid, logger: options.logger });
     }
-    return new WebSocketTransport(handlers, options.wsUrl);
+    return new WebSocketTransport(handlers, options.wsUrl, options.logger);
 };

--- a/client/packages/core/src/signaling/transports/sse.ts
+++ b/client/packages/core/src/signaling/transports/sse.ts
@@ -2,6 +2,7 @@ import type { SerenadaLogger } from '../../types.js';
 import type { SignalingMessage } from '../types.js';
 import type { SignalingTransport, TransportHandlers, TransportKind } from './types.js';
 import { CONNECT_TIMEOUT_MS } from '../../constants.js';
+import { formatError } from '../../formatError.js';
 
 const createSid = () => {
     if (window.crypto && window.crypto.getRandomValues) {
@@ -86,7 +87,7 @@ export class SseTransport implements SignalingTransport {
                 const msg: SignalingMessage = JSON.parse(event.data);
                 this.handlers.onMessage(msg);
             } catch (e) {
-                this.logger?.log('error', 'Transport', `Failed to parse SSE message: ${e}`);
+                this.logger?.log('error', 'Transport', `Failed to parse SSE message: ${formatError(e)}`);
             }
         };
     }
@@ -139,7 +140,7 @@ export class SseTransport implements SignalingTransport {
                 }
             })
             .catch(err => {
-                this.logger?.log('error', 'Transport', `Failed to send SSE message: ${err}`);
+                this.logger?.log('error', 'Transport', `Failed to send SSE message: ${formatError(err)}`);
             });
     }
 }

--- a/client/packages/core/src/signaling/transports/sse.ts
+++ b/client/packages/core/src/signaling/transports/sse.ts
@@ -1,3 +1,4 @@
+import type { SerenadaLogger } from '../../types.js';
 import type { SignalingMessage } from '../types.js';
 import type { SignalingTransport, TransportHandlers, TransportKind } from './types.js';
 import { CONNECT_TIMEOUT_MS } from '../../constants.js';
@@ -19,11 +20,13 @@ export class SseTransport implements SignalingTransport {
     private sid: string;
     private sseUrl: string;
     private connectTimeout: number | null = null;
+    private logger?: SerenadaLogger;
 
-    constructor(handlers: TransportHandlers, baseUrl: string, options?: { sid?: string }) {
+    constructor(handlers: TransportHandlers, baseUrl: string, options?: { sid?: string; logger?: SerenadaLogger }) {
         this.handlers = handlers;
         this.sid = options?.sid || createSid();
         this.sseUrl = `${baseUrl}/sse`;
+        this.logger = options?.logger;
     }
 
     getSessionId(): string {
@@ -55,7 +58,7 @@ export class SseTransport implements SignalingTransport {
 
         this.connectTimeout = window.setTimeout(() => {
             if (this.es && this.es.readyState !== EventSource.OPEN) {
-                console.warn(`[SSE] Connection timeout after ${CONNECT_TIMEOUT_MS}ms`);
+                this.logger?.log('warning', 'Transport', `SSE connection timeout after ${CONNECT_TIMEOUT_MS}ms`);
                 this.es.close();
                 this.es = null;
                 this.open = false;
@@ -83,7 +86,7 @@ export class SseTransport implements SignalingTransport {
                 const msg: SignalingMessage = JSON.parse(event.data);
                 this.handlers.onMessage(msg);
             } catch (e) {
-                console.error('Failed to parse message', e);
+                this.logger?.log('error', 'Transport', `Failed to parse SSE message: ${e}`);
             }
         };
     }
@@ -136,7 +139,7 @@ export class SseTransport implements SignalingTransport {
                 }
             })
             .catch(err => {
-                console.error('[SSE] Failed to send message', err);
+                this.logger?.log('error', 'Transport', `Failed to send SSE message: ${err}`);
             });
     }
 }

--- a/client/packages/core/src/signaling/transports/ws.ts
+++ b/client/packages/core/src/signaling/transports/ws.ts
@@ -1,3 +1,4 @@
+import type { SerenadaLogger } from '../../types.js';
 import type { SignalingMessage } from '../types.js';
 import type { SignalingTransport, TransportHandlers, TransportKind } from './types.js';
 import { CONNECT_TIMEOUT_MS } from '../../constants.js';
@@ -9,10 +10,12 @@ export class WebSocketTransport implements SignalingTransport {
     private open = false;
     private connectTimeout: number | null = null;
     private wsUrl: string;
+    private logger?: SerenadaLogger;
 
-    constructor(handlers: TransportHandlers, wsUrl: string) {
+    constructor(handlers: TransportHandlers, wsUrl: string, logger?: SerenadaLogger) {
         this.handlers = handlers;
         this.wsUrl = wsUrl;
+        this.logger = logger;
     }
 
     private clearConnectTimeout() {
@@ -34,7 +37,7 @@ export class WebSocketTransport implements SignalingTransport {
 
         this.connectTimeout = window.setTimeout(() => {
             if (this.ws && this.ws.readyState !== WebSocket.OPEN) {
-                console.warn(`[WS] Connection timeout after ${CONNECT_TIMEOUT_MS}ms`);
+                this.logger?.log('warning', 'Transport', `WS connection timeout after ${CONNECT_TIMEOUT_MS}ms`);
                 this.ws.close();
                 this.open = false;
                 this.handlers.onClose('timeout');
@@ -64,7 +67,7 @@ export class WebSocketTransport implements SignalingTransport {
                 const msg: SignalingMessage = JSON.parse(event.data);
                 this.handlers.onMessage(msg);
             } catch (e) {
-                console.error('Failed to parse message', e);
+                this.logger?.log('error', 'Transport', `Failed to parse WS message: ${e}`);
             }
         };
     }

--- a/client/packages/core/src/signaling/transports/ws.ts
+++ b/client/packages/core/src/signaling/transports/ws.ts
@@ -2,6 +2,7 @@ import type { SerenadaLogger } from '../../types.js';
 import type { SignalingMessage } from '../types.js';
 import type { SignalingTransport, TransportHandlers, TransportKind } from './types.js';
 import { CONNECT_TIMEOUT_MS } from '../../constants.js';
+import { formatError } from '../../formatError.js';
 
 export class WebSocketTransport implements SignalingTransport {
     kind: TransportKind = 'ws';
@@ -67,7 +68,7 @@ export class WebSocketTransport implements SignalingTransport {
                 const msg: SignalingMessage = JSON.parse(event.data);
                 this.handlers.onMessage(msg);
             } catch (e) {
-                this.logger?.log('error', 'Transport', `Failed to parse WS message: ${e}`);
+                this.logger?.log('error', 'Transport', `Failed to parse WS message: ${formatError(e)}`);
             }
         };
     }

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -49,6 +49,7 @@ export interface SerenadaConfig {
     defaultVideoEnabled?: boolean;
     transports?: TransportKind[];
     turnsOnly?: boolean;
+    logger?: SerenadaLogger;
 }
 
 export interface CreateRoomResult {
@@ -152,4 +153,10 @@ export interface IceProbeReport {
     turnPassed: boolean;
     logs: string[];
     iceServersSummary?: string;
+}
+
+export type SerenadaLogLevel = 'debug' | 'info' | 'warning' | 'error';
+
+export interface SerenadaLogger {
+    log(level: SerenadaLogLevel, tag: string, message: string): void;
 }

--- a/client/src/pages/CallRoom.tsx
+++ b/client/src/pages/CallRoom.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { BellRing, CheckSquare, Copy, Square } from 'lucide-react';
 import { SerenadaCallFlow } from '@serenada/react-ui';
 import type { SerenadaString } from '@serenada/react-ui';
-import { SerenadaCore, SNAPSHOT_PREPARE_TIMEOUT_MS } from '@serenada/core';
+import { SerenadaCore, ConsoleSerenadaLogger, SNAPSHOT_PREPARE_TIMEOUT_MS } from '@serenada/core';
 import type { CallState, SerenadaSessionHandle } from '@serenada/core';
 import { useToast } from '../contexts/ToastContext';
 import { saveCall } from '../utils/callHistory';
@@ -224,7 +224,7 @@ const CallRoom: React.FC = () => {
     const callStartTimeRef = useRef<number | null>(null);
     const pushNotifySentRef = useRef(false);
 
-    const core = useMemo(() => new SerenadaCore({ serverHost: getConfiguredServerHost() }), []);
+    const core = useMemo(() => new SerenadaCore({ serverHost: getConfiguredServerHost(), logger: new ConsoleSerenadaLogger() }), []);
     const strings = useMemo(() => buildSerenadaCallStrings(t), [t]);
 
     const stopPreview = useCallback(() => {


### PR DESCRIPTION
## Summary
- Introduce `SerenadaLogger` protocol/interface across all three SDKs (iOS, Android, Web) so host apps control logging destination
- Replace direct platform logging (`print`/`os_log` on iOS, `android.util.Log` on Android, `console.*` on Web) with optional logger injection
- Default is silent (no logger = no output); built-in convenience loggers provided for opt-in (`PrintSerenadaLogger`, `AndroidSerenadaLogger`, `ConsoleSerenadaLogger`)
- Consistent tag conventions across platforms: `Session`, `Signaling`, `Transport`, `WebRTC`, `PeerConnection`, `Negotiation`, `Audio`, `Camera`, `ScreenShare`, `Stats`

## Test plan
- [x] iOS: `xcodebuild test` — 167 tests pass
- [x] Android: `./gradlew :serenada-core:compileDebugKotlin` and `:serenada-core:testDebugUnitTest` — build and tests pass
- [x] Web: `npm run build`, `npm run lint` (no new errors), `npm run test` — 115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)