### PR TITLE
Add typed PeerConnectionState to web SDK

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export type {
     ConnectionStatus,
     CameraMode,
     MediaCapability,
+    PeerConnectionState,
     Participant,
     LocalParticipant,
     CallError,

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -10,11 +10,13 @@ export type CameraMode = 'selfie' | 'world' | 'composite' | 'screenShare';
 
 export type MediaCapability = 'camera' | 'microphone';
 
+export type PeerConnectionState = 'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed';
+
 export interface Participant {
     cid: string;
     audioEnabled: boolean;
     videoEnabled: boolean;
-    connectionState: string;
+    connectionState: PeerConnectionState;
 }
 
 export interface LocalParticipant {


### PR DESCRIPTION
## Summary
- Add `PeerConnectionState` type union (`'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed'`) to `@serenada/core`
- Narrow `Participant.connectionState` from `string` to `PeerConnectionState`
- Export `PeerConnectionState` from the package public API

## Details
Stage 1 of SDK Remediation: replace stringly-typed `connectionState` with a proper type union matching the WebRTC `RTCPeerConnectionState` spec. No cast needed in `SerenadaSession.ts` since TypeScript recognizes the structural equivalence between `RTCPeerConnectionState` and `PeerConnectionState`.

## Test plan
- [x] TypeScript compilation passes (`npm run build`)
- [x] All 115 Vitest tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)