### PR TITLE
Add typed CallErrorCode to web SDK

### DIFF
--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -17,15 +17,14 @@ function mapErrorCode(serverCode: string): CallErrorCode {
             return 'roomEnded';
         case 'CONNECTION_FAILED':
             return 'connectionFailed';
-        case 'NOT_IN_ROOM':
-        case 'NOT_HOST':
-            return 'permissionDenied';
         case 'BAD_REQUEST':
         case 'UNSUPPORTED_VERSION':
         case 'INVALID_ROOM_ID':
         case 'SERVER_NOT_CONFIGURED':
         case 'INVALID_RECONNECT_TOKEN':
         case 'TURN_REFRESH_FAILED':
+        case 'NOT_IN_ROOM':
+        case 'NOT_HOST':
             return 'serverError';
         default:
             return 'unknown';

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -1,10 +1,36 @@
-import type { CallState, CallStats, CameraMode, ConnectionStatus, MediaCapability, SerenadaConfig, SerenadaSessionHandle } from './types.js';
+import type { CallErrorCode, CallState, CallStats, CameraMode, ConnectionStatus, MediaCapability, SerenadaConfig, SerenadaSessionHandle } from './types.js';
 import { SignalingEngine } from './signaling/SignalingEngine.js';
 import { MediaEngine } from './media/MediaEngine.js';
 import { CallStatsCollector } from './media/callStats.js';
 import type { TransportKind } from './signaling/transports/types.js';
 import type { SignalingMessage } from './signaling/types.js';
 import { resolveServerUrls } from './serverUrls.js';
+
+function mapErrorCode(serverCode: string): CallErrorCode {
+    switch (serverCode) {
+        case 'JOIN_TIMEOUT':
+            return 'signalingTimeout';
+        case 'ROOM_FULL':
+        case 'ROOM_CAPACITY_UNSUPPORTED':
+            return 'roomFull';
+        case 'ROOM_ENDED':
+            return 'roomEnded';
+        case 'CONNECTION_FAILED':
+            return 'connectionFailed';
+        case 'NOT_IN_ROOM':
+        case 'NOT_HOST':
+            return 'permissionDenied';
+        case 'BAD_REQUEST':
+        case 'UNSUPPORTED_VERSION':
+        case 'INVALID_ROOM_ID':
+        case 'SERVER_NOT_CONFIGURED':
+        case 'INVALID_RECONNECT_TOKEN':
+        case 'TURN_REFRESH_FAILED':
+            return 'serverError';
+        default:
+            return 'unknown';
+    }
+}
 
 export class SerenadaSession implements SerenadaSessionHandle {
     private signaling: SignalingEngine;
@@ -250,7 +276,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
             connectionStatus: this.media.connectionStatus as ConnectionStatus,
             activeTransport: this.signaling.activeTransport as TransportKind | null,
             requiredPermissions: this._state.requiredPermissions,
-            error: error ? { code: 'signaling_error', message: error } : null,
+            error: error ? { code: mapErrorCode(error.code), message: error.message } : null,
         };
 
         this.notifyListeners();

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
     Participant,
     LocalParticipant,
     CallError,
+    CallErrorCode,
     CallState,
     SerenadaConfig,
     CreateRoomResult,

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -35,7 +35,7 @@ export class SignalingEngine {
     roomState: RoomState | null = null;
     turnToken: string | null = null;
     turnTokenTTLMs: number | null = null;
-    error: string | null = null;
+    error: { code: string; message: string } | null = null;
     roomStatuses: RoomStatuses = {};
 
     // Config
@@ -174,7 +174,7 @@ export class SignalingEngine {
                 if (this.joinAttemptId !== attemptId || this.joinAcked) return;
                 this.logger?.log('error', 'Signaling', 'Join hard timeout reached');
                 this.clearJoinTimers();
-                this.error = 'Join timed out';
+                this.error = { code: 'JOIN_TIMEOUT', message: 'Join timed out' };
                 this.notifyStateChange();
             }, JOIN_HARD_TIMEOUT_MS);
         } else {
@@ -303,7 +303,10 @@ export class SignalingEngine {
                 break;
             case 'error':
                 if (msg.payload && msg.payload.message) {
-                    this.error = String(msg.payload.message);
+                    this.error = {
+                        code: (msg.payload.code as string) ?? 'UNKNOWN',
+                        message: String(msg.payload.message),
+                    };
                 }
                 break;
         }

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -25,8 +25,17 @@ export interface LocalParticipant {
     isHost: boolean;
 }
 
+export type CallErrorCode =
+    | 'signalingTimeout'
+    | 'connectionFailed'
+    | 'roomFull'
+    | 'roomEnded'
+    | 'permissionDenied'
+    | 'serverError'
+    | 'unknown';
+
 export interface CallError {
-    code: string;
+    code: CallErrorCode;
     message: string;
 }
 


### PR DESCRIPTION
## Summary
- Define `CallErrorCode` string union type (`signalingTimeout`, `connectionFailed`, `roomFull`, `roomEnded`, `permissionDenied`, `serverError`, `unknown`) in `types.ts`
- Change `SignalingEngine.error` from `string | null` to `{ code: string; message: string } | null` to carry server error codes through
- Add `mapErrorCode()` in `SerenadaSession.ts` that maps server codes (e.g. `ROOM_FULL`, `JOIN_TIMEOUT`) to typed `CallErrorCode` values
- Export `CallErrorCode` from `@serenada/core`

## Test plan
- [x] TypeScript compilation passes (`npm run build`)
- [x] All 115 existing tests pass (`npm test`)
- [ ] Verify error codes surface correctly in call UI when a room is full or join times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)