### PR TITLE
Add typed SerenadaPeerConnectionState enum to Android SDK

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -25,6 +25,7 @@ import app.serenada.core.call.LocalFrameSnapshotCapture
 import app.serenada.core.call.Participant
 import app.serenada.core.call.PeerConnectionSlotProtocol
 import app.serenada.core.call.RemoteParticipant
+import app.serenada.core.call.SerenadaPeerConnectionState
 import app.serenada.core.call.RealtimeCallStats
 import app.serenada.core.call.RoomState
 import app.serenada.core.call.SessionAudioController
@@ -825,7 +826,7 @@ class SerenadaSession internal constructor(
             ?: peerSlots.keys.toList()
         val remoteParticipants = orderedRemoteCids.mapNotNull { cid ->
             val slot = peerSlots[cid] ?: return@mapNotNull null
-            RemoteParticipant(cid = cid, videoEnabled = slot.isRemoteVideoTrackEnabled(), connectionState = slot.getConnectionState().name)
+            RemoteParticipant(cid = cid, videoEnabled = slot.isRemoteVideoTrackEnabled(), connectionState = SerenadaPeerConnectionState.fromRtcState(slot.getConnectionState()))
         }
         val currentState = _state.value
         val currentDiagnostics = _diagnostics.value

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
@@ -3,5 +3,5 @@ package app.serenada.core.call
 data class RemoteParticipant(
     val cid: String,
     val videoEnabled: Boolean,
-    val connectionState: String,
+    val connectionState: SerenadaPeerConnectionState,
 )

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SerenadaPeerConnectionState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SerenadaPeerConnectionState.kt
@@ -1,0 +1,25 @@
+package app.serenada.core.call
+
+import org.webrtc.PeerConnection
+
+/** Per-peer connection state exposed on [RemoteParticipant]. */
+enum class SerenadaPeerConnectionState(val value: String) {
+    NEW("NEW"),
+    CONNECTING("CONNECTING"),
+    CONNECTED("CONNECTED"),
+    DISCONNECTED("DISCONNECTED"),
+    FAILED("FAILED"),
+    CLOSED("CLOSED");
+
+    companion object {
+        fun fromRtcState(state: PeerConnection.PeerConnectionState): SerenadaPeerConnectionState =
+            when (state) {
+                PeerConnection.PeerConnectionState.NEW -> NEW
+                PeerConnection.PeerConnectionState.CONNECTING -> CONNECTING
+                PeerConnection.PeerConnectionState.CONNECTED -> CONNECTED
+                PeerConnection.PeerConnectionState.DISCONNECTED -> DISCONNECTED
+                PeerConnection.PeerConnectionState.FAILED -> FAILED
+                PeerConnection.PeerConnectionState.CLOSED -> CLOSED
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `SerenadaPeerConnectionState` enum in `serenada-core` that maps from WebRTC's `PeerConnection.PeerConnectionState`
- Change `RemoteParticipant.connectionState` from `String` to `SerenadaPeerConnectionState` for compile-time safety
- Update `SerenadaSession` to use `SerenadaPeerConnectionState.fromRtcState()` when building `RemoteParticipant`

## Test plan
- [x] `./gradlew :serenada-core:test` passes (62 tasks, all green)
- [ ] Verify that downstream consumers of `RemoteParticipant.connectionState` compile with the new enum type
- [ ] Confirm enum values match the six WebRTC peer connection states (NEW, CONNECTING, CONNECTED, DISCONNECTED, FAILED, CLOSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)