### PR TITLE
Android: Replace errorMessage with typed CallError sealed class

### DIFF
--- a/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
@@ -244,12 +244,12 @@ class CallManager(context: Context) : RoomWatcherDelegate {
                 roomId = state.roomId ?: currentRoomId,
                 localCid = state.localCid,
                 statusMessageResId = statusMessageResId,
-                errorMessageResId = if (state.phase == CallPhase.Error && state.errorMessage.isNullOrBlank()) {
+                errorMessageResId = if (state.phase == CallPhase.Error && state.error == null) {
                     R.string.error_unknown
                 } else {
                     null
                 },
-                errorMessageText = if (state.phase == CallPhase.Error) state.errorMessage else null,
+                errorMessageText = if (state.phase == CallPhase.Error) state.error?.displayMessage else null,
                 isHost = state.isHost,
                 participantCount = state.participantCount,
                 localAudioEnabled = state.localAudioEnabled,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -242,7 +242,7 @@ private fun rememberCallUiState(
             phase = state.phase,
             roomId = state.roomId,
             localCid = state.localCid,
-            errorMessageText = state.errorMessage,
+            errorMessageText = state.error?.displayMessage,
             isHost = state.isHost,
             participantCount = state.participantCount,
             localAudioEnabled = state.localAudioEnabled,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/CallError.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/CallError.kt
@@ -1,0 +1,26 @@
+package app.serenada.core
+
+/**
+ * Typed error representation for SDK call errors.
+ * Matches the iOS `CallError` enum for cross-platform parity.
+ */
+sealed class CallError {
+    object SignalingTimeout : CallError()
+    object ConnectionFailed : CallError()
+    object RoomFull : CallError()
+    object RoomEnded : CallError()
+    object PermissionDenied : CallError()
+    data class ServerError(val message: String) : CallError()
+    data class Unknown(val message: String) : CallError()
+
+    /** Human-readable message for UI display. */
+    val displayMessage: String get() = when (this) {
+        is SignalingTimeout -> "Connection timed out"
+        is ConnectionFailed -> "Connection failed"
+        is RoomFull -> "Room is full"
+        is RoomEnded -> "Call ended"
+        is PermissionDenied -> "Permission denied"
+        is ServerError -> message
+        is Unknown -> message
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
@@ -20,7 +20,7 @@ data class CallState(
     val remoteParticipants: List<RemoteParticipant> = emptyList(),
     val connectionStatus: ConnectionStatus = ConnectionStatus.Connected,
     val localCameraMode: LocalCameraMode = LocalCameraMode.SELFIE,
-    val errorMessage: String? = null,
+    val error: CallError? = null,
     val requiredPermissions: List<MediaCapability> = emptyList(),
 ) {
     val remoteVideoEnabled: Boolean

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCoreDelegate.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCoreDelegate.kt
@@ -22,8 +22,8 @@ interface SerenadaCoreDelegate {
     fun onSessionEnded(session: SerenadaSession, reason: EndReason) {}
 }
 
-enum class EndReason {
-    LOCAL_LEFT,
-    REMOTE_ENDED,
-    ERROR,
+sealed class EndReason {
+    object LocalLeft : EndReason()
+    object RemoteEnded : EndReason()
+    data class Error(val error: CallError) : EndReason()
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -128,8 +128,8 @@ class SerenadaSession internal constructor(
         isSignalingConnected = { signalingClient.isConnected() },
         onJoinTimeout = {
             resetResources()
-            updateState(CallState(phase = CallPhase.Error, errorMessage = "Connection failed"))
-            delegate?.invoke()?.onSessionEnded(this, EndReason.ERROR)
+            updateState(CallState(phase = CallPhase.Error, error = CallError.ConnectionFailed))
+            delegate?.invoke()?.onSessionEnded(this, EndReason.Error(CallError.ConnectionFailed))
         },
         ensureSignalingConnection = { ensureSignalingConnection() },
         onRecovery = {
@@ -321,7 +321,7 @@ class SerenadaSession internal constructor(
         assertMainThread()
         if (_state.value.phase == CallPhase.Idle) return
         sendMessage("leave", null)
-        cleanupCall(EndReason.LOCAL_LEFT)
+        cleanupCall(EndReason.LocalLeft)
     }
 
     fun end() {
@@ -412,7 +412,7 @@ class SerenadaSession internal constructor(
         assertMainThread()
         if (awaitingPermissions) {
             awaitingPermissions = false
-            cleanupCall(EndReason.LOCAL_LEFT)
+            cleanupCall(EndReason.LocalLeft)
         }
     }
 
@@ -544,7 +544,7 @@ class SerenadaSession internal constructor(
             _state.value.copy(
                 phase = CallPhase.Joining,
                 roomId = roomId,
-                errorMessage = null,
+                error = null,
                 localAudioEnabled = config.defaultAudioEnabled,
                 localVideoEnabled = config.defaultVideoEnabled,
                 remoteParticipants = emptyList(),
@@ -752,7 +752,7 @@ class SerenadaSession internal constructor(
     }
 
     private fun handleRoomEnded() {
-        cleanupCall(EndReason.REMOTE_ENDED)
+        cleanupCall(EndReason.RemoteEnded)
     }
 
     private fun handleContentState(msg: SignalingMessage) {
@@ -778,16 +778,19 @@ class SerenadaSession internal constructor(
     }
 
     private fun handleError(msg: SignalingMessage) {
-        val rawMessage = msg.payload?.optString("message").orEmpty().ifBlank { null }
+        val code = msg.payload?.optString("code")?.trim()?.ifBlank { null }
+        val rawMessage = msg.payload?.optString("message")?.trim()?.ifBlank { null }
+        val callError = when (code) {
+            "ROOM_CAPACITY_UNSUPPORTED" -> CallError.RoomFull
+            "CONNECTION_FAILED" -> CallError.ConnectionFailed
+            "JOIN_TIMEOUT" -> CallError.SignalingTimeout
+            "ROOM_ENDED" -> CallError.RoomEnded
+            else -> if (rawMessage != null) CallError.ServerError(rawMessage) else CallError.Unknown("Unknown error")
+        }
         clearJoinTimeout()
         resetResources()
-        updateState(
-            CallState(
-                phase = CallPhase.Error,
-                errorMessage = rawMessage ?: "Unknown error"
-            )
-        )
-        delegate?.invoke()?.onSessionEnded(this, EndReason.ERROR)
+        updateState(CallState(phase = CallPhase.Error, error = callError))
+        delegate?.invoke()?.onSessionEnded(this, EndReason.Error(callError))
     }
 
     private fun handleSignalingPayload(msg: SignalingMessage) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -781,7 +781,7 @@ class SerenadaSession internal constructor(
         val code = msg.payload?.optString("code")?.trim()?.ifBlank { null }
         val rawMessage = msg.payload?.optString("message")?.trim()?.ifBlank { null }
         val callError = when (code) {
-            "ROOM_CAPACITY_UNSUPPORTED" -> CallError.RoomFull
+            "ROOM_CAPACITY_UNSUPPORTED", "ROOM_FULL" -> CallError.RoomFull
             "CONNECTION_FAILED" -> CallError.ConnectionFailed
             "JOIN_TIMEOUT" -> CallError.SignalingTimeout
             "ROOM_ENDED" -> CallError.RoomEnded

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
@@ -94,7 +94,8 @@ class SerenadaSessionContractTest {
         factory.simulateError(code = "ROOM_CAPACITY_UNSUPPORTED", message = "Room is full")
 
         assertEquals(CallPhase.Error, factory.session.state.value.phase)
-        assertNotNull(factory.session.state.value.errorMessage)
+        assertNotNull(factory.session.state.value.error)
+        assertTrue(factory.session.state.value.error is CallError.RoomFull)
         assertTrue("Engine should be released", factory.fakeMedia.releaseCalls > 0)
         assertTrue("Signaling should be closed", factory.fakeSignaling.closeCalls > 0)
     }


### PR DESCRIPTION
## Summary
- Created `CallError` sealed class with variants: `SignalingTimeout`, `ConnectionFailed`, `RoomFull`, `RoomEnded`, `PermissionDenied`, `ServerError`, `Unknown` — matching iOS for cross-platform parity
- Replaced `CallState.errorMessage: String?` with `CallState.error: CallError?`
- Refactored `EndReason` from enum (`LOCAL_LEFT`, `REMOTE_ENDED`, `ERROR`) to sealed class (`LocalLeft`, `RemoteEnded`, `Error(CallError)`)
- Updated `handleError()` in `SerenadaSession` to map server error codes (`ROOM_CAPACITY_UNSUPPORTED`, `CONNECTION_FAILED`, etc.) to typed `CallError` variants
- Updated all consumers: `SerenadaCallFlow`, `CallManager`, and contract tests

## Test plan
- [x] `./gradlew :serenada-core:test` — all unit tests pass
- [x] `./gradlew assembleDebug` — full debug build succeeds
- [ ] Manual verification on device (SDK API change, verify error display in call UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)