### PR TITLE
Add roomEnded and permissionDenied to iOS CallError enum

### DIFF
--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -59,6 +59,8 @@ public enum CallError: Equatable, Sendable {
     case signalingTimeout
     case connectionFailed
     case roomFull
+    case roomEnded
+    case permissionDenied
     case serverError(String)
     case unknown(String)
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -686,6 +686,8 @@ public final class SerenadaSession: ObservableObject {
                 return .connectionFailed
             case "JOIN_TIMEOUT":
                 return .signalingTimeout
+            case "ROOM_ENDED":
+                return .roomEnded
             case .some:
                 return .serverError(rawMessage ?? code ?? "Server error")
             default:

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -607,6 +607,10 @@ final class CallManager: ObservableObject {
             return L10n.callStatusConnectionFailed
         case .roomFull:
             return L10n.errorRoomCapacityUnsupported
+        case .roomEnded:
+            return L10n.callStatusRoomEnded
+        case .permissionDenied:
+            return L10n.callStatusConnectionFailed
         case .serverError(let message), .unknown(let message):
             return message.isEmpty ? L10n.errorUnknown : message
         }


### PR DESCRIPTION
## Summary
- Add `.roomEnded` and `.permissionDenied` cases to the `CallError` enum in `SerenadaCore` for cross-platform parity with Android/Web SDKs
- Map the `ROOM_ENDED` server error code in `SerenadaSession.handleError()`
- Handle both new cases in `CallManager.errorMessage(for:)` with appropriate localized strings

## Test plan
- [x] `xcodebuild build` succeeds (iOS Simulator, iPhone 16, iOS 18.4)
- [x] All 167 unit tests pass (`xcodebuild -only-testing:SerenadaiOSTests test`)
- [x] Verified no other exhaustive switches on `CallError` need updating (SerenadaCallUI and tests do not switch on it)
- [x] Verified `room_ended` message type is handled separately in `handleSignalingMessage` (line 606-607), so `ROOM_ENDED` error code mapping is an additional safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)