### PR TITLE
Add typed SerenadaPeerConnectionState enum to iOS SDK

### DIFF
--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -536,12 +536,12 @@ public final class PeerConnectionSlot: PeerConnectionSlotProtocol {
 #endif
     }
 
-    public func getConnectionState() -> String {
+    public func getConnectionState() -> SerenadaPeerConnectionState {
 #if canImport(WebRTC)
-        guard let peerConnection else { return "NEW" }
-        return connectionStateString(peerConnection.connectionState)
+        guard let peerConnection else { return .new }
+        return peerConnectionState(peerConnection.connectionState)
 #else
-        return "NEW"
+        return .new
 #endif
     }
 

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
@@ -50,7 +50,7 @@ public protocol PeerConnectionSlotProtocol: AnyObject {
 
     // State queries
     func isReady() -> Bool
-    func getConnectionState() -> String
+    func getConnectionState() -> SerenadaPeerConnectionState
     func getIceConnectionState() -> String
     func getSignalingState() -> String
     func hasRemoteDescription() -> Bool

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -609,8 +609,8 @@ final class PeerNegotiationEngine {
     private static let icePriority: [String: Int] = [
         "FAILED": 0, "DISCONNECTED": 1, "CHECKING": 2, "NEW": 3, "CONNECTED": 4, "COMPLETED": 5, "CLOSED": 6, "COUNT": 7, "UNKNOWN": 8,
     ]
-    private static let connectionPriority: [String: Int] = [
-        "FAILED": 0, "DISCONNECTED": 1, "CONNECTING": 2, "NEW": 3, "CONNECTED": 4, "CLOSED": 5, "UNKNOWN": 6,
+    private static let connectionPriority: [SerenadaPeerConnectionState: Int] = [
+        .failed: 0, .disconnected: 1, .connecting: 2, .new: 3, .connected: 4, .closed: 5,
     ]
     private static let signalingPriority: [String: Int] = [
         "HAVE_LOCAL_OFFER": 0, "HAVE_REMOTE_OFFER": 1, "HAVE_LOCAL_PRANSWER": 2, "HAVE_REMOTE_PRANSWER": 3, "STABLE": 4, "CLOSED": 5, "UNKNOWN": 6,
@@ -620,7 +620,7 @@ final class PeerNegotiationEngine {
         var bestIcePri = Int.max
         var nextIceState = "NEW"
         var bestConnPri = Int.max
-        var nextConnectionState = "NEW"
+        var nextConnectionState: SerenadaPeerConnectionState = .new
         var bestSigPri = Int.max
         var nextSignalingState = "STABLE"
 
@@ -646,7 +646,7 @@ final class PeerNegotiationEngine {
 
         onAggregatePeerStateChanged(
             IceConnectionState(rawValueOrUnknown: nextIceState),
-            PeerConnectionState(rawValueOrUnknown: nextConnectionState),
+            PeerConnectionState(rawValueOrUnknown: nextConnectionState.rawValue),
             SignalingState(rawValueOrUnknown: nextSignalingState)
         )
     }

--- a/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
+++ b/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
@@ -90,7 +90,10 @@ func peerConnectionState(_ state: RTCPeerConnectionState) -> SerenadaPeerConnect
     case .disconnected: return .disconnected
     case .failed: return .failed
     case .closed: return .closed
-    @unknown default: return .new
+    @unknown default:
+        // Future RTCPeerConnectionState values are mapped to .new as a safe default.
+        // This avoids crashing on SDK upgrades when the WebRTC framework adds new states.
+        return .new
     }
 }
 

--- a/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
+++ b/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
@@ -79,21 +79,18 @@ func positiveRatePerMinute(currentValue: Int64, previousValue: Int64, elapsedSec
 }
 
 func connectionStateString(_ state: RTCPeerConnectionState) -> String {
+    peerConnectionState(state).rawValue
+}
+
+func peerConnectionState(_ state: RTCPeerConnectionState) -> SerenadaPeerConnectionState {
     switch state {
-    case .new:
-        return "NEW"
-    case .connecting:
-        return "CONNECTING"
-    case .connected:
-        return "CONNECTED"
-    case .disconnected:
-        return "DISCONNECTED"
-    case .failed:
-        return "FAILED"
-    case .closed:
-        return "CLOSED"
-    @unknown default:
-        return "UNKNOWN"
+    case .new: return .new
+    case .connecting: return .connecting
+    case .connected: return .connected
+    case .disconnected: return .disconnected
+    case .failed: return .failed
+    case .closed: return .closed
+    @unknown default: return .new
     }
 }
 

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -32,11 +32,11 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
     public let cid: String
     public var audioEnabled: Bool
     public var videoEnabled: Bool
-    public var connectionState: String
+    public var connectionState: SerenadaPeerConnectionState
 
     public var id: String { cid }
 
-    public init(cid: String, audioEnabled: Bool = true, videoEnabled: Bool = true, connectionState: String = "NEW") {
+    public init(cid: String, audioEnabled: Bool = true, videoEnabled: Bool = true, connectionState: SerenadaPeerConnectionState = .new) {
         self.cid = cid
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled

--- a/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
@@ -3,11 +3,11 @@ import Foundation
 public struct RemoteParticipant: Identifiable, Equatable {
     public let cid: String
     public var videoEnabled: Bool
-    public var connectionState: String
+    public var connectionState: SerenadaPeerConnectionState
 
     public var id: String { cid }
 
-    public init(cid: String, videoEnabled: Bool, connectionState: String) {
+    public init(cid: String, videoEnabled: Bool, connectionState: SerenadaPeerConnectionState) {
         self.cid = cid
         self.videoEnabled = videoEnabled
         self.connectionState = connectionState

--- a/client-ios/SerenadaCore/Sources/Models/SerenadaPeerConnectionState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/SerenadaPeerConnectionState.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Typed peer connection state, replacing raw String.
+/// Values match WebRTC RTCPeerConnectionState (UPPER_CASE for cross-platform wire parity with Android).
+public enum SerenadaPeerConnectionState: String, Codable, Equatable, Sendable {
+    case new = "NEW"
+    case connecting = "CONNECTING"
+    case connected = "CONNECTED"
+    case disconnected = "DISCONNECTED"
+    case failed = "FAILED"
+    case closed = "CLOSED"
+}

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -838,7 +838,7 @@ public final class SerenadaSession: ObservableObject {
                     cid: participant.cid,
                     audioEnabled: true,
                     videoEnabled: slot?.isRemoteVideoTrackEnabled() ?? false,
-                    connectionState: slot?.getConnectionState() ?? "NEW"
+                    connectionState: slot?.getConnectionState() ?? .new
                 )
             }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
@@ -16,7 +16,7 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
 
     // State machine
     private(set) var signalingState = "STABLE"
-    private(set) var connectionState = "NEW"
+    private(set) var connectionState: SerenadaPeerConnectionState = .new
     private(set) var iceConnectionState = "NEW"
     private(set) var ready = true
     private(set) var remoteDescriptionSet = false
@@ -169,7 +169,7 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
     // MARK: - State Queries
 
     func isReady() -> Bool { ready }
-    func getConnectionState() -> String { connectionState }
+    func getConnectionState() -> SerenadaPeerConnectionState { connectionState }
     func getIceConnectionState() -> String { iceConnectionState }
     func getSignalingState() -> String { signalingState }
     func hasRemoteDescription() -> Bool { remoteDescriptionSet }
@@ -192,9 +192,9 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
 
     // MARK: - Test Drivers
 
-    func simulateConnectionStateChange(_ state: String) {
+    func simulateConnectionStateChange(_ state: SerenadaPeerConnectionState) {
         connectionState = state
-        onConnectionStateChange?(remoteCid, state)
+        onConnectionStateChange?(remoteCid, state.rawValue)
     }
 
     func simulateIceConnectionStateChange(_ state: String) {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
@@ -172,7 +172,7 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertNotNil(fakeSlot)
 
         // Simulate connection DISCONNECTED
-        fakeSlot?.simulateConnectionStateChange("DISCONNECTED")
+        fakeSlot?.simulateConnectionStateChange(.disconnected)
         await harness.yieldToMainActor()
 
         // ICE restart should be scheduled (task set)
@@ -192,7 +192,7 @@ final class SessionNegotiationTests: XCTestCase {
         let offersBefore = fakeSlot?.createOfferCalls ?? 0
 
         // Simulate connection FAILED (delay=0 → immediate)
-        fakeSlot?.simulateConnectionStateChange("FAILED")
+        fakeSlot?.simulateConnectionStateChange(.failed)
         await harness.yieldToMainActor()
         // Advance clock to let any delayed tasks fire, plus yields for MainActor scheduling
         await harness.fakeClock.advance(byMs: 100)
@@ -217,12 +217,12 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertNotNil(fakeSlot)
 
         // Schedule an ICE restart
-        fakeSlot?.simulateConnectionStateChange("DISCONNECTED")
+        fakeSlot?.simulateConnectionStateChange(.disconnected)
         await harness.yieldToMainActor()
         XCTAssertNotNil(fakeSlot?.iceRestartTask, "ICE restart should be scheduled")
 
         // Simulate CONNECTED → should clear the restart task
-        fakeSlot?.simulateConnectionStateChange("CONNECTED")
+        fakeSlot?.simulateConnectionStateChange(.connected)
         await harness.yieldToMainActor()
 
         XCTAssertNil(fakeSlot?.iceRestartTask, "ICE restart task should be cleared on CONNECTED")


### PR DESCRIPTION
## Summary
- Add `SerenadaPeerConnectionState` enum to replace raw `String` for connection state on `SerenadaRemoteParticipant` and `RemoteParticipant` in the iOS SDK
- Update `PeerConnectionSlotProtocol.getConnectionState()` to return the new enum instead of `String`
- Update `PeerNegotiationEngine.connectionPriority` dictionary to use typed enum keys
- Update `connectionStateString()` in RtcStatsHelpers to delegate to a new `peerConnectionState()` function returning the enum
- Update test fakes and test call sites to use enum values

## Test plan
- [x] Full Xcode build succeeds (`xcodebuild build` on iPhone 16 simulator)
- [x] All 167 unit tests pass with 0 failures
- [x] Verified no downstream breakage in SerenadaCallUI or host app (both consume the changed types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)