### PR TITLE
Add worktree bootstrap and validation scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,5 +100,17 @@ xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS \
 ```
 - Use the following deep-link to join a live call: `https://serenada.app/call/YovflsGamCygX912gb26Jeaq8Es`
 
+## Worktree Setup
+When working in a git worktree, run the bootstrap script to install all dependencies:
+```bash
+tools/worktree-bootstrap.sh .
+```
+Skip platforms you don't need with `SKIP_WEB=1`, `SKIP_SERVER=1`, `SKIP_ANDROID=1`, `SKIP_IOS=1`.
+
+Validate the worktree is build-ready:
+```bash
+tools/worktree-validate.sh .
+```
+
 ## When unsure
 - Ask for clarification instead of guessing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,21 @@ xcodebuild \
   test
 ```
 
+### Worktree Bootstrap & Validation
+After creating a git worktree, bootstrap it to install all dependencies:
+```bash
+tools/worktree-bootstrap.sh <worktree-path>    # install deps in a worktree
+tools/worktree-bootstrap.sh                     # or run in the main checkout
+SKIP_ANDROID=1 SKIP_IOS=1 tools/worktree-bootstrap.sh ../my-wt  # web+server only
+```
+
+Validate that a worktree (or the main repo) is build-ready:
+```bash
+tools/worktree-validate.sh <worktree-path>     # full validation (builds + tests)
+tools/worktree-validate.sh                      # validate the main checkout
+SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh  # structure + deps only
+```
+
 ### Load Testing
 ```bash
 ./server/loadtest/run-local.sh    # Run signaling load sweep against local Docker stack

--- a/tools/worktree-bootstrap.sh
+++ b/tools/worktree-bootstrap.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Bootstrap a worktree (or any checkout) by installing all dependencies.
+#
+# Run this after creating a git worktree to make it build-ready.
+# Also works on the main checkout or a fresh clone.
+#
+# Usage:
+#   tools/worktree-bootstrap.sh [path]     # defaults to repo root
+#   tools/worktree-bootstrap.sh ../my-wt
+#
+# Options (env vars):
+#   SKIP_WEB=1       Skip web client (npm install)
+#   SKIP_SERVER=1    Skip Go server (go mod download)
+#   SKIP_ANDROID=1   Skip Android client (gradlew)
+#   SKIP_IOS=1       Skip iOS client (xcodegen)
+#   SKIP_ENV=1       Skip .env creation
+
+set -euo pipefail
+
+# --- Colors & logging (matches smoke-test/lib/common.sh) ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+die() { log_error "$@"; exit 1; }
+
+# --- Resolve paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find the main working tree (first entry from `git worktree list`)
+MAIN_REPO="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
+if [ -z "$MAIN_REPO" ] || [ ! -d "$MAIN_REPO" ]; then
+    MAIN_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+TARGET="${1:-$MAIN_REPO}"
+if [[ "$TARGET" != /* ]]; then
+    TARGET="$(cd "$TARGET" 2>/dev/null && pwd)"
+fi
+
+if [ ! -d "$TARGET" ]; then
+    die "Directory not found: $TARGET"
+fi
+
+log_info "Bootstrapping: $TARGET"
+
+# Track results for summary
+RESULTS=()
+record() { RESULTS+=("$1"); }
+
+# --- .env ---
+if [ "${SKIP_ENV:-}" != "1" ]; then
+    if [ -f "$TARGET/.env" ]; then
+        log_ok ".env already exists"
+        record "env:exists"
+    elif [ -f "$MAIN_REPO/.env" ] && [ "$TARGET" != "$MAIN_REPO" ]; then
+        log_info "Copying .env from main repo"
+        cp "$MAIN_REPO/.env" "$TARGET/.env"
+        record "env:copied"
+    elif [ -f "$TARGET/.env.example" ]; then
+        log_info "Creating .env from .env.example"
+        cp "$TARGET/.env.example" "$TARGET/.env"
+        record "env:from-example"
+    else
+        log_warn "No .env or .env.example found"
+        record "env:missing"
+    fi
+else
+    record "env:skipped"
+fi
+
+# --- Web client ---
+if [ "${SKIP_WEB:-}" != "1" ]; then
+    if [ -f "$TARGET/client/package.json" ]; then
+        log_info "Installing web client dependencies..."
+        if (cd "$TARGET/client" && npm install --no-audit --no-fund 2>&1); then
+            log_ok "Web client: npm install complete"
+            record "web:ok"
+        else
+            log_error "Web client: npm install failed"
+            record "web:failed"
+        fi
+    else
+        log_warn "Web client: package.json not found"
+        record "web:not-found"
+    fi
+else
+    record "web:skipped"
+fi
+
+# --- Go server ---
+if [ "${SKIP_SERVER:-}" != "1" ]; then
+    if [ -f "$TARGET/server/go.mod" ]; then
+        if command -v go >/dev/null 2>&1; then
+            log_info "Downloading Go server dependencies..."
+            if (cd "$TARGET/server" && go mod download 2>&1); then
+                log_ok "Go server: dependencies downloaded"
+                record "server:ok"
+            else
+                log_error "Go server: go mod download failed"
+                record "server:failed"
+            fi
+        else
+            log_warn "Go server: 'go' not found in PATH"
+            record "server:no-go"
+        fi
+    else
+        log_warn "Go server: go.mod not found"
+        record "server:not-found"
+    fi
+else
+    record "server:skipped"
+fi
+
+# --- Android client ---
+if [ "${SKIP_ANDROID:-}" != "1" ]; then
+    if [ -f "$TARGET/client-android/gradlew" ]; then
+        # Ensure local.properties exists (gitignored, needed for SDK path + Firebase config)
+        if [ ! -f "$TARGET/client-android/local.properties" ]; then
+            # Try copying from the main repo first (has SDK path + Firebase config)
+            MAIN_LP="$MAIN_REPO/client-android/local.properties"
+            if [ "$TARGET" != "$MAIN_REPO" ] && [ -f "$MAIN_LP" ]; then
+                log_info "Copying local.properties from main repo"
+                cp "$MAIN_LP" "$TARGET/client-android/local.properties"
+            else
+                # Generate a minimal one with the standard macOS SDK path
+                SDK_PATH="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+                if [ -d "$SDK_PATH" ]; then
+                    log_info "Creating local.properties (sdk.dir=$SDK_PATH)"
+                    echo "sdk.dir=$SDK_PATH" > "$TARGET/client-android/local.properties"
+                fi
+            fi
+        fi
+
+        # Check for Android SDK
+        HAS_SDK=false
+        if [ -n "${ANDROID_HOME:-}" ] && [ -d "$ANDROID_HOME" ]; then
+            HAS_SDK=true
+        elif [ -f "$TARGET/client-android/local.properties" ] && grep -q 'sdk.dir' "$TARGET/client-android/local.properties" 2>/dev/null; then
+            HAS_SDK=true
+        fi
+
+        if [ "$HAS_SDK" = false ]; then
+            log_warn "Android client: no SDK found (set ANDROID_HOME or create local.properties)"
+            record "android:no-sdk"
+        elif ! command -v java >/dev/null 2>&1; then
+            log_warn "Android client: 'java' not found in PATH"
+            record "android:no-java"
+        else
+            log_info "Syncing Android Gradle dependencies..."
+            if (cd "$TARGET/client-android" && ./gradlew --no-daemon dependencies >/dev/null 2>&1); then
+                log_ok "Android client: Gradle sync complete"
+                record "android:ok"
+            else
+                log_warn "Android client: Gradle sync failed"
+                record "android:failed"
+            fi
+        fi
+    else
+        log_warn "Android client: gradlew not found"
+        record "android:not-found"
+    fi
+else
+    record "android:skipped"
+fi
+
+# --- iOS client ---
+if [ "${SKIP_IOS:-}" != "1" ]; then
+    if [ -f "$TARGET/client-ios/project.yml" ]; then
+        # Ensure GoogleService-Info.plist exists (gitignored, needed for Firebase/FCM)
+        PLIST_PATH="$TARGET/client-ios/Resources/GoogleService-Info.plist"
+        if [ ! -f "$PLIST_PATH" ]; then
+            MAIN_PLIST="$MAIN_REPO/client-ios/Resources/GoogleService-Info.plist"
+            if [ "$TARGET" != "$MAIN_REPO" ] && [ -f "$MAIN_PLIST" ]; then
+                mkdir -p "$(dirname "$PLIST_PATH")"
+                log_info "Copying GoogleService-Info.plist from main repo"
+                cp "$MAIN_PLIST" "$PLIST_PATH"
+            else
+                log_warn "GoogleService-Info.plist not found (iOS push notifications won't work)"
+            fi
+        fi
+
+        if command -v xcodegen >/dev/null 2>&1; then
+            log_info "Generating iOS Xcode project..."
+            if (cd "$TARGET/client-ios" && xcodegen generate 2>&1); then
+                log_ok "iOS client: Xcode project generated"
+                record "ios:ok"
+            else
+                log_error "iOS client: xcodegen failed"
+                record "ios:failed"
+            fi
+        else
+            log_warn "iOS client: 'xcodegen' not found (brew install xcodegen)"
+            record "ios:no-xcodegen"
+        fi
+    else
+        log_warn "iOS client: project.yml not found"
+        record "ios:not-found"
+    fi
+else
+    record "ios:skipped"
+fi
+
+# --- Summary ---
+echo ""
+log_info "=== Bootstrap Summary ==="
+
+FAILURES=0
+for result in "${RESULTS[@]}"; do
+    component="${result%%:*}"
+    status="${result#*:}"
+    case "$status" in
+        ok|exists|copied|from-example)
+            log_ok "  $component: $status" ;;
+        skipped)
+            echo -e "  ${YELLOW}SKIP${NC}  $component" ;;
+        no-*)
+            log_warn "  $component: $status" ;;
+        *)
+            log_error "  $component: $status"
+            FAILURES=$((FAILURES + 1)) ;;
+    esac
+done
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+    log_warn "Bootstrap completed with $FAILURES issue(s). Run 'tools/worktree-validate.sh' to diagnose."
+    exit 1
+else
+    log_ok "Bootstrap complete"
+fi

--- a/tools/worktree-bootstrap.sh
+++ b/tools/worktree-bootstrap.sh
@@ -41,12 +41,13 @@ if [ -z "$MAIN_REPO" ] || [ ! -d "$MAIN_REPO" ]; then
 fi
 
 TARGET="${1:-$MAIN_REPO}"
+ORIGINAL_TARGET="$TARGET"
 if [[ "$TARGET" != /* ]]; then
-    TARGET="$(cd "$TARGET" 2>/dev/null && pwd)"
+    TARGET="$(cd "$TARGET" 2>/dev/null && pwd || true)"
 fi
 
-if [ ! -d "$TARGET" ]; then
-    die "Directory not found: $TARGET"
+if [ -z "$TARGET" ] || [ ! -d "$TARGET" ]; then
+    die "Directory not found: $ORIGINAL_TARGET"
 fi
 
 log_info "Bootstrapping: $TARGET"
@@ -79,13 +80,18 @@ fi
 # --- Web client ---
 if [ "${SKIP_WEB:-}" != "1" ]; then
     if [ -f "$TARGET/client/package.json" ]; then
-        log_info "Installing web client dependencies..."
-        if (cd "$TARGET/client" && npm install --no-audit --no-fund 2>&1); then
-            log_ok "Web client: npm install complete"
-            record "web:ok"
+        if command -v npm >/dev/null 2>&1; then
+            log_info "Installing web client dependencies..."
+            if (cd "$TARGET/client" && npm ci --no-audit --no-fund 2>&1); then
+                log_ok "Web client: npm ci complete"
+                record "web:ok"
+            else
+                log_error "Web client: npm ci failed"
+                record "web:failed"
+            fi
         else
-            log_error "Web client: npm install failed"
-            record "web:failed"
+            log_warn "Web client: 'npm' not found in PATH"
+            record "web:no-npm"
         fi
     else
         log_warn "Web client: package.json not found"

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# Validate that a worktree (or the main repo) has all components functional.
+#
+# Usage:
+#   tools/worktree-validate.sh [path]     # defaults to repo root
+#   tools/worktree-validate.sh ../my-wt
+#
+# Options (env vars):
+#   SKIP_WEB=1       Skip web client checks
+#   SKIP_SERVER=1    Skip Go server checks
+#   SKIP_ANDROID=1   Skip Android client checks
+#   SKIP_IOS=1       Skip iOS client checks
+#   SKIP_BUILD=1     Skip compilation checks (only verify deps/structure)
+#   SKIP_TEST=1      Skip test execution
+#   VERBOSE=1        Show command output
+
+set -euo pipefail
+
+# --- Colors & logging ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
+log_skip()  { echo -e "${YELLOW}[SKIP]${NC}  $*"; }
+
+VERBOSE="${VERBOSE:-0}"
+
+# Redirect output based on verbosity
+run_quiet() {
+    if [ "$VERBOSE" = "1" ]; then
+        "$@"
+    else
+        "$@" >/dev/null 2>&1
+    fi
+}
+
+# --- Resolve target directory ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TARGET="${1:-$DEFAULT_ROOT}"
+if [[ "$TARGET" != /* ]]; then
+    TARGET="$(cd "$TARGET" 2>/dev/null && pwd)"
+fi
+
+if [ ! -d "$TARGET" ]; then
+    echo "Directory not found: $TARGET"
+    exit 1
+fi
+
+echo -e "${BOLD}Validating: $TARGET${NC}"
+echo ""
+
+# --- Counters ---
+PASS=0
+FAIL=0
+WARN=0
+SKIP=0
+
+check_pass() { log_ok "$1"; PASS=$((PASS + 1)); }
+check_fail() { log_fail "$1"; FAIL=$((FAIL + 1)); }
+check_warn() { log_warn "$1"; WARN=$((WARN + 1)); }
+check_skip() { log_skip "$1"; SKIP=$((SKIP + 1)); }
+
+# ============================================================
+# Section: Repository structure
+# ============================================================
+echo -e "${BOLD}--- Repository Structure ---${NC}"
+
+# Git
+if git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    BRANCH=$(git -C "$TARGET" branch --show-current 2>/dev/null || echo "(detached)")
+    check_pass "Git repository (branch: $BRANCH)"
+else
+    check_fail "Not a git repository"
+fi
+
+# .env
+if [ -f "$TARGET/.env" ]; then
+    # Check for placeholder secrets
+    if grep -q 'dev-secret\|dev-room-id-secret\|change-me' "$TARGET/.env" 2>/dev/null; then
+        check_warn ".env exists but contains placeholder secrets"
+    else
+        check_pass ".env configured"
+    fi
+elif [ -f "$TARGET/.env.example" ]; then
+    check_warn ".env missing (run: cp .env.example .env)"
+else
+    check_fail ".env and .env.example both missing"
+fi
+
+# Key directories
+for dir in client server client-android client-ios; do
+    if [ -d "$TARGET/$dir" ]; then
+        check_pass "Directory: $dir/"
+    else
+        check_fail "Directory missing: $dir/"
+    fi
+done
+
+# Cross-platform resilience constants
+if [ -f "$TARGET/scripts/check-resilience-constants.mjs" ]; then
+    if command -v node >/dev/null 2>&1; then
+        if run_quiet node "$TARGET/scripts/check-resilience-constants.mjs"; then
+            check_pass "Resilience constants parity"
+        else
+            check_fail "Resilience constants out of sync"
+        fi
+    else
+        check_warn "Resilience constants: 'node' not found, cannot verify"
+    fi
+fi
+
+# ============================================================
+# Section: Web client
+# ============================================================
+echo ""
+echo -e "${BOLD}--- Web Client ---${NC}"
+
+if [ "${SKIP_WEB:-}" = "1" ]; then
+    check_skip "Web client (SKIP_WEB=1)"
+else
+    CLIENT="$TARGET/client"
+
+    # node_modules
+    if [ -d "$CLIENT/node_modules" ]; then
+        check_pass "node_modules installed"
+    else
+        check_fail "node_modules missing (run: cd client && npm install)"
+    fi
+
+    # Workspace packages
+    for pkg in core react-ui; do
+        if [ -d "$CLIENT/packages/$pkg" ]; then
+            check_pass "Package: @serenada/$pkg"
+        else
+            check_fail "Package missing: packages/$pkg"
+        fi
+    done
+
+    # TypeScript build
+    if [ "${SKIP_BUILD:-}" != "1" ]; then
+        if [ -d "$CLIENT/node_modules" ]; then
+            log_info "Building web client..."
+            if (cd "$CLIENT" && run_quiet npm run build); then
+                check_pass "TypeScript + Vite build"
+            else
+                check_fail "Build failed (npm run build)"
+            fi
+        else
+            check_skip "Build: node_modules missing"
+        fi
+    else
+        check_skip "Web build (SKIP_BUILD=1)"
+    fi
+
+    # Lint
+    if [ "${SKIP_BUILD:-}" != "1" ]; then
+        if [ -d "$CLIENT/node_modules" ]; then
+            if (cd "$CLIENT" && run_quiet npm run lint); then
+                check_pass "ESLint"
+            else
+                check_warn "ESLint errors found (pre-existing lint issues)"
+            fi
+        fi
+    fi
+
+    # Tests
+    if [ "${SKIP_TEST:-}" != "1" ]; then
+        if [ -d "$CLIENT/node_modules" ]; then
+            log_info "Running web tests..."
+            if (cd "$CLIENT" && run_quiet npm test -- --run); then
+                check_pass "Vitest"
+            else
+                check_fail "Tests failed (npm test)"
+            fi
+        else
+            check_skip "Tests: node_modules missing"
+        fi
+    else
+        check_skip "Web tests (SKIP_TEST=1)"
+    fi
+fi
+
+# ============================================================
+# Section: Go server
+# ============================================================
+echo ""
+echo -e "${BOLD}--- Go Server ---${NC}"
+
+if [ "${SKIP_SERVER:-}" = "1" ]; then
+    check_skip "Go server (SKIP_SERVER=1)"
+else
+    SERVER="$TARGET/server"
+
+    # Go toolchain
+    if command -v go >/dev/null 2>&1; then
+        GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | head -1)
+        check_pass "Go installed ($GO_VERSION)"
+
+        # Check minimum version (1.24)
+        GO_MINOR=$(echo "$GO_VERSION" | grep -oE '[0-9]+\.[0-9]+' | cut -d. -f2)
+        if [ "${GO_MINOR:-0}" -lt 24 ]; then
+            check_warn "Go 1.24+ required (found $GO_VERSION)"
+        fi
+    else
+        check_fail "Go not installed"
+    fi
+
+    # go.mod/go.sum
+    if [ -f "$SERVER/go.mod" ] && [ -f "$SERVER/go.sum" ]; then
+        check_pass "go.mod + go.sum present"
+    else
+        check_fail "go.mod or go.sum missing"
+    fi
+
+    # Build
+    if [ "${SKIP_BUILD:-}" != "1" ] && command -v go >/dev/null 2>&1; then
+        log_info "Building Go server..."
+        if (cd "$SERVER" && run_quiet go build -o /dev/null .); then
+            check_pass "Go build"
+        else
+            check_fail "Go build failed"
+        fi
+    elif [ "${SKIP_BUILD:-}" = "1" ]; then
+        check_skip "Go build (SKIP_BUILD=1)"
+    fi
+
+    # Tests
+    if [ "${SKIP_TEST:-}" != "1" ] && command -v go >/dev/null 2>&1; then
+        log_info "Running Go tests..."
+        if (cd "$SERVER" && run_quiet go test ./...); then
+            check_pass "Go tests"
+        else
+            check_fail "Go tests failed"
+        fi
+    elif [ "${SKIP_TEST:-}" = "1" ]; then
+        check_skip "Go tests (SKIP_TEST=1)"
+    fi
+fi
+
+# ============================================================
+# Section: Android client
+# ============================================================
+echo ""
+echo -e "${BOLD}--- Android Client ---${NC}"
+
+if [ "${SKIP_ANDROID:-}" = "1" ]; then
+    check_skip "Android client (SKIP_ANDROID=1)"
+else
+    ANDROID="$TARGET/client-android"
+
+    # Gradle wrapper
+    if [ -x "$ANDROID/gradlew" ]; then
+        check_pass "Gradle wrapper (executable)"
+    elif [ -f "$ANDROID/gradlew" ]; then
+        check_warn "Gradle wrapper exists but not executable (run: chmod +x gradlew)"
+    else
+        check_fail "Gradle wrapper missing"
+    fi
+
+    # WebRTC AAR
+    AAR=$(find "$ANDROID" -name "*.aar" -path "*/libs/*" 2>/dev/null | head -1)
+    if [ -n "$AAR" ]; then
+        CHECKSUM_FILE="${AAR}.sha256"
+        if [ -f "$CHECKSUM_FILE" ]; then
+            check_pass "WebRTC AAR + checksum file"
+        else
+            check_warn "WebRTC AAR found but no .sha256 checksum file"
+        fi
+    else
+        check_warn "WebRTC AAR not found in libs/"
+    fi
+
+    # Java/JDK
+    if command -v java >/dev/null 2>&1; then
+        JAVA_VERSION=$(java -version 2>&1 | head -1)
+        check_pass "Java installed ($JAVA_VERSION)"
+    else
+        check_warn "Java not installed (needed for Gradle)"
+    fi
+
+    # Android SDK
+    HAS_ANDROID_SDK=false
+    if [ -n "${ANDROID_HOME:-}" ] && [ -d "$ANDROID_HOME" ]; then
+        check_pass "Android SDK (\$ANDROID_HOME: $ANDROID_HOME)"
+        HAS_ANDROID_SDK=true
+    elif [ -f "$ANDROID/local.properties" ] && grep -q 'sdk.dir' "$ANDROID/local.properties" 2>/dev/null; then
+        check_pass "Android SDK (via local.properties)"
+        HAS_ANDROID_SDK=true
+    else
+        check_warn "Android SDK not found (set ANDROID_HOME or create local.properties)"
+    fi
+
+    # Build
+    if [ "${SKIP_BUILD:-}" != "1" ] && [ -x "$ANDROID/gradlew" ] && command -v java >/dev/null 2>&1; then
+        if [ "$HAS_ANDROID_SDK" = true ]; then
+            log_info "Checking Android build (assembleDebug)..."
+            if (cd "$ANDROID" && run_quiet ./gradlew --no-daemon assembleDebug); then
+                check_pass "Android assembleDebug"
+            else
+                check_fail "Android assembleDebug failed"
+            fi
+        else
+            check_skip "Android build (no SDK)"
+        fi
+    elif [ "${SKIP_BUILD:-}" = "1" ]; then
+        check_skip "Android build (SKIP_BUILD=1)"
+    fi
+fi
+
+# ============================================================
+# Section: iOS client
+# ============================================================
+echo ""
+echo -e "${BOLD}--- iOS Client ---${NC}"
+
+if [ "${SKIP_IOS:-}" = "1" ]; then
+    check_skip "iOS client (SKIP_IOS=1)"
+else
+    IOS="$TARGET/client-ios"
+
+    # XcodeGen
+    if command -v xcodegen >/dev/null 2>&1; then
+        check_pass "xcodegen installed"
+    else
+        check_warn "xcodegen not installed (brew install xcodegen)"
+    fi
+
+    # project.yml
+    if [ -f "$IOS/project.yml" ]; then
+        check_pass "project.yml present"
+    else
+        check_fail "project.yml missing"
+    fi
+
+    # Xcode project (generated)
+    if [ -d "$IOS/SerenadaiOS.xcodeproj" ]; then
+        check_pass "Xcode project generated"
+    else
+        check_warn "Xcode project not generated (run: cd client-ios && xcodegen generate)"
+    fi
+
+    # WebRTC XCFramework
+    if [ -d "$IOS/Vendor/WebRTC/WebRTC.xcframework" ]; then
+        # Checksum verification
+        if [ -f "$IOS/scripts/verify_webrtc_checksum.sh" ]; then
+            if run_quiet sh "$IOS/scripts/verify_webrtc_checksum.sh"; then
+                check_pass "WebRTC.xcframework checksum verified"
+            else
+                check_fail "WebRTC.xcframework checksum mismatch"
+            fi
+        else
+            check_pass "WebRTC.xcframework present (no checksum script)"
+        fi
+    else
+        check_warn "WebRTC.xcframework not found"
+    fi
+
+    # xcodebuild
+    if command -v xcodebuild >/dev/null 2>&1; then
+        check_pass "Xcode command-line tools installed"
+    else
+        check_warn "xcodebuild not found"
+    fi
+
+    # Resolve a simulator destination (pick first available iPhone 16 by device ID)
+    IOS_SIM_ID=""
+    if command -v xcrun >/dev/null 2>&1; then
+        IOS_SIM_ID=$(xcrun simctl list devices available -j 2>/dev/null \
+            | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for runtime, devices in data.get('devices', {}).items():
+    if 'iOS' not in runtime:
+        continue
+    for d in devices:
+        if d.get('name') == 'iPhone 16' and d.get('isAvailable'):
+            print(d['udid'])
+            sys.exit(0)
+" 2>/dev/null || true)
+    fi
+
+    if [ -n "$IOS_SIM_ID" ]; then
+        IOS_DEST="platform=iOS Simulator,id=$IOS_SIM_ID"
+    else
+        IOS_DEST="platform=iOS Simulator,name=iPhone 16"
+    fi
+
+    # Build (only if project exists)
+    if [ "${SKIP_BUILD:-}" != "1" ] && [ -d "$IOS/SerenadaiOS.xcodeproj" ] && command -v xcodebuild >/dev/null 2>&1; then
+        log_info "Building iOS (simulator)..."
+        if (cd "$IOS" && run_quiet xcodebuild build \
+            -project SerenadaiOS.xcodeproj \
+            -scheme SerenadaiOS \
+            -destination "$IOS_DEST" \
+            -quiet \
+            CODE_SIGNING_ALLOWED=NO); then
+            check_pass "iOS simulator build"
+        else
+            check_fail "iOS simulator build failed"
+        fi
+    elif [ "${SKIP_BUILD:-}" = "1" ]; then
+        check_skip "iOS build (SKIP_BUILD=1)"
+    fi
+
+    # Tests
+    if [ "${SKIP_TEST:-}" != "1" ] && [ -d "$IOS/SerenadaiOS.xcodeproj" ] && command -v xcodebuild >/dev/null 2>&1; then
+        log_info "Running iOS tests..."
+        if (cd "$IOS" && run_quiet xcodebuild test \
+            -project SerenadaiOS.xcodeproj \
+            -scheme SerenadaiOS \
+            -destination "$IOS_DEST" \
+            -quiet); then
+            check_pass "iOS tests"
+        else
+            check_fail "iOS tests failed"
+        fi
+    elif [ "${SKIP_TEST:-}" = "1" ]; then
+        check_skip "iOS tests (SKIP_TEST=1)"
+    fi
+fi
+
+# ============================================================
+# Section: Docker
+# ============================================================
+echo ""
+echo -e "${BOLD}--- Docker ---${NC}"
+
+if [ -f "$TARGET/docker-compose.yml" ]; then
+    check_pass "docker-compose.yml present"
+else
+    check_warn "docker-compose.yml missing"
+fi
+
+if command -v docker >/dev/null 2>&1; then
+    if docker info >/dev/null 2>&1; then
+        check_pass "Docker daemon running"
+    else
+        check_warn "Docker installed but daemon not running"
+    fi
+else
+    check_warn "Docker not installed"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+TOTAL=$((PASS + FAIL + WARN + SKIP))
+echo -e "${BOLD}=== Validation Summary ===${NC}"
+echo -e "  ${GREEN}PASS${NC}: $PASS  ${RED}FAIL${NC}: $FAIL  ${YELLOW}WARN${NC}: $WARN  SKIP: $SKIP  (total: $TOTAL)"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    log_fail "Validation completed with $FAIL failure(s)"
+    exit 1
+elif [ "$WARN" -gt 0 ]; then
+    log_warn "Validation passed with $WARN warning(s)"
+    exit 0
+else
+    log_ok "All checks passed"
+    exit 0
+fi

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -46,12 +46,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 TARGET="${1:-$DEFAULT_ROOT}"
+ORIGINAL_TARGET="$TARGET"
 if [[ "$TARGET" != /* ]]; then
-    TARGET="$(cd "$TARGET" 2>/dev/null && pwd)"
+    TARGET="$(cd "$TARGET" 2>/dev/null && pwd || true)"
 fi
 
-if [ ! -d "$TARGET" ]; then
-    echo "Directory not found: $TARGET"
+if [ -z "$TARGET" ] || [ ! -d "$TARGET" ]; then
+    echo "Directory not found: $ORIGINAL_TARGET"
     exit 1
 fi
 
@@ -85,7 +86,7 @@ fi
 # .env
 if [ -f "$TARGET/.env" ]; then
     # Check for placeholder secrets
-    if grep -q 'dev-secret\|dev-room-id-secret\|change-me' "$TARGET/.env" 2>/dev/null; then
+    if grep -qE 'dev-secret|dev-room-id-secret|change-me' "$TARGET/.env" 2>/dev/null; then
         check_warn ".env exists but contains placeholder secrets"
     else
         check_pass ".env configured"
@@ -145,9 +146,17 @@ else
         fi
     done
 
+    # Check npm is available for build/lint/test steps
+    HAS_NPM=false
+    if command -v npm >/dev/null 2>&1; then
+        HAS_NPM=true
+    fi
+
     # TypeScript build
     if [ "${SKIP_BUILD:-}" != "1" ]; then
-        if [ -d "$CLIENT/node_modules" ]; then
+        if [ "$HAS_NPM" != true ]; then
+            check_skip "Web build ('npm' not found)"
+        elif [ -d "$CLIENT/node_modules" ]; then
             log_info "Building web client..."
             if (cd "$CLIENT" && run_quiet npm run build); then
                 check_pass "TypeScript + Vite build"
@@ -163,18 +172,26 @@ else
 
     # Lint
     if [ "${SKIP_BUILD:-}" != "1" ]; then
-        if [ -d "$CLIENT/node_modules" ]; then
+        if [ "$HAS_NPM" != true ]; then
+            check_skip "Web lint ('npm' not found)"
+        elif [ -d "$CLIENT/node_modules" ]; then
             if (cd "$CLIENT" && run_quiet npm run lint); then
                 check_pass "ESLint"
             else
-                check_warn "ESLint errors found (pre-existing lint issues)"
+                check_warn "ESLint errors found"
             fi
+        else
+            check_skip "Lint: node_modules missing"
         fi
+    else
+        check_skip "Web lint (SKIP_BUILD=1)"
     fi
 
     # Tests
     if [ "${SKIP_TEST:-}" != "1" ]; then
-        if [ -d "$CLIENT/node_modules" ]; then
+        if [ "$HAS_NPM" != true ]; then
+            check_skip "Web tests ('npm' not found)"
+        elif [ -d "$CLIENT/node_modules" ]; then
             log_info "Running web tests..."
             if (cd "$CLIENT" && run_quiet npm test -- --run); then
                 check_pass "Vitest"
@@ -224,11 +241,13 @@ else
     # Build
     if [ "${SKIP_BUILD:-}" != "1" ] && command -v go >/dev/null 2>&1; then
         log_info "Building Go server..."
-        if (cd "$SERVER" && run_quiet go build -o /dev/null .); then
+        GO_BUILD_OUT=$(mktemp "${TMPDIR:-/tmp}/serenada-server.XXXXXX")
+        if (cd "$SERVER" && run_quiet go build -o "$GO_BUILD_OUT" .); then
             check_pass "Go build"
         else
             check_fail "Go build failed"
         fi
+        rm -f "$GO_BUILD_OUT"
     elif [ "${SKIP_BUILD:-}" = "1" ]; then
         check_skip "Go build (SKIP_BUILD=1)"
     fi
@@ -314,6 +333,22 @@ else
     elif [ "${SKIP_BUILD:-}" = "1" ]; then
         check_skip "Android build (SKIP_BUILD=1)"
     fi
+
+    # Tests
+    if [ "${SKIP_TEST:-}" != "1" ] && [ -x "$ANDROID/gradlew" ] && command -v java >/dev/null 2>&1; then
+        if [ "$HAS_ANDROID_SDK" = true ]; then
+            log_info "Running Android unit tests..."
+            if (cd "$ANDROID" && run_quiet ./gradlew --no-daemon :app:testDebugUnitTest); then
+                check_pass "Android unit tests"
+            else
+                check_fail "Android unit tests failed"
+            fi
+        else
+            check_skip "Android tests (no SDK)"
+        fi
+    elif [ "${SKIP_TEST:-}" = "1" ]; then
+        check_skip "Android tests (SKIP_TEST=1)"
+    fi
 fi
 
 # ============================================================
@@ -373,7 +408,7 @@ else
 
     # Resolve a simulator destination (pick first available iPhone 16 by device ID)
     IOS_SIM_ID=""
-    if command -v xcrun >/dev/null 2>&1; then
+    if command -v xcrun >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
         IOS_SIM_ID=$(xcrun simctl list devices available -j 2>/dev/null \
             | python3 -c "
 import sys, json
@@ -411,17 +446,18 @@ for runtime, devices in data.get('devices', {}).items():
         check_skip "iOS build (SKIP_BUILD=1)"
     fi
 
-    # Tests
+    # Tests (unit tests only — UI tests require a live server and have known flaky failures)
     if [ "${SKIP_TEST:-}" != "1" ] && [ -d "$IOS/SerenadaiOS.xcodeproj" ] && command -v xcodebuild >/dev/null 2>&1; then
-        log_info "Running iOS tests..."
+        log_info "Running iOS unit tests..."
         if (cd "$IOS" && run_quiet xcodebuild test \
             -project SerenadaiOS.xcodeproj \
             -scheme SerenadaiOS \
             -destination "$IOS_DEST" \
+            -only-testing:SerenadaiOSTests \
             -quiet); then
-            check_pass "iOS tests"
+            check_pass "iOS unit tests"
         else
-            check_fail "iOS tests failed"
+            check_fail "iOS unit tests failed"
         fi
     elif [ "${SKIP_TEST:-}" = "1" ]; then
         check_skip "iOS tests (SKIP_TEST=1)"


### PR DESCRIPTION
Adds two scripts to make git worktrees build-ready across all platforms:

- **`tools/worktree-bootstrap.sh`** — installs deps (npm, go mod, gradlew, xcodegen) and copies gitignored config files (`.env`, `local.properties`, `GoogleService-Info.plist`) from the main working tree.
- **`tools/worktree-validate.sh`** — runs 30+ checks covering repo structure, toolchain versions, builds, lint, tests, and Docker status across web, Go, Android, and iOS.

Both scripts gracefully skip platforms when toolchains are missing (no Android SDK, no xcodegen, etc.) and support `SKIP_*` env vars for selective runs. CLAUDE.md and AGENTS.md updated with usage instructions for agents.