### PR TITLE
Add versioning policy, changelog, and version parity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to the Serenada SDK are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.1.0] — 2026-03-22
+
+### Added
+- Headless SDK + optional UI architecture across Web, Android, and iOS
+- `SerenadaCore` entry point with `join(url)`, `join(roomId)`, and `createRoom()` on all platforms
+- `SerenadaSession` state machine with observable `CallState` (phase, participants, connection status)
+- Dual-transport signaling (WebSocket primary, SSE fallback) with automatic failover
+- WebRTC peer connection management with ICE restart, TURN refresh, and exponential backoff
+- Pre-built call UI components (`SerenadaCallFlow`) on all platforms
+- Cross-platform resilience constants with automated parity verification
+- Typed `CallError` enum with 7 canonical error codes (all platforms)
+- Typed `PeerConnectionState` enum replacing raw strings (all platforms)
+- Camera mode system (selfie, world, composite, screen share)
+- Screen sharing support on all platforms
+- Push notification infrastructure (host app integration)
+- Room occupancy monitoring via `RoomWatcher`
+- Diagnostics and connectivity probes via `SerenadaDiagnostics`
+- Sample apps for Web, Android, and iOS

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,35 @@
+# Versioning Policy
+
+## Semantic Versioning
+Serenada SDKs follow [Semantic Versioning 2.0.0](https://semver.org/).
+
+### Pre-1.0 (current)
+- **Minor** bumps (0.x.0) may include breaking changes
+- **Patch** bumps (0.0.x) are backward-compatible bug fixes and improvements
+
+### Post-1.0
+- **Major** bumps for breaking changes
+- **Minor** bumps for new features (backward-compatible)
+- **Patch** bumps for bug fixes
+
+## Version Synchronization
+All SDK packages share the same version number and are released together:
+- `@serenada/core` (npm)
+- `@serenada/react-ui` (npm)
+- `serenada-core` (Maven/AAR)
+- `serenada-call-ui` (Maven/AAR)
+- `SerenadaCore` (SPM)
+
+## What Constitutes a Breaking Change
+- Removal or rename of public types, methods, or properties
+- Changes to state machine transitions (CallPhase flow)
+- Signaling protocol version bump
+- Changes to constructor signatures or required configuration
+- Behavioral changes that existing consumers depend on
+
+## Verifying Version Parity
+```bash
+node scripts/check-version-parity.mjs
+```
+
+This script checks that all SDK packages declare the same version.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -5,7 +5,7 @@ Serenada SDKs follow [Semantic Versioning 2.0.0](https://semver.org/).
 
 ### Pre-1.0 (current)
 - **Minor** bumps (0.x.0) may include breaking changes
-- **Patch** bumps (0.0.x) are backward-compatible bug fixes and improvements
+- **Patch** bumps (0.1.x) are backward-compatible bug fixes and improvements
 
 ### Post-1.0
 - **Major** bumps for breaking changes

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -47,6 +47,11 @@ const sources = [
         file: 'client-ios/SerenadaCore/Sources/SerenadaCore.swift',
         regex: /static\s+let\s+version\s*=\s*"([^"]+)"/,
     },
+    {
+        name: '@serenada/react-ui pinned @serenada/core dep',
+        file: 'client/packages/react-ui/package.json',
+        regex: /"@serenada\/core"\s*:\s*"\^?([^"]+)"/,
+    },
 ];
 
 // ── Parse and compare ───────────────────────────────────────────────
@@ -79,7 +84,7 @@ if (uniqueVersions.length > 1) {
         console.error(`  ${v.name}: ${v.version}`);
     }
     allMatch = false;
-} else if (uniqueVersions.length === 1) {
+} else if (uniqueVersions.length === 1 && allMatch && versions.length === sources.length) {
     console.log(`OK: All ${versions.length} version sources match at ${uniqueVersions[0]}.`);
 }
 

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that all Serenada SDK packages declare the same version.
+ *
+ * Usage:  node scripts/check-version-parity.mjs
+ * Exit 0 on match, 1 on mismatch.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+// ── Version sources ─────────────────────────────────────────────────
+
+const sources = [
+    {
+        name: '@serenada/core (TS constant)',
+        file: 'client/packages/core/src/index.ts',
+        regex: /SERENADA_CORE_VERSION\s*=\s*'([^']+)'/,
+    },
+    {
+        name: '@serenada/core (package.json)',
+        file: 'client/packages/core/package.json',
+        regex: /"version"\s*:\s*"([^"]+)"/,
+    },
+    {
+        name: '@serenada/react-ui (package.json)',
+        file: 'client/packages/react-ui/package.json',
+        regex: /"version"\s*:\s*"([^"]+)"/,
+    },
+    {
+        name: 'serenada-core (build.gradle.kts)',
+        file: 'client-android/serenada-core/build.gradle.kts',
+        regex: /version\s*=\s*"([^"]+)"/,
+    },
+    {
+        name: 'serenada-call-ui (build.gradle.kts)',
+        file: 'client-android/serenada-call-ui/build.gradle.kts',
+        regex: /version\s*=\s*"([^"]+)"/,
+    },
+    {
+        name: 'SerenadaCore (Swift)',
+        file: 'client-ios/SerenadaCore/Sources/SerenadaCore.swift',
+        regex: /static\s+let\s+version\s*=\s*"([^"]+)"/,
+    },
+];
+
+// ── Parse and compare ───────────────────────────────────────────────
+
+let allMatch = true;
+const versions = [];
+
+for (const src of sources) {
+    const filePath = resolve(root, src.file);
+    try {
+        const content = readFileSync(filePath, 'utf-8');
+        const match = content.match(src.regex);
+        if (match) {
+            versions.push({ name: src.name, version: match[1] });
+        } else {
+            console.error(`ERROR: Could not find version in ${src.file}`);
+            allMatch = false;
+        }
+    } catch (e) {
+        console.error(`ERROR: Could not read ${src.file}: ${e.message}`);
+        allMatch = false;
+    }
+}
+
+const uniqueVersions = [...new Set(versions.map(v => v.version))];
+
+if (uniqueVersions.length > 1) {
+    console.error('VERSION MISMATCH:');
+    for (const v of versions) {
+        console.error(`  ${v.name}: ${v.version}`);
+    }
+    allMatch = false;
+} else if (uniqueVersions.length === 1) {
+    console.log(`OK: All ${versions.length} version sources match at ${uniqueVersions[0]}.`);
+}
+
+process.exit(allMatch ? 0 : 1);


### PR DESCRIPTION
## Summary
- Add `VERSIONING.md` documenting semver policy, version synchronization across all SDK packages, and breaking change criteria
- Add `CHANGELOG.md` with initial 0.1.0 release entry covering all SDK features shipped so far
- Add `scripts/check-version-parity.mjs` that verifies all 6 version declarations (Web TS constant, Web package.json x2, Android build.gradle.kts x2, iOS Swift) are in sync — exits 0 on match, 1 on mismatch

## Test plan
- [x] `node scripts/check-version-parity.mjs` exits 0 with `OK: All 6 version sources match at 0.1.0.`
- [ ] Intentionally change one version to confirm the script detects mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)