### PR TITLE
Document activeTransport parity across platforms

### DIFF
--- a/samples/web/README.md
+++ b/samples/web/README.md
@@ -69,11 +69,11 @@ On Android and iOS, the active transport is available on the diagnostics object:
 ```kotlin
 // Android — available on CallDiagnostics
 val diagnostics = session.diagnostics.value
-println(diagnostics.activeTransport) // "ws" or "sse"
+println(diagnostics.activeTransport ?: "none") // "ws", "sse", or "none"
 ```
 
 ```swift
 // iOS — available on CallDiagnostics
 let diagnostics = session.diagnostics
-print(diagnostics.activeTransport ?? "none") // "ws" or "sse"
+print(diagnostics.activeTransport ?? "none") // "ws", "sse", or "none" if nil
 ```

--- a/samples/web/README.md
+++ b/samples/web/README.md
@@ -53,3 +53,27 @@ const serenada = createSerenadaCore({ serverHost: 'serenada.app' })
 const room = await serenada.createRoom()
 <SerenadaCallFlow url={room.url} session={room.session} onDismiss={() => navigate('/')} />
 ```
+
+## Transport Visibility
+
+The SDK exposes which signaling transport (WebSocket or SSE) is currently active.
+
+```typescript
+// Web — available on CallState
+const state = session.state;
+console.log(state.activeTransport); // 'ws' | 'sse' | null
+```
+
+On Android and iOS, the active transport is available on the diagnostics object:
+
+```kotlin
+// Android — available on CallDiagnostics
+val diagnostics = session.diagnostics.value
+println(diagnostics.activeTransport) // "ws" or "sse"
+```
+
+```swift
+// iOS — available on CallDiagnostics
+let diagnostics = session.diagnostics
+print(diagnostics.activeTransport ?? "none") // "ws" or "sse"
+```


### PR DESCRIPTION
## Summary
- Add a "Transport Visibility" section to `samples/web/README.md` documenting how to access `activeTransport` on all three platforms (Web, Android, iOS)
- Documentation-only change; no code modified

## Test plan
- [x] Verified `activeTransport` field exists on Web (`CallState.activeTransport` in `types.ts`)
- [x] Verified `activeTransport` field exists on Android (`CallDiagnostics.activeTransport` in `CallDiagnostics.kt`)
- [x] Verified `activeTransport` field exists on iOS (`CallDiagnostics.activeTransport` in `CallDiagnostics.swift`)
- [x] Visual review of rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)