### PR TITLE
Update docs for post-SDK-remediation state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Room occupancy monitoring via `RoomWatcher`
 - Diagnostics and connectivity probes via `SerenadaDiagnostics`
 - Sample apps for Web, Android, and iOS
+
+### Improved (post-initial release)
+- Typed `CallError` sealed class on Android replacing `errorMessage: String?` — 7 canonical error codes matching iOS
+- Typed `CallErrorCode` union on web (`signalingTimeout`, `connectionFailed`, `roomFull`, `roomEnded`, `permissionDenied`, `serverError`, `webrtcUnavailable`, `unknown`)
+- Typed `PeerConnectionState` / `SerenadaPeerConnectionState` enums replacing raw `String` on all platforms
+- Typed signaling message payloads on web (7 parse functions replacing 15 unsafe casts)
+- Typed signaling payloads on Android and iOS (structured data classes/structs)
+- Extracted `SignalingMessageRouter` and `JoinFlowCoordinator` from SerenadaSession on iOS (1180→786 lines) and Android (1052→854 lines)
+- Moved `@serenada/core` from dependency to peer dependency in `@serenada/react-ui`
+- `SerenadaCore.isSupported()` static method for WebRTC capability detection
+- CSS isolation via `[data-serenada-callflow]` attribute selector with `!important` on root layout
+- Optional `className` prop on `SerenadaCallFlow` for host-app style overrides
+- Integration test harness with 7 signaling protocol scenarios
+- Version parity verification script (`scripts/check-version-parity.mjs`)
+- `VERSIONING.md` semantic versioning policy and `CHANGELOG.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh  # structure + deps only
 ./server/loadtest/run-local.sh    # Run signaling load sweep against local Docker stack
 ```
 
+### Integration Tests
+```bash
+bash tools/integration-test/run.sh    # Run signaling integration tests (requires Go 1.24+)
+```
+
 ### Cross-Platform Smoke Test
 ```bash
 bash tools/smoke-test/smoke-test.sh                          # Full run (both devices plugged in)
@@ -156,12 +161,13 @@ Dependencies: gorilla/websocket, webpush-go, godotenv, modernc.org/sqlite.
 Monorepo with headless SDK + React UI layer + thin app shell. Built with React 19 + TypeScript + Vite.
 
 **Headless SDK** (`packages/core/`):
-- `src/SerenadaCore.ts` — entry point (join/createRoom)
+- `src/SerenadaCore.ts` — entry point (join/createRoom), `isSupported()` static method for WebRTC capability detection
 - `src/SerenadaSession.ts` — session state machine, pub/sub state distribution
 - `src/signaling/SignalingEngine.ts` — dual-transport signaling (WS + SSE)
+- `src/signaling/payloads.ts` — typed payload interfaces and parse functions
 - `src/media/MediaEngine.ts` — WebRTC peer connections, local media, ICE management
 - `src/constants.ts` — shared resilience constants (cross-platform verified)
-- `src/types.ts` — public type definitions (CallState, CallPhase, etc.)
+- `src/types.ts` — public type definitions (CallState, CallPhase, CallErrorCode, PeerConnectionState, etc.)
 
 **React UI** (`packages/react-ui/`):
 - `src/SerenadaCallFlow.tsx` — pre-built call UI component (URL-first or session-first)
@@ -189,6 +195,9 @@ Kotlin + Jetpack Compose + Material3. Three-module Gradle project.
 - `call/PeerConnectionSlot.kt` — per-peer connection management
 - `call/CompositeCameraCapturer.kt` — 3-mode camera (selfie → world → composite)
 - `call/WebRtcResilienceConstants.kt` — shared resilience constants
+- `call/SignalingMessageRouter.kt` — inbound signaling message dispatch
+- `call/JoinFlowCoordinator.kt` — join flow timers and reconnect scheduling
+- `call/SignalingPayloads.kt` — typed payload data classes for signaling messages
 - `network/CoreApiClient.kt` — HTTP API client
 - `diagnostics/` — connectivity and TURN probes
 
@@ -214,7 +223,10 @@ SwiftUI + Swift 5.10, project generated via XcodeGen (`project.yml`). Two SPM pa
 - `Sources/Call/WebRtcEngine.swift` — WebRTC integration
 - `Sources/Call/PeerConnectionSlot.swift` — per-peer connection management
 - `Sources/Call/WebRtcResilienceConstants.swift` — shared resilience constants
+- `Sources/Call/SignalingMessageRouter.swift` — inbound signaling message dispatch
+- `Sources/Call/JoinFlowCoordinator.swift` — join flow timers and permission checks (absorbed JoinTimer)
 - `Sources/Signaling/` — SignalingClient + WS/SSE transports
+- `Sources/Signaling/SignalingPayloads.swift` — typed payload structs for signaling messages
 - `Sources/Networking/CoreAPIClient.swift` — HTTP API client
 - `Sources/RoomWatcher.swift` — room occupancy monitoring
 
@@ -246,6 +258,10 @@ JSON message envelope with fields: `v` (version), `type`, `rid` (room ID), `sid`
 WebRTC resilience timing constants (reconnect backoff, join timeout, ICE restart cooldown, etc.) are shared across all three clients. Verify parity with:
 ```bash
 node scripts/check-resilience-constants.mjs
+```
+Verify SDK version parity across all platforms with:
+```bash
+node scripts/check-version-parity.mjs
 ```
 Source files: `client/packages/core/src/constants.ts`, `client-android/serenada-core/.../call/WebRtcResilienceConstants.kt`, `client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift`.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ go run ./cmd/loadconduit --base-url http://localhost --report-json ./loadtest/re
 Detailed request/timing sequence:
 - [`server/loadtest/LOAD_SIMULATION_SEQUENCE.md`](server/loadtest/LOAD_SIMULATION_SEQUENCE.md)
 
+### Integration Tests
+
+```bash
+bash tools/integration-test/run.sh    # Run signaling integration tests (requires Go 1.24+)
+```
+
+### Version Parity
+
+Verify SDK versions match across all platforms:
+```bash
+node scripts/check-version-parity.mjs
+```
+
 ## Architecture
 
 ```

--- a/samples/ios/README.md
+++ b/samples/ios/README.md
@@ -33,7 +33,7 @@ xcodebuild \
 The simulator is enough to verify project setup and call flow wiring. Use a physical device to validate camera and microphone behavior.
 For physical-device runs, set your Apple development team in Xcode signing settings first.
 
-If you change [project.yml](/Users/alexeygavrilov/Developer/src/connected/samples/ios/project.yml), regenerate the checked-in project with:
+If you change [project.yml](project.yml), regenerate the checked-in project with:
 
 ```bash
 cd samples/ios


### PR DESCRIPTION
## Summary
- Add extracted files (SignalingMessageRouter, JoinFlowCoordinator, SignalingPayloads) to CLAUDE.md architecture sections for iOS, Android, and Web
- Document integration test command and version parity check in CLAUDE.md and README.md
- Expand CHANGELOG.md [0.1.0] with "Improved (post-initial release)" section listing all SDK remediation work
- Update type annotations for CallErrorCode, PeerConnectionState, and isSupported() in CLAUDE.md
- Fix hardcoded absolute path in samples/ios/README.md (replaced with relative path)

## Test plan
- [ ] Verify all Markdown renders correctly on GitHub
- [ ] Confirm referenced file paths match actual repo structure
- [ ] Confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)