### PR TITLE
Fix watcher subscription sync and startup config loading

### DIFF
--- a/client-ios/SerenadaCore/Sources/RoomWatcher.swift
+++ b/client-ios/SerenadaCore/Sources/RoomWatcher.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+@MainActor
+protocol RoomWatcherSignalingClient: AnyObject {
+    var listener: SignalingClientListener? { get set }
+    func connect(host: String)
+    func isConnected() -> Bool
+    func send(_ message: SignalingMessage)
+    func close()
+    func recordPong()
+}
+
 /// Room occupancy info (participant count and max capacity).
 public struct RoomOccupancy: Equatable {
     public let count: Int
@@ -23,7 +33,7 @@ public final class RoomWatcher {
     /// Delegate notified when room occupancy changes.
     public weak var delegate: RoomWatcherDelegate?
 
-    private let signalingClient: SignalingClient
+    private let signalingClient: any RoomWatcherSignalingClient
     private var watchedRoomIds: [String] = []
     private var statuses: [String: RoomOccupancy] = [:]
     private var reconnectAttempts = 0
@@ -35,6 +45,11 @@ public final class RoomWatcher {
         self.signalingClient.listener = self
     }
 
+    init(signalingClient: any RoomWatcherSignalingClient) {
+        self.signalingClient = signalingClient
+        self.signalingClient.listener = self
+    }
+
     /// Current occupancy statuses keyed by room ID.
     public var currentStatuses: [String: RoomOccupancy] {
         statuses
@@ -42,6 +57,7 @@ public final class RoomWatcher {
 
     /// Start watching the given room IDs for occupancy changes.
     public func watchRooms(roomIds: [String], host: String) {
+        let hostChanged = self.host.map { $0.compare(host, options: .caseInsensitive) != .orderedSame } ?? false
         self.host = host
         watchedRoomIds = roomIds
 
@@ -50,6 +66,10 @@ public final class RoomWatcher {
 
         reconnectTask?.cancel()
         reconnectTask = nil
+
+        if hostChanged {
+            signalingClient.close()
+        }
 
         guard !watchedRoomIds.isEmpty else {
             if signalingClient.isConnected() {
@@ -111,7 +131,8 @@ public final class RoomWatcher {
 
     private func mergeStatusesPayload(payload: JSONValue?) {
         guard let payload = payload?.objectValue else { return }
-        for (rid, value) in payload {
+        let watchedSet = Set(watchedRoomIds)
+        for (rid, value) in payload where watchedSet.contains(rid) {
             if let status = parseOccupancy(value, fallback: statuses[rid]) {
                 statuses[rid] = status
             }
@@ -127,6 +148,7 @@ public final class RoomWatcher {
         else {
             return
         }
+        guard watchedRoomIds.contains(rid) else { return }
 
         statuses[rid] = RoomOccupancy(
             count: max(0, count),
@@ -194,3 +216,5 @@ extension RoomWatcher: SignalingClientListener {
         scheduleReconnect()
     }
 }
+
+extension SignalingClient: RoomWatcherSignalingClient {}

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RoomWatcherTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RoomWatcherTests.swift
@@ -1,0 +1,149 @@
+@testable import SerenadaCore
+import XCTest
+
+@MainActor
+final class RoomWatcherTests: XCTestCase {
+    func testFiltersDroppedRoomsFromBulkAndIncrementalUpdates() {
+        let signalingClient = FakeRoomWatcherSignalingClient()
+        let watcher = RoomWatcher(signalingClient: signalingClient)
+        let delegate = RoomWatcherDelegateSpy()
+        watcher.delegate = delegate
+
+        watcher.watchRooms(roomIds: ["alpha", "beta"], host: "one.example")
+        XCTAssertEqual(signalingClient.connectHosts, ["one.example"])
+
+        signalingClient.simulateOpen()
+        XCTAssertEqual(signalingClient.lastWatchedRoomIds, ["alpha", "beta"])
+
+        signalingClient.simulateMessage(
+            SignalingMessage(
+                type: "room_statuses",
+                payload: .object([
+                    "alpha": .object(["count": .number(1), "maxParticipants": .number(4)]),
+                    "gamma": .object(["count": .number(3), "maxParticipants": .number(4)]),
+                ])
+            )
+        )
+        XCTAssertEqual(watcher.currentStatuses, [
+            "alpha": RoomOccupancy(count: 1, maxParticipants: 4)
+        ])
+
+        watcher.watchRooms(roomIds: ["beta"], host: "one.example")
+        XCTAssertEqual(signalingClient.lastWatchedRoomIds, ["beta"])
+
+        signalingClient.simulateMessage(
+            SignalingMessage(
+                type: "room_statuses",
+                payload: .object([
+                    "alpha": .object(["count": .number(4), "maxParticipants": .number(4)]),
+                    "beta": .object(["count": .number(2), "maxParticipants": .number(4)]),
+                ])
+            )
+        )
+        XCTAssertEqual(watcher.currentStatuses, [
+            "beta": RoomOccupancy(count: 2, maxParticipants: 4)
+        ])
+
+        signalingClient.simulateMessage(
+            SignalingMessage(
+                type: "room_status_update",
+                payload: .object([
+                    "rid": .string("alpha"),
+                    "count": .number(5),
+                    "maxParticipants": .number(4),
+                ])
+            )
+        )
+        XCTAssertEqual(watcher.currentStatuses, [
+            "beta": RoomOccupancy(count: 2, maxParticipants: 4)
+        ])
+
+        signalingClient.simulateMessage(
+            SignalingMessage(
+                type: "room_status_update",
+                payload: .object([
+                    "rid": .string("beta"),
+                    "count": .number(6),
+                    "maxParticipants": .number(4),
+                ])
+            )
+        )
+        XCTAssertEqual(watcher.currentStatuses, [
+            "beta": RoomOccupancy(count: 6, maxParticipants: 4)
+        ])
+        XCTAssertEqual(delegate.snapshots.last, watcher.currentStatuses)
+    }
+
+    func testHostChangeClosesAndReconnectsBeforeResubscribing() {
+        let signalingClient = FakeRoomWatcherSignalingClient()
+        let watcher = RoomWatcher(signalingClient: signalingClient)
+
+        watcher.watchRooms(roomIds: ["alpha"], host: "one.example")
+        signalingClient.simulateOpen()
+        XCTAssertEqual(signalingClient.connectHosts, ["one.example"])
+        XCTAssertEqual(signalingClient.lastWatchedRoomIds, ["alpha"])
+
+        signalingClient.sentMessages.removeAll()
+        watcher.watchRooms(roomIds: ["alpha"], host: "two.example")
+
+        XCTAssertEqual(signalingClient.closeCalls, 1)
+        XCTAssertEqual(signalingClient.connectHosts, ["one.example", "two.example"])
+        XCTAssertTrue(signalingClient.sentMessages.isEmpty)
+
+        signalingClient.simulateOpen()
+        XCTAssertEqual(signalingClient.lastWatchedRoomIds, ["alpha"])
+    }
+}
+
+@MainActor
+private final class RoomWatcherDelegateSpy: RoomWatcherDelegate {
+    var snapshots: [[String: RoomOccupancy]] = []
+
+    func roomWatcher(_ watcher: RoomWatcher, didUpdateStatuses statuses: [String : RoomOccupancy]) {
+        snapshots.append(statuses)
+    }
+}
+
+@MainActor
+private final class FakeRoomWatcherSignalingClient: RoomWatcherSignalingClient {
+    var listener: SignalingClientListener?
+    var connected = false
+    var connectHosts: [String] = []
+    var sentMessages: [SignalingMessage] = []
+    var closeCalls = 0
+    var recordPongCalls = 0
+
+    var lastWatchedRoomIds: [String]? {
+        sentMessages.last?.payload?.objectValue?["rids"]?.arrayValue?.compactMap { $0.stringValue }
+    }
+
+    func connect(host: String) {
+        connectHosts.append(host)
+    }
+
+    func isConnected() -> Bool {
+        connected
+    }
+
+    func send(_ message: SignalingMessage) {
+        sentMessages.append(message)
+    }
+
+    func close() {
+        closeCalls += 1
+        connected = false
+    }
+
+    func recordPong() {
+        recordPongCalls += 1
+    }
+
+    func simulateOpen() {
+        connected = true
+        listener?.onOpen(activeTransport: "ws")
+    }
+
+    func simulateMessage(_ message: SignalingMessage) {
+        listener?.onMessage(message)
+    }
+}

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		932FE0F4C5B2A808073B537A /* BackoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC9E71EE9415390DBBFC4A7 /* BackoffTests.swift */; };
 		9342C14683CA7530772F5F93 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE887624CBDA34B0B333C6A /* SettingsStore.swift */; };
 		9ADDE9F64E5B64AB5128AF50 /* CameraModeFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F052EA0D1D083D292B3CF0E /* CameraModeFlowTests.swift */; };
+		9C333A1799F89B5A4A9080BB /* RoomWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D3BC3109B79353E8157F76 /* RoomWatcherTests.swift */; };
 		A166AEDB8228E8C0BB59B927 /* SerenadaCallUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7502F7E9518E36BE37DEBD99 /* SerenadaCallUI */; };
 		A281E4C5D7AE35EEF75A87A8 /* SerenadaSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7830FA5A71601737755C721D /* SerenadaSessionTests.swift */; };
 		A3E593BBB26536974F9B5152 /* JoinSnapshotFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0824DD6CEC2DF4431D724B4D /* JoinSnapshotFeature.swift */; };
@@ -162,6 +163,7 @@
 		6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushKeyStore.swift; sourceTree = "<group>"; };
 		70D055EA10214AFAD5F76FFE /* layout_conformance_v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = layout_conformance_v1.json; sourceTree = "<group>"; };
 		7830FA5A71601737755C721D /* SerenadaSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaSessionTests.swift; sourceTree = "<group>"; };
+		79D3BC3109B79353E8157F76 /* RoomWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomWatcherTests.swift; sourceTree = "<group>"; };
 		7C5B216BB8A302914AB1CA5B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		7EE887624CBDA34B0B333C6A /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		8656DA5A095E572174461E96 /* L10nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10nTests.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				23CA15C6609960E60FFBCD90 /* JoinFlowCoordinatorTests.swift */,
 				F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */,
 				E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */,
+				79D3BC3109B79353E8157F76 /* RoomWatcherTests.swift */,
 				7830FA5A71601737755C721D /* SerenadaSessionTests.swift */,
 				8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */,
 				09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */,
@@ -775,6 +778,7 @@
 				366BA266D1F08550723BA77D /* LayoutConformanceTests.swift in Sources */,
 				C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */,
 				71320D322F59D2244B5A2027 /* RoomStatusesTests.swift in Sources */,
+				9C333A1799F89B5A4A9080BB /* RoomWatcherTests.swift in Sources */,
 				3153C0E407E8DD601B43B97E /* RootViewRoutingTests.swift in Sources */,
 				F237C6E7ED0C17810C58C49F /* SavedRoomStoreTests.swift in Sources */,
 				A281E4C5D7AE35EEF75A87A8 /* SerenadaSessionTests.swift in Sources */,

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serenada/core",
   "version": "0.2.0",
-  "description": "Headless WebRTC call engine for 1:1 video calls — vanilla TypeScript, no React dependency",
+  "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/client/packages/core/src/RoomWatcher.ts
+++ b/client/packages/core/src/RoomWatcher.ts
@@ -68,6 +68,9 @@ export class RoomWatcher {
         this.notify();
 
         if (this.watchedRoomIds.length === 0) {
+            if (this.hasConnected && this.signaling.isConnected) {
+                this.signaling.watchRooms([]);
+            }
             return;
         }
 

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -210,7 +210,6 @@ export class SignalingEngine {
     }
 
     watchRooms(rids: string[]): void {
-        if (rids.length === 0) return;
         this.sendMessage('watch_rooms', { rids });
     }
 

--- a/client/packages/core/test/signaling/RoomWatcher.test.ts
+++ b/client/packages/core/test/signaling/RoomWatcher.test.ts
@@ -92,4 +92,25 @@ describe('RoomWatcher', () => {
 
         expect(signaling.destroyCalls).toBe(1);
     });
+
+    it('clears server-side subscriptions when the watched room list becomes empty after connecting', () => {
+        const signaling = new FakeSignalingEngine();
+        const watcher = new RoomWatcher(
+            { serverHost: 'serenada.app' },
+            { createSignalingEngine: () => signaling as unknown as SignalingEngine },
+        );
+
+        watcher.watchRooms(['alpha']);
+        signaling.emit({
+            isConnected: true,
+            activeTransport: 'ws',
+        });
+        expect(signaling.watchCalls).toEqual([['alpha']]);
+
+        signaling.watchCalls = [];
+        watcher.watchRooms([]);
+
+        expect(signaling.connectCalls).toBe(1);
+        expect(signaling.watchCalls).toEqual([[]]);
+    });
 });

--- a/client/packages/core/test/signaling/SignalingEngine.test.ts
+++ b/client/packages/core/test/signaling/SignalingEngine.test.ts
@@ -277,6 +277,29 @@ describe('auto-rejoin on reconnect', () => {
     });
 });
 
+describe('watch_rooms signaling', () => {
+    it('sends watch_rooms even when the watched room list is empty', () => {
+        const engine = createEngine(['ws']);
+        engine.connect();
+
+        const ws = lastTransport();
+        ws.simulateOpen();
+
+        engine.watchRooms([]);
+
+        expect(ws.sentMessages).toContainEqual({
+            v: 1,
+            type: 'watch_rooms',
+            rid: undefined,
+            cid: undefined,
+            to: undefined,
+            payload: { rids: [] },
+        });
+
+        engine.destroy();
+    });
+});
+
 // ---------------------------------------------------------------------------
 // 6. Join hard timeout
 // ---------------------------------------------------------------------------

--- a/docs/serenada_prd.md
+++ b/docs/serenada_prd.md
@@ -14,7 +14,7 @@
 Family members need a **frictionless way to start a video call** without installing apps, creating accounts, or navigating complex UIs. The experience should be instant and link-based.
 
 ### 1.2 Proposed solution
-**Serenada** is a **single-page web application (SPA)** that enables quick **1:1 video calls** using **WebRTC**, accessible directly from modern browsers on desktop and mobile (especially Android).
+**Serenada** is a **link-based calling product** that enables quick **1:1 and small-group video calls** using **WebRTC**, with web and native clients available across desktop and mobile platforms.
 
 Core interaction:
 - Open the site
@@ -31,7 +31,7 @@ Core interaction:
 Serenada must:
 1. Allow a user to **start a video call with one tap**
 2. Generate a **unique, shareable URL** for each call
-3. Allow another user to **join the same call from a browser**
+3. Allow another user to **join the same call from a browser or native client**
 4. Provide **basic in-call controls** (mute, camera toggle, end call)
 5. Work reliably on:
    - Android Chrome (primary)
@@ -42,7 +42,7 @@ Serenada must:
 ### 2.2 Non-goals (explicitly out of scope)
 - User accounts or authentication
 - Contact lists
-- Group calls (>2 participants)
+- Group calls larger than the current small-room limit (more than 4 participants)
 - Text chat
 - Call recording
 - Screen sharing

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -429,10 +429,13 @@ Client keepalive. Server ignores.
 ### 4.12 Room Status Monitoring (WebSocket/SSE)
 
 Used to aggregate real-time occupancy for a list of rooms (e.g., recent calls list).
-Currently consumed by both the React web home screen and the native Android home screen recent-calls UX.
+Currently consumed by the React web home screen and the native Android/iOS home screen recent-calls UX.
 
 #### `watch_rooms` (client → server)
 Subscribe to updates for a list of rooms.
+
+Each `watch_rooms` message replaces the client's previous watched-room set.
+Send `rids: []` to clear all room-watch subscriptions for that connection.
 
 ```json
 {
@@ -579,6 +582,7 @@ Returns TURN credentials for a valid TURN token. The token is issued by the back
 
 ### 8.3 `GET|POST /api/diagnostic-token`
 Issues a short-lived diagnostic TURN token (5 seconds).
+This is a diagnostics-only, rate-limited exception to the normal joined-session TURN token flow.
 
 **Response**
 ```json
@@ -603,7 +607,7 @@ Triggers a room invite push notification to subscribers of the room.
 ## 9. Security requirements
 
 - **HTTPS for APIs, WebSocket/SSE for signaling**.
-- **TURN Gating**: TURN tokens are only issued in the `joined` message after successful `rid` validation, preventing unauthorized use of the TURN relay by unauthenticated clients.
+- **TURN Gating**: Call TURN tokens are issued only in the `joined` message after successful `rid` validation. `/api/diagnostic-token` remains available as a short-lived, rate-limited diagnostics exception.
 - Rate limit:
   - new WS connections per IP
   - SSE requests per IP

--- a/server/main.go
+++ b/server/main.go
@@ -15,6 +15,7 @@ func main() {
 	// Load .env from current directory or parent directory (for local dev)
 	_ = godotenv.Load()
 	_ = godotenv.Load("../.env")
+	refreshAllowedOriginsFromEnv()
 	rateLimitBypass = parseRateLimitBypass(os.Getenv("RATE_LIMIT_BYPASS_IPS"))
 
 	// Initialize signaling

--- a/server/multiparty_test.go
+++ b/server/multiparty_test.go
@@ -69,6 +69,19 @@ func joinPayload(rid string, capMax int, createMax int) []byte {
 	return b
 }
 
+func watchRoomsPayload(rids []string) []byte {
+	payloadBytes, _ := json.Marshal(map[string]interface{}{
+		"rids": rids,
+	})
+	msg := Message{
+		V:       1,
+		Type:    "watch_rooms",
+		Payload: payloadBytes,
+	}
+	b, _ := json.Marshal(msg)
+	return b
+}
+
 // legacyJoinPayload builds a join message without capabilities (legacy client).
 func legacyJoinPayload(rid string) []byte {
 	msg := Message{
@@ -518,6 +531,112 @@ func TestWatchRoomsIncludesMaxParticipants(t *testing.T) {
 	t.Fatal("did not receive room_statuses message")
 }
 
+func TestWatchRoomsReplacesPreviousSubscriptions(t *testing.T) {
+	t.Setenv("ROOM_ID_SECRET", "test-room-id-secret")
+	ridA := mustTestRoomID(t)
+	ridB := mustTestRoomID(t)
+	hub := newHub(4)
+
+	watcher := fakeClient(hub)
+	hub.registerClient(watcher)
+	hub.handleMessage(watcher, watchRoomsPayload([]string{ridA}))
+	drainMessages(watcher)
+
+	hub.handleMessage(watcher, watchRoomsPayload([]string{ridB}))
+	msgs := drainMessages(watcher)
+	for _, msg := range msgs {
+		if msg.Type != "room_statuses" {
+			continue
+		}
+		var payload map[string]map[string]int
+		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+			t.Fatalf("failed to parse room_statuses payload: %v", err)
+		}
+		if _, ok := payload[ridA]; ok {
+			t.Fatalf("did not expect room_statuses payload to include previous room %s", ridA)
+		}
+		if _, ok := payload[ridB]; !ok {
+			t.Fatalf("expected room_statuses payload to include replacement room %s", ridB)
+		}
+	}
+
+	participantA := fakeClient(hub)
+	hub.registerClient(participantA)
+	hub.handleMessage(participantA, joinPayload(ridA, 4, 4))
+
+	for _, msg := range drainMessages(watcher) {
+		if msg.Type == "room_status_update" {
+			var payload struct {
+				RID string `json:"rid"`
+			}
+			if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+				t.Fatalf("failed to parse room_status_update payload: %v", err)
+			}
+			if payload.RID == ridA {
+				t.Fatalf("did not expect room_status_update for unsubscribed room %s", ridA)
+			}
+		}
+	}
+
+	participantB := fakeClient(hub)
+	hub.registerClient(participantB)
+	hub.handleMessage(participantB, joinPayload(ridB, 4, 4))
+
+	for _, msg := range drainMessages(watcher) {
+		if msg.Type != "room_status_update" {
+			continue
+		}
+		var payload struct {
+			RID   string `json:"rid"`
+			Count int    `json:"count"`
+		}
+		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+			t.Fatalf("failed to parse room_status_update payload: %v", err)
+		}
+		if payload.RID == ridB && payload.Count == 1 {
+			return
+		}
+	}
+
+	t.Fatalf("expected room_status_update for replacement room %s", ridB)
+}
+
+func TestWatchRoomsClearsSubscriptionsWithEmptyList(t *testing.T) {
+	t.Setenv("ROOM_ID_SECRET", "test-room-id-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	watcher := fakeClient(hub)
+	hub.registerClient(watcher)
+	hub.handleMessage(watcher, watchRoomsPayload([]string{rid}))
+	drainMessages(watcher)
+
+	hub.handleMessage(watcher, watchRoomsPayload([]string{}))
+	msgs := drainMessages(watcher)
+	for _, msg := range msgs {
+		if msg.Type != "room_statuses" {
+			continue
+		}
+		var payload map[string]map[string]int
+		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+			t.Fatalf("failed to parse room_statuses payload: %v", err)
+		}
+		if len(payload) != 0 {
+			t.Fatalf("expected empty room_statuses payload after clearing subscriptions, got %+v", payload)
+		}
+	}
+
+	participant := fakeClient(hub)
+	hub.registerClient(participant)
+	hub.handleMessage(participant, joinPayload(rid, 4, 4))
+
+	for _, msg := range drainMessages(watcher) {
+		if msg.Type == "room_status_update" {
+			t.Fatalf("did not expect room_status_update after clearing subscriptions: %+v", msg)
+		}
+	}
+}
+
 func TestRoomStatusUpdateIncludesMaxParticipants(t *testing.T) {
 	t.Setenv("ROOM_ID_SECRET", "test-room-id-secret")
 	rid := mustTestRoomID(t)
@@ -525,15 +644,7 @@ func TestRoomStatusUpdateIncludesMaxParticipants(t *testing.T) {
 
 	watcher := fakeClient(hub)
 	hub.registerClient(watcher)
-	watchPayload, _ := json.Marshal(map[string]interface{}{
-		"rids": []string{rid},
-	})
-	watchMsg, _ := json.Marshal(Message{
-		V:       1,
-		Type:    "watch_rooms",
-		Payload: watchPayload,
-	})
-	hub.handleMessage(watcher, watchMsg)
+	hub.handleMessage(watcher, watchRoomsPayload([]string{rid}))
 	drainMessages(watcher)
 
 	participant := fakeClient(hub)

--- a/server/multiparty_test.go
+++ b/server/multiparty_test.go
@@ -544,10 +544,12 @@ func TestWatchRoomsReplacesPreviousSubscriptions(t *testing.T) {
 
 	hub.handleMessage(watcher, watchRoomsPayload([]string{ridB}))
 	msgs := drainMessages(watcher)
+	foundRoomStatuses := false
 	for _, msg := range msgs {
 		if msg.Type != "room_statuses" {
 			continue
 		}
+		foundRoomStatuses = true
 		var payload map[string]map[string]int
 		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
 			t.Fatalf("failed to parse room_statuses payload: %v", err)
@@ -558,6 +560,9 @@ func TestWatchRoomsReplacesPreviousSubscriptions(t *testing.T) {
 		if _, ok := payload[ridB]; !ok {
 			t.Fatalf("expected room_statuses payload to include replacement room %s", ridB)
 		}
+	}
+	if !foundRoomStatuses {
+		t.Fatal("expected room_statuses message when replacing watched rooms")
 	}
 
 	participantA := fakeClient(hub)
@@ -613,10 +618,12 @@ func TestWatchRoomsClearsSubscriptionsWithEmptyList(t *testing.T) {
 
 	hub.handleMessage(watcher, watchRoomsPayload([]string{}))
 	msgs := drainMessages(watcher)
+	foundRoomStatuses := false
 	for _, msg := range msgs {
 		if msg.Type != "room_statuses" {
 			continue
 		}
+		foundRoomStatuses = true
 		var payload map[string]map[string]int
 		if err := json.Unmarshal(msg.Payload, &payload); err != nil {
 			t.Fatalf("failed to parse room_statuses payload: %v", err)
@@ -624,6 +631,9 @@ func TestWatchRoomsClearsSubscriptionsWithEmptyList(t *testing.T) {
 		if len(payload) != 0 {
 			t.Fatalf("expected empty room_statuses payload after clearing subscriptions, got %+v", payload)
 		}
+	}
+	if !foundRoomStatuses {
+		t.Fatal("expected room_statuses message when clearing watched rooms")
 	}
 
 	participant := fakeClient(hub)

--- a/server/rate_limit.go
+++ b/server/rate_limit.go
@@ -12,22 +12,30 @@ import (
 
 var rateLimitBypass = parseRateLimitBypass(os.Getenv("RATE_LIMIT_BYPASS_IPS"))
 
+const (
+	ipLimiterEntryTTL      = 30 * time.Minute
+	ipLimiterPruneInterval = 10 * time.Minute
+)
+
 // SimpleTokenBucket implements a token bucket rate limiter.
 type SimpleTokenBucket struct {
 	tokens         float64
 	capacity       float64
 	refillRate     float64 // tokens per second
 	lastRefillTime time.Time
+	lastSeen       time.Time
 	mu             sync.Mutex
 }
 
 func NewSimpleTokenBucket(capacity float64, refillRate float64) *SimpleTokenBucket {
 	// Initial full bucket
+	now := time.Now()
 	return &SimpleTokenBucket{
 		tokens:         capacity,
 		capacity:       capacity,
 		refillRate:     refillRate,
-		lastRefillTime: time.Now(),
+		lastRefillTime: now,
+		lastSeen:       now,
 	}
 }
 
@@ -53,10 +61,12 @@ func (tb *SimpleTokenBucket) Allow() bool {
 
 // Global Rate Limiter Manager
 type IPLimiter struct {
-	ips   map[string]*SimpleTokenBucket
-	mu    sync.Mutex
-	rate  float64
-	burst float64
+	ips          map[string]*SimpleTokenBucket
+	mu           sync.Mutex
+	rate         float64
+	burst        float64
+	lastPrunedAt time.Time
+	now          func() time.Time
 }
 
 type rateLimitBypassList struct {
@@ -124,6 +134,7 @@ func NewIPLimiter(r float64, b float64) *IPLimiter {
 		ips:   make(map[string]*SimpleTokenBucket),
 		rate:  r,
 		burst: b,
+		now:   time.Now,
 	}
 }
 
@@ -131,16 +142,32 @@ func (i *IPLimiter) GetLimiter(ip string) *SimpleTokenBucket {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	now := i.now()
+	i.pruneStaleEntries(now)
+
 	limiter, exists := i.ips[ip]
 	if !exists {
 		limiter = NewSimpleTokenBucket(i.burst, i.rate)
 		i.ips[ip] = limiter
 	}
+	limiter.lastSeen = now
 
 	return limiter
 }
 
-// Cleanup routine to remove old IPs could be added here to prevent memory leaks
+func (i *IPLimiter) pruneStaleEntries(now time.Time) {
+	if !i.lastPrunedAt.IsZero() && now.Sub(i.lastPrunedAt) < ipLimiterPruneInterval {
+		return
+	}
+
+	cutoff := now.Add(-ipLimiterEntryTTL)
+	for ip, limiter := range i.ips {
+		if limiter.lastSeen.Before(cutoff) {
+			delete(i.ips, ip)
+		}
+	}
+	i.lastPrunedAt = now
+}
 
 // Middleware
 func rateLimitMiddleware(limiter *IPLimiter, next http.HandlerFunc) http.HandlerFunc {

--- a/server/rate_limit_test.go
+++ b/server/rate_limit_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestParseRateLimitBypassAndContains(t *testing.T) {
@@ -47,5 +48,34 @@ func TestRateLimitMiddlewareBypass(t *testing.T) {
 
 	if hits != 3 {
 		t.Fatalf("expected handler hits=3, got %d", hits)
+	}
+}
+
+func TestIPLimiterPrunesIdleEntries(t *testing.T) {
+	base := time.Date(2026, time.March, 25, 12, 0, 0, 0, time.UTC)
+	limiter := NewIPLimiter(1, 1)
+	limiter.now = func() time.Time { return base }
+	limiter.lastPrunedAt = base.Add(-11 * time.Minute)
+
+	stale := NewSimpleTokenBucket(1, 1)
+	stale.lastSeen = base.Add(-31 * time.Minute)
+	fresh := NewSimpleTokenBucket(1, 1)
+	fresh.lastSeen = base.Add(-29 * time.Minute)
+
+	limiter.ips["stale"] = stale
+	limiter.ips["fresh"] = fresh
+
+	got := limiter.GetLimiter("fresh")
+	if got != fresh {
+		t.Fatalf("expected existing fresh limiter to be returned")
+	}
+	if _, ok := limiter.ips["stale"]; ok {
+		t.Fatalf("expected stale limiter entry to be pruned")
+	}
+	if _, ok := limiter.ips["fresh"]; !ok {
+		t.Fatalf("expected fresh limiter entry to remain")
+	}
+	if !fresh.lastSeen.Equal(base) {
+		t.Fatalf("expected fresh limiter lastSeen to refresh to %v, got %v", base, fresh.lastSeen)
 	}
 }

--- a/server/security.go
+++ b/server/security.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 )
 
-var (
-	allowedOrigins = parseAllowedOrigins(os.Getenv("ALLOWED_ORIGINS"))
-)
+var allowedOrigins = map[string]bool{}
 
 func parseAllowedOrigins(raw string) map[string]bool {
 	origins := make(map[string]bool)
@@ -19,6 +17,10 @@ func parseAllowedOrigins(raw string) map[string]bool {
 		}
 	}
 	return origins
+}
+
+func refreshAllowedOriginsFromEnv() {
+	allowedOrigins = parseAllowedOrigins(os.Getenv("ALLOWED_ORIGINS"))
 }
 
 func isOriginAllowed(r *http.Request) bool {

--- a/server/security_test.go
+++ b/server/security_test.go
@@ -28,9 +28,9 @@ func TestParseAllowedOriginsMultiple(t *testing.T) {
 	if len(origins) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(origins))
 	}
-	for _, o := range []string{"https://a.com", "https://b.com", "https://c.com"} {
-		if !origins[o] {
-			t.Fatalf("expected %q to be present", o)
+	for _, origin := range []string{"https://a.com", "https://b.com", "https://c.com"} {
+		if !origins[origin] {
+			t.Fatalf("expected %q to be present", origin)
 		}
 	}
 }
@@ -42,6 +42,28 @@ func TestParseAllowedOriginsWhitespace(t *testing.T) {
 	}
 	if !origins["https://a.com"] {
 		t.Fatalf("expected trimmed origin to be present")
+	}
+}
+
+func TestRefreshAllowedOriginsFromEnv(t *testing.T) {
+	original := allowedOrigins
+	defer func() { allowedOrigins = original }()
+
+	t.Setenv("ALLOWED_ORIGINS", "https://allowed.example,https://other.example")
+	refreshAllowedOriginsFromEnv()
+
+	req := httptest.NewRequest(http.MethodGet, "http://serenada.app/api/room-id", nil)
+	req.Host = "serenada.app"
+	req.Header.Set("Origin", "https://allowed.example")
+	if !isOriginAllowed(req) {
+		t.Fatalf("expected configured origin to be allowed")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "http://serenada.app/api/room-id", nil)
+	req.Host = "serenada.app"
+	req.Header.Set("Origin", "https://denied.example")
+	if isOriginAllowed(req) {
+		t.Fatalf("expected non-configured origin to be denied")
 	}
 }
 
@@ -78,8 +100,8 @@ func TestIsOriginAllowedRejectsUnknown(t *testing.T) {
 
 func TestIsOriginAllowedLocalhostBypass(t *testing.T) {
 	original := allowedOrigins
-	allowedOrigins = parseAllowedOrigins("")
 	defer func() { allowedOrigins = original }()
+	allowedOrigins = parseAllowedOrigins("")
 
 	for _, origin := range []string{
 		"http://localhost",
@@ -96,34 +118,47 @@ func TestIsOriginAllowedLocalhostBypass(t *testing.T) {
 
 func TestIsOriginAllowedHostFallback(t *testing.T) {
 	original := allowedOrigins
-	allowedOrigins = parseAllowedOrigins("")
 	defer func() { allowedOrigins = original }()
+	allowedOrigins = parseAllowedOrigins("")
 
-	req := httptest.NewRequest(http.MethodGet, "http://myapp.example.com/", nil)
-	req.Host = "myapp.example.com"
-	req.Header.Set("Origin", "https://myapp.example.com")
+	req := httptest.NewRequest(http.MethodGet, "http://serenada.app/api/room-id", nil)
+	req.Host = "serenada.app"
+	req.Header.Set("Origin", "https://serenada.app")
 	if !isOriginAllowed(req) {
-		t.Fatalf("origin matching Host header should be allowed")
+		t.Fatalf("expected same-host origin to be allowed")
 	}
 }
 
 func TestIsOriginAllowedHostFallbackMismatch(t *testing.T) {
 	original := allowedOrigins
-	allowedOrigins = parseAllowedOrigins("")
 	defer func() { allowedOrigins = original }()
+	allowedOrigins = parseAllowedOrigins("")
 
-	req := httptest.NewRequest(http.MethodGet, "http://myapp.example.com/", nil)
-	req.Host = "myapp.example.com"
-	req.Header.Set("Origin", "https://other.example.com")
+	req := httptest.NewRequest(http.MethodGet, "http://serenada.app/api/room-id", nil)
+	req.Host = "serenada.app"
+	req.Header.Set("Origin", "https://other.example")
 	if isOriginAllowed(req) {
 		t.Fatalf("origin not matching Host should be rejected")
 	}
 }
 
+func TestIsOriginAllowedLocalhostFallback(t *testing.T) {
+	original := allowedOrigins
+	defer func() { allowedOrigins = original }()
+	allowedOrigins = parseAllowedOrigins("")
+
+	req := httptest.NewRequest(http.MethodGet, "http://serenada.app/api/room-id", nil)
+	req.Host = "serenada.app"
+	req.Header.Set("Origin", "http://localhost:5173")
+	if !isOriginAllowed(req) {
+		t.Fatalf("expected localhost origin to be allowed")
+	}
+}
+
 func TestIsOriginAllowedEmptyHostRejects(t *testing.T) {
 	original := allowedOrigins
-	allowedOrigins = parseAllowedOrigins("")
 	defer func() { allowedOrigins = original }()
+	allowedOrigins = parseAllowedOrigins("")
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Host = ""

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -874,6 +874,12 @@ func (h *Hub) handleWatchRooms(c *Client, msg Message) {
 
 	h.mu.Lock()
 	status := make(map[string]map[string]int)
+	for rid, clientSet := range h.watchers {
+		delete(clientSet, c)
+		if len(clientSet) == 0 {
+			delete(h.watchers, rid)
+		}
+	}
 	for _, rid := range payload.RIDs {
 		if err := validateRoomID(rid); err != nil {
 			continue


### PR DESCRIPTION
## Summary
- load `ALLOWED_ORIGINS` after `.env` initialization and add regression coverage for configured, same-host, and localhost CORS behavior
- make `watch_rooms` authoritative on the server, align web and iOS room watchers with clear-on-empty and host-change behavior, and add watcher regression tests
- prune idle public rate-limit buckets and update protocol/package/PRD docs to reflect current multiparty and diagnostics behavior

## Testing
- `cd server && go test ./...`
- `cd client && npm test`
- `cd client-android && ./gradlew :serenada-core:testDebugUnitTest :app:testDebugUnitTest`
- `cd client-ios && xcodegen generate && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' test`
  - `SerenadaiOSTests` unit suite passed, including the new `RoomWatcherTests`
  - existing UI tests timed out waiting for participant count to rise above 1 in `DeepLinkParticipantCountUITests` and `DeepLinkRejoinFlowUITests`
