### PR TITLE
Add in-app user feedback with Telegram forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ TRUST_PROXY=1
 # ENABLE_INTERNAL_STATS=1
 # INTERNAL_STATS_TOKEN=change-me
 
+# Telegram bot for receiving user feedback (optional)
+#TELEGRAM_BOT_TOKEN=
+#TELEGRAM_CHAT_ID=
+
 # Deployment Configuration
 # VPS_HOST=root@your-vps-ip
 # DOMAIN=serenada.app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Go signaling server — flat package structure (no deep hierarchy). Key files:
 - `ws.go` / `sse.go` — WebSocket and SSE transport handlers
 - `room_id.go` — HMAC-based room ID generation/validation
 - `push.go` / `push_fcm.go` — Web Push (VAPID) and Firebase Cloud Messaging
+- `feedback.go` — user feedback endpoint with Telegram bot forwarding
 - `security.go` — CORS/origin validation
 - `rate_limit.go` — IP-based rate limiting
 - `internal/stats/` — metrics collection
@@ -206,7 +207,7 @@ Kotlin + Jetpack Compose + Material3. Three-module Gradle project.
 
 **Host app** (`app/`):
 - `call/CallManager.kt` — app-level call orchestrator (integrates SDK)
-- `ui/` — Compose screens (JoinScreen, SettingsScreen, DiagnosticsScreen)
+- `ui/` — Compose screens (JoinScreen, SettingsScreen, DiagnosticsScreen) with in-app feedback dialog
 - `push/` — Firebase Cloud Messaging integration
 - `service/` — foreground call service
 
@@ -239,7 +240,7 @@ SwiftUI + Swift 5.10, project generated via XcodeGen (`project.yml`). Two SPM pa
 - `Core/Call/CallManager.swift` — app-level call orchestrator (integrates SDK)
 - `Core/Push/` — push notifications (JoinSnapshotFeature, PushSubscriptionManager)
 - `Core/Stores/` — settings, saved rooms, recent calls
-- `UI/Screens/` — SwiftUI screens (JoinScreen, SettingsScreen, DiagnosticsScreen)
+- `UI/Screens/` — SwiftUI screens (JoinScreen, SettingsScreen, DiagnosticsScreen, FeedbackScreen)
 - `Shared/PushKeyStore.swift` — push encryption keys (shared with NotificationService extension)
 - `NotificationService/` — push notification app extension (decrypts snapshot images)
 - `BroadcastUpload/` — screen sharing broadcast extension
@@ -288,6 +289,7 @@ Server reads `.env` from the project root. See `.env.example` for all variables.
 - `ALLOWED_ORIGINS` — CORS origins
 - `BLOCK_WEBSOCKET` — test SSE fallback (`hang` or `block`)
 - `TRANSPORTS` — transport priority (default: `ws,sse`)
+- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` — optional, for receiving user feedback via Telegram
 
 ## Testing Deep Link
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -48,6 +48,8 @@ Edit `.env.production` and set the following required variables:
 - `FCM_SERVICE_ACCOUNT_FILE` or `FCM_SERVICE_ACCOUNT_JSON` *(optional, required for native Android and iOS push receive)*:
   - `FCM_SERVICE_ACCOUNT_FILE`: absolute path on VPS to Firebase service-account JSON
   - `FCM_SERVICE_ACCOUNT_JSON`: inline JSON string (alternative to file path)
+- `TELEGRAM_BOT_TOKEN` *(optional)*: Telegram bot token for receiving user feedback (create via [@BotFather](https://t.me/BotFather))
+- `TELEGRAM_CHAT_ID` *(optional)*: Telegram chat ID where feedback messages are sent
 - `RATE_LIMIT_BYPASS_IPS` *(optional, test-only)*: Comma-separated exact IPs/CIDRs that bypass HTTP rate limits (e.g. `127.0.0.1,10.0.0.0/8`)
 - `ENABLE_INTERNAL_STATS` *(optional, default disabled)*: Set to `1` only for controlled load testing to expose `/api/internal/stats`
 - `INTERNAL_STATS_TOKEN` *(required when internal stats are enabled)*: Required as `X-Internal-Token` header on `/api/internal/stats`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A simple, privacy-focused video calling application built with WebRTC. No accoun
 - **Self-hostable** – Run your own instance with full control
 - **Optional join alerts** – Encrypted push notifications with snapshot previews (web + native Android + native iOS)
 - **Room invite push** – In waiting state you can explicitly invite subscribers of the room; Android and iOS show these only for saved rooms and have a Settings toggle to disable invite notifications
+- **In-app feedback** – Send bug reports and suggestions directly from the app (web footer, Android/iOS settings); messages are forwarded to a configurable Telegram chat
 
 ## Quick Start
 

--- a/client-android/app/src/main/java/app/serenada/android/network/ApiClient.kt
+++ b/client-android/app/src/main/java/app/serenada/android/network/ApiClient.kt
@@ -223,6 +223,43 @@ class HostApiClient(private val okHttpClient: OkHttpClient) {
         })
     }
 
+    fun submitFeedback(
+        host: String,
+        message: String,
+        locale: String,
+        appVersion: String,
+        onResult: (Result<Int>) -> Unit
+    ) {
+        val url = buildHttpsUrl(host, "/api/feedback")
+        if (url == null) {
+            onResult(Result.failure(IllegalArgumentException("Invalid host")))
+            return
+        }
+
+        val payload = JSONObject().apply {
+            put("message", message)
+            put("platform", "android")
+            put("locale", locale)
+            put("version", appVersion)
+        }
+        val requestBody = payload.toString().toRequestBody("application/json".toMediaType())
+        val httpRequest = Request.Builder()
+            .url(url)
+            .post(requestBody)
+            .build()
+        okHttpClient.newCall(httpRequest).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                onResult(Result.failure(e))
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use {
+                    onResult(Result.success(response.code))
+                }
+            }
+        })
+    }
+
     private fun parsePushRecipients(body: String): Result<List<PushRecipient>> {
         return try {
             val recipientsJson = JSONArray(body)

--- a/client-android/app/src/main/java/app/serenada/android/ui/SettingsScreen.kt
+++ b/client-android/app/src/main/java/app/serenada/android/ui/SettingsScreen.kt
@@ -115,6 +115,7 @@ fun SettingsScreen(
     var feedbackText by remember { mutableStateOf("") }
     var isSendingFeedback by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
+    val feedbackApiClient = remember { HostApiClient(OkHttpClient()) }
 
     Scaffold(
         topBar = {
@@ -418,39 +419,32 @@ fun SettingsScreen(
                     TextButton(
                         onClick = {
                             isSendingFeedback = true
-                            val apiClient = HostApiClient(OkHttpClient())
-                            apiClient.submitFeedback(
+                            feedbackApiClient.submitFeedback(
                                 host = host,
                                 message = feedbackText.trim(),
                                 locale = selectedLanguage,
                                 appVersion = appVersion
                             ) { result ->
-                                isSendingFeedback = false
-                                result.fold(
-                                    onSuccess = { code ->
-                                        val msgRes = when {
-                                            code == 429 -> R.string.feedback_rate_limit
-                                            code in 200..299 -> R.string.feedback_success
-                                            else -> R.string.feedback_error
-                                        }
-                                        scope.launch {
-                                            withContext(Dispatchers.Main) {
-                                                Toast.makeText(context, context.getString(msgRes), Toast.LENGTH_SHORT).show()
-                                                if (code in 200..299) {
-                                                    showFeedbackDialog = false
-                                                    feedbackText = ""
-                                                }
+                                scope.launch(Dispatchers.Main) {
+                                    isSendingFeedback = false
+                                    result.fold(
+                                        onSuccess = { code ->
+                                            val msgRes = when {
+                                                code == 429 -> R.string.feedback_rate_limit
+                                                code in 200..299 -> R.string.feedback_success
+                                                else -> R.string.feedback_error
                                             }
-                                        }
-                                    },
-                                    onFailure = {
-                                        scope.launch {
-                                            withContext(Dispatchers.Main) {
-                                                Toast.makeText(context, context.getString(R.string.feedback_error), Toast.LENGTH_SHORT).show()
+                                            Toast.makeText(context, context.getString(msgRes), Toast.LENGTH_SHORT).show()
+                                            if (code in 200..299) {
+                                                showFeedbackDialog = false
+                                                feedbackText = ""
                                             }
+                                        },
+                                        onFailure = {
+                                            Toast.makeText(context, context.getString(R.string.feedback_error), Toast.LENGTH_SHORT).show()
                                         }
-                                    }
-                                )
+                                    )
+                                }
                             }
                         },
                         enabled = feedbackText.trim().isNotEmpty() && !isSendingFeedback

--- a/client-android/app/src/main/java/app/serenada/android/ui/SettingsScreen.kt
+++ b/client-android/app/src/main/java/app/serenada/android/ui/SettingsScreen.kt
@@ -52,12 +52,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import android.widget.Toast
+import androidx.compose.material3.AlertDialog
 import app.serenada.android.BuildConfig
 import app.serenada.android.R
 import app.serenada.android.data.SettingsStore
+import app.serenada.android.network.HostApiClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -106,6 +110,11 @@ fun SettingsScreen(
     var isPinging by remember { mutableStateOf(false) }
     var pingFailed by remember { mutableStateOf(false) }
     val appVersion = BuildConfig.VERSION_NAME.ifBlank { "-" }
+
+    var showFeedbackDialog by remember { mutableStateOf(false) }
+    var feedbackText by remember { mutableStateOf("") }
+    var isSendingFeedback by remember { mutableStateOf(false) }
+    val context = androidx.compose.ui.platform.LocalContext.current
 
     Scaffold(
         topBar = {
@@ -356,6 +365,17 @@ fun SettingsScreen(
                     )
                 }
 
+                SettingsSection(
+                    title = stringResource(R.string.settings_feedback_title)
+                ) {
+                    OutlinedButton(
+                        onClick = { showFeedbackDialog = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.settings_send_feedback))
+                    }
+                }
+
                 Text(
                     text = stringResource(R.string.settings_app_version, appVersion),
                     style = MaterialTheme.typography.bodySmall,
@@ -363,6 +383,100 @@ fun SettingsScreen(
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
             }
+        }
+
+        if (showFeedbackDialog) {
+            AlertDialog(
+                onDismissRequest = {
+                    if (!isSendingFeedback) {
+                        showFeedbackDialog = false
+                        feedbackText = ""
+                    }
+                },
+                title = { Text(stringResource(R.string.settings_send_feedback)) },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = feedbackText,
+                            onValueChange = { if (it.length <= 2000) feedbackText = it },
+                            placeholder = { Text(stringResource(R.string.feedback_placeholder)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(160.dp),
+                            shape = RoundedCornerShape(14.dp),
+                            maxLines = 8
+                        )
+                        Text(
+                            text = "${feedbackText.length}/2000",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.align(Alignment.End)
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            isSendingFeedback = true
+                            val apiClient = HostApiClient(OkHttpClient())
+                            apiClient.submitFeedback(
+                                host = host,
+                                message = feedbackText.trim(),
+                                locale = selectedLanguage,
+                                appVersion = appVersion
+                            ) { result ->
+                                isSendingFeedback = false
+                                result.fold(
+                                    onSuccess = { code ->
+                                        val msgRes = when {
+                                            code == 429 -> R.string.feedback_rate_limit
+                                            code in 200..299 -> R.string.feedback_success
+                                            else -> R.string.feedback_error
+                                        }
+                                        scope.launch {
+                                            withContext(Dispatchers.Main) {
+                                                Toast.makeText(context, context.getString(msgRes), Toast.LENGTH_SHORT).show()
+                                                if (code in 200..299) {
+                                                    showFeedbackDialog = false
+                                                    feedbackText = ""
+                                                }
+                                            }
+                                        }
+                                    },
+                                    onFailure = {
+                                        scope.launch {
+                                            withContext(Dispatchers.Main) {
+                                                Toast.makeText(context, context.getString(R.string.feedback_error), Toast.LENGTH_SHORT).show()
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        },
+                        enabled = feedbackText.trim().isNotEmpty() && !isSendingFeedback
+                    ) {
+                        if (isSendingFeedback) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Text(stringResource(R.string.feedback_send))
+                        }
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = {
+                            showFeedbackDialog = false
+                            feedbackText = ""
+                        },
+                        enabled = !isSendingFeedback
+                    ) {
+                        Text(stringResource(R.string.common_back))
+                    }
+                }
+            )
         }
     }
 }

--- a/client-android/app/src/main/res/values-es/strings.xml
+++ b/client-android/app/src/main/res/values-es/strings.xml
@@ -150,4 +150,12 @@
     <string name="settings_invites_title">Invitaciones</string>
     <string name="settings_invite_notifications">Notificaciones de invitación</string>
     <string name="settings_invite_notifications_info">Mostrar notificaciones cuando te inviten a una sala guardada.</string>
+
+    <string name="settings_feedback_title">Comentarios</string>
+    <string name="settings_send_feedback">Enviar comentarios</string>
+    <string name="feedback_placeholder">Describe tu problema o sugerencia...</string>
+    <string name="feedback_success">¡Gracias por tus comentarios!</string>
+    <string name="feedback_rate_limit">Espera antes de enviar más comentarios.</string>
+    <string name="feedback_error">No se pudo enviar. Inténtalo de nuevo.</string>
+    <string name="feedback_send">Enviar</string>
 </resources>

--- a/client-android/app/src/main/res/values-fr/strings.xml
+++ b/client-android/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,12 @@
     <string name="settings_invites_title">Invitations</string>
     <string name="settings_invite_notifications">Notifications d\'invitation</string>
     <string name="settings_invite_notifications_info">Afficher les notifications quand vous êtes invité dans une salle enregistrée.</string>
+
+    <string name="settings_feedback_title">Retour</string>
+    <string name="settings_send_feedback">Envoyer un retour</string>
+    <string name="feedback_placeholder">Décrivez votre problème ou suggestion...</string>
+    <string name="feedback_success">Merci pour votre retour !</string>
+    <string name="feedback_rate_limit">Veuillez patienter avant d\'envoyer un autre retour.</string>
+    <string name="feedback_error">Échec de l\'envoi. Veuillez réessayer.</string>
+    <string name="feedback_send">Envoyer</string>
 </resources>

--- a/client-android/app/src/main/res/values-ru/strings.xml
+++ b/client-android/app/src/main/res/values-ru/strings.xml
@@ -151,4 +151,12 @@
     <string name="settings_invites_title">Приглашения</string>
     <string name="settings_invite_notifications">Уведомления о приглашениях</string>
     <string name="settings_invite_notifications_info">Показывать уведомления, когда вас зовут в сохраненную комнату.</string>
+
+    <string name="settings_feedback_title">Отзыв</string>
+    <string name="settings_send_feedback">Отправить отзыв</string>
+    <string name="feedback_placeholder">Опишите проблему или предложение...</string>
+    <string name="feedback_success">Спасибо за ваш отзыв!</string>
+    <string name="feedback_rate_limit">Подождите перед отправкой нового отзыва.</string>
+    <string name="feedback_error">Не удалось отправить отзыв. Попробуйте ещё раз.</string>
+    <string name="feedback_send">Отправить</string>
 </resources>

--- a/client-android/app/src/main/res/values/strings.xml
+++ b/client-android/app/src/main/res/values/strings.xml
@@ -151,4 +151,12 @@
     <string name="settings_saved_rooms_share_link_chooser">Share room link</string>
     <string name="common_copy">Copy</string>
     <string name="common_share">Share</string>
+
+    <string name="settings_feedback_title">Feedback</string>
+    <string name="settings_send_feedback">Send Feedback</string>
+    <string name="feedback_placeholder">Describe your issue or suggestion...</string>
+    <string name="feedback_success">Thank you for your feedback!</string>
+    <string name="feedback_rate_limit">Please wait before sending more feedback.</string>
+    <string name="feedback_error">Failed to send feedback. Please try again.</string>
+    <string name="feedback_send">Send</string>
 </resources>

--- a/client-ios/Resources/en.lproj/Localizable.strings
+++ b/client-ios/Resources/en.lproj/Localizable.strings
@@ -156,3 +156,11 @@
 "call_error_generic" = "Something went wrong";
 "call_joining" = "Joining...";
 "call_ended" = "Call ended";
+
+"feedback_title" = "Feedback";
+"feedback_send_action" = "Send Feedback";
+"feedback_placeholder" = "Describe your issue or suggestion...";
+"feedback_send" = "Send";
+"feedback_success" = "Thank you for your feedback!";
+"feedback_rate_limit" = "Please wait before sending more feedback.";
+"feedback_error" = "Failed to send feedback. Please try again.";

--- a/client-ios/Resources/es.lproj/Localizable.strings
+++ b/client-ios/Resources/es.lproj/Localizable.strings
@@ -156,3 +156,11 @@
 "call_error_generic" = "Algo salió mal";
 "call_joining" = "Uniéndose...";
 "call_ended" = "Llamada finalizada";
+
+"feedback_title" = "Comentarios";
+"feedback_send_action" = "Enviar comentarios";
+"feedback_placeholder" = "Describe tu problema o sugerencia...";
+"feedback_send" = "Enviar";
+"feedback_success" = "¡Gracias por tus comentarios!";
+"feedback_rate_limit" = "Espera antes de enviar más comentarios.";
+"feedback_error" = "No se pudo enviar. Inténtalo de nuevo.";

--- a/client-ios/Resources/fr.lproj/Localizable.strings
+++ b/client-ios/Resources/fr.lproj/Localizable.strings
@@ -156,3 +156,11 @@
 "call_error_generic" = "Une erreur est survenue";
 "call_joining" = "Connexion...";
 "call_ended" = "Appel terminé";
+
+"feedback_title" = "Retour";
+"feedback_send_action" = "Envoyer un retour";
+"feedback_placeholder" = "Décrivez votre problème ou suggestion...";
+"feedback_send" = "Envoyer";
+"feedback_success" = "Merci pour votre retour !";
+"feedback_rate_limit" = "Veuillez patienter avant d'envoyer un autre retour.";
+"feedback_error" = "Échec de l'envoi. Veuillez réessayer.";

--- a/client-ios/Resources/ru.lproj/Localizable.strings
+++ b/client-ios/Resources/ru.lproj/Localizable.strings
@@ -156,3 +156,11 @@
 "call_error_generic" = "Что-то пошло не так";
 "call_joining" = "Подключение...";
 "call_ended" = "Звонок завершён";
+
+"feedback_title" = "Отзыв";
+"feedback_send_action" = "Отправить отзыв";
+"feedback_placeholder" = "Опишите проблему или предложение...";
+"feedback_send" = "Отправить";
+"feedback_success" = "Спасибо за ваш отзыв!";
+"feedback_rate_limit" = "Подождите перед отправкой нового отзыва.";
+"feedback_error" = "Не удалось отправить отзыв. Попробуйте ещё раз.";

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		0361CD790E1AFC86D02CF4F6 /* FakeAudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2247BFD0D693E4041DAF16 /* FakeAudioController.swift */; };
 		0587ECB1D9436E518EF012E9 /* FakeAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F42A2D07ED2383049D7227F /* FakeAPIClient.swift */; };
 		0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = EA93F28D0C87ABED6B756036 /* Localizable.strings */; };
-		0DFE82331F5566B5EDA39486 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D479C87899A2276880ED95C6 /* GoogleService-Info.plist */; };
 		144C4C15F4B31D2E8AE8057A /* FakeSessionClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B88E3237E25D45BB2BD9B4 /* FakeSessionClock.swift */; };
 		169DFB9313A225EBD1962BFE /* BroadcastShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C9C837439E676ED7F04801 /* BroadcastShared.swift */; };
 		16ED701C50FCF1CF741D04F1 /* JoinRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */; };
@@ -59,6 +58,7 @@
 		AD701F4DE41EA9DFCC2125CE /* JoinScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */; };
 		B402B3581D8D647DC2D139A7 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
 		BC3AE1438258D205BFE66CD2 /* SerenadaiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */; };
+		BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */; };
 		C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */; };
 		C8363EE39A1335203566D71B /* RoomStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */; };
 		CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AA70D76623801E762E2DB /* ErrorScreen.swift */; };
@@ -188,11 +188,11 @@
 		C5849DCA4B2F1D0DD0411242 /* PushSubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushSubscriptionManager.swift; sourceTree = "<group>"; };
 		CC2247BFD0D693E4041DAF16 /* FakeAudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAudioController.swift; sourceTree = "<group>"; };
 		D0BE7FF0C166694E0F58114A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D479C87899A2276880ED95C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureResolutionSelectionTests.swift; sourceTree = "<group>"; };
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = Vendor/WebRTC/WebRTC.xcframework; sourceTree = "<group>"; };
+		E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -303,7 +303,6 @@
 		4C2BB5F4B1F4D2ED577B9AF6 = {
 			isa = PBXGroup;
 			children = (
-				D479C87899A2276880ED95C6 /* GoogleService-Info.plist */,
 				F86221F53AB93BC5BEEE7E9F /* BroadcastUpload */,
 				961901030B63AB715A9ED19C /* NotificationService */,
 				3DDC1D067C4415DBE46DAC91 /* Packages */,
@@ -364,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				D0BE7FF0C166694E0F58114A /* Assets.xcassets */,
+				E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */,
 				E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */,
 				EA93F28D0C87ABED6B756036 /* Localizable.strings */,
 			);
@@ -691,7 +691,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
-				0DFE82331F5566B5EDA39486 /* GoogleService-Info.plist in Resources */,
+				BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		51F5648F7D5B4883A8B13A8D /* WebRTC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5B73BDA93B3B03BE10F8F3DC /* DeepLinkParticipantCountUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE1FC71083746A8D257448 /* DeepLinkParticipantCountUITests.swift */; };
 		60DD419576BB73E40DC4D993 /* SignalingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */; };
+		6198802831401A13687DDCA9 /* FeedbackScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */; };
 		6E8767096E3E70790EB1CEE5 /* SessionNegotiationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */; };
 		6E92E404B6B3E0A636F21C56 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529A15EA2C43DB2F91F46FC /* RootView.swift */; };
 		6EE2ED9D63185C2AA8581CFE /* L10nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8656DA5A095E572174461E96 /* L10nTests.swift */; };
@@ -57,7 +58,6 @@
 		AD701F4DE41EA9DFCC2125CE /* JoinScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */; };
 		B402B3581D8D647DC2D139A7 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
 		BC3AE1438258D205BFE66CD2 /* SerenadaiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */; };
-		BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */; };
 		C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */; };
 		C8363EE39A1335203566D71B /* RoomStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */; };
 		CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AA70D76623801E762E2DB /* ErrorScreen.swift */; };
@@ -154,6 +154,7 @@
 		41E34F50FDC1E2F064028B68 /* SessionTestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTestHarness.swift; sourceTree = "<group>"; };
 		43E2F0452DE65337073894BF /* RecentCallStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCallStore.swift; sourceTree = "<group>"; };
 		461DCF4D9C695C2B6051BF91 /* FakeMediaEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMediaEngine.swift; sourceTree = "<group>"; };
+		47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackScreen.swift; sourceTree = "<group>"; };
 		4D4E0E538F82CE87BE4FDB24 /* SerenadaCallUI */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SerenadaCallUI; path = SerenadaCallUI; sourceTree = SOURCE_ROOT; };
 		4ECD8A5FB8E492716B9681E3 /* SavedRoomStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRoomStoreTests.swift; sourceTree = "<group>"; };
 		53E3B13DA44022026D9F605D /* SavedRoomStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRoomStore.swift; sourceTree = "<group>"; };
@@ -190,7 +191,6 @@
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = Vendor/WebRTC/WebRTC.xcframework; sourceTree = "<group>"; };
-		E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -361,7 +361,6 @@
 			isa = PBXGroup;
 			children = (
 				D0BE7FF0C166694E0F58114A /* Assets.xcassets */,
-				E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */,
 				E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */,
 				EA93F28D0C87ABED6B756036 /* Localizable.strings */,
 			);
@@ -415,6 +414,7 @@
 			children = (
 				96AD1035F89AEDD9E3B0F38C /* DiagnosticsScreen.swift */,
 				2D7AA70D76623801E762E2DB /* ErrorScreen.swift */,
+				47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */,
 				34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */,
 				6625E5E013BB38E369F98188 /* JoinWithCodeScreen.swift */,
 				018403014C9AEDF89B039618 /* SettingsScreen.swift */,
@@ -688,7 +688,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
-				BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -729,6 +728,7 @@
 				DABDC3CE432EA96C10798200 /* CallManager.swift in Sources */,
 				46722D2E3EFC8D06D8B51355 /* DiagnosticsScreen.swift in Sources */,
 				CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */,
+				6198802831401A13687DDCA9 /* FeedbackScreen.swift in Sources */,
 				AD701F4DE41EA9DFCC2125CE /* JoinScreen.swift in Sources */,
 				A3E593BBB26536974F9B5152 /* JoinSnapshotFeature.swift in Sources */,
 				252529C96E5D4B8966096E25 /* JoinWithCodeScreen.swift in Sources */,

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0361CD790E1AFC86D02CF4F6 /* FakeAudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2247BFD0D693E4041DAF16 /* FakeAudioController.swift */; };
 		0587ECB1D9436E518EF012E9 /* FakeAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F42A2D07ED2383049D7227F /* FakeAPIClient.swift */; };
 		0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = EA93F28D0C87ABED6B756036 /* Localizable.strings */; };
+		0DFE82331F5566B5EDA39486 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D479C87899A2276880ED95C6 /* GoogleService-Info.plist */; };
 		144C4C15F4B31D2E8AE8057A /* FakeSessionClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B88E3237E25D45BB2BD9B4 /* FakeSessionClock.swift */; };
 		169DFB9313A225EBD1962BFE /* BroadcastShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C9C837439E676ED7F04801 /* BroadcastShared.swift */; };
 		16ED701C50FCF1CF741D04F1 /* JoinRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */; };
@@ -187,6 +188,7 @@
 		C5849DCA4B2F1D0DD0411242 /* PushSubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushSubscriptionManager.swift; sourceTree = "<group>"; };
 		CC2247BFD0D693E4041DAF16 /* FakeAudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAudioController.swift; sourceTree = "<group>"; };
 		D0BE7FF0C166694E0F58114A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D479C87899A2276880ED95C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureResolutionSelectionTests.swift; sourceTree = "<group>"; };
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 		4C2BB5F4B1F4D2ED577B9AF6 = {
 			isa = PBXGroup;
 			children = (
+				D479C87899A2276880ED95C6 /* GoogleService-Info.plist */,
 				F86221F53AB93BC5BEEE7E9F /* BroadcastUpload */,
 				961901030B63AB715A9ED19C /* NotificationService */,
 				3DDC1D067C4415DBE46DAC91 /* Packages */,
@@ -688,6 +691,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
+				0DFE82331F5566B5EDA39486 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client-ios/Sources/App/RootView.swift
+++ b/client-ios/Sources/App/RootView.swift
@@ -35,6 +35,7 @@ struct RootView: View {
     @State private var showSettings = false
     @State private var showJoinWithCode = false
     @State private var showDiagnostics = false
+    @State private var showFeedback = false
 
     var body: some View {
         let uiState = callManager.uiState
@@ -141,6 +142,7 @@ struct RootView: View {
                 showJoinWithCode = false
                 showSettings = false
                 showDiagnostics = false
+                showFeedback = false
                 settingsSaveInProgress = false
                 settingsHostError = nil
                 roomInput = ""
@@ -157,6 +159,7 @@ struct RootView: View {
                     isHdVideoExperimentalEnabled: callManager.isHdVideoExperimentalEnabled,
                     areSavedRoomsShownFirst: callManager.areSavedRoomsShownFirst,
                     areRoomInviteNotificationsEnabled: callManager.areRoomInviteNotificationsEnabled,
+                    showFeedback: $showFeedback,
                     appVersion: callManager.appVersion,
                     hostError: settingsHostError,
                     isSaving: settingsSaveInProgress,
@@ -185,6 +188,14 @@ struct RootView: View {
                 }
                 .navigationDestination(isPresented: $showDiagnostics) {
                     DiagnosticsScreen(host: hostInput)
+                }
+                .navigationDestination(isPresented: $showFeedback) {
+                    FeedbackScreen(
+                        host: hostInput,
+                        appVersion: callManager.appVersion,
+                        locale: callManager.selectedLanguage,
+                        onDismiss: { showFeedback = false }
+                    )
                 }
             }
         }
@@ -230,6 +241,7 @@ struct RootView: View {
         settingsHostError = nil
         settingsSaveInProgress = false
         showDiagnostics = false
+        showFeedback = false
         showSettings = false
     }
 

--- a/client-ios/Sources/Core/Networking/APIClient.swift
+++ b/client-ios/Sources/Core/Networking/APIClient.swift
@@ -220,6 +220,31 @@ final class APIClient {
     }
 }
 
+    func submitFeedback(host: String, message: String, locale: String, appVersion: String) async throws -> Int {
+        guard let url = buildURL(host: host, path: "/api/feedback") else {
+            throw APIError.invalidHost
+        }
+
+        struct FeedbackPayload: Encodable {
+            let message: String
+            let platform: String
+            let locale: String
+            let version: String
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(FeedbackPayload(
+            message: message, platform: "ios", locale: locale, version: appVersion
+        ))
+
+        let (_, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        return statusCode
+    }
+}
+
 private struct PushSnapshotIDResponse: Codable {
     let id: String
 }

--- a/client-ios/Sources/Core/Networking/APIClient.swift
+++ b/client-ios/Sources/Core/Networking/APIClient.swift
@@ -218,7 +218,6 @@ final class APIClient {
             throw APIError.http("Push notify failed")
         }
     }
-}
 
     func submitFeedback(host: String, message: String, locale: String, appVersion: String) async throws -> Int {
         guard let url = buildURL(host: host, path: "/api/feedback") else {

--- a/client-ios/Sources/Core/Utils/L10n.swift
+++ b/client-ios/Sources/Core/Utils/L10n.swift
@@ -92,6 +92,14 @@ enum L10n {
     static var settingsAppVersion: String { text("settings_app_version") }
     static var settingsErrorInvalidServerHost: String { text("settings_error_invalid_server_host") }
 
+    static var feedbackTitle: String { text("feedback_title") }
+    static var feedbackSendAction: String { text("feedback_send_action") }
+    static var feedbackPlaceholder: String { text("feedback_placeholder") }
+    static var feedbackSend: String { text("feedback_send") }
+    static var feedbackSuccess: String { text("feedback_success") }
+    static var feedbackRateLimit: String { text("feedback_rate_limit") }
+    static var feedbackError: String { text("feedback_error") }
+
     static var errorSomethingWentWrong: String { text("error_something_went_wrong") }
     static var errorEnterRoomOrId: String { text("error_enter_room_or_id") }
     static var errorFailedCreateRoom: String { text("error_failed_create_room") }

--- a/client-ios/Sources/UI/Screens/FeedbackScreen.swift
+++ b/client-ios/Sources/UI/Screens/FeedbackScreen.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct FeedbackScreen: View {
+    let host: String
+    let appVersion: String
+    let locale: String
+    let onDismiss: () -> Void
+
+    @State private var message = ""
+    @State private var isSubmitting = false
+    @State private var resultMessage: String?
+    @State private var resultIsError = false
+
+    private let maxLength = 2000
+
+    var body: some View {
+        Form {
+            Section {
+                TextEditor(text: $message)
+                    .frame(minHeight: 120)
+                    .onChange(of: message) { newValue in
+                        if newValue.count > maxLength {
+                            message = String(newValue.prefix(maxLength))
+                        }
+                    }
+
+                HStack {
+                    Spacer()
+                    Text("\(message.count)/\(maxLength)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text(L10n.feedbackPlaceholder)
+            }
+
+            if let resultMessage {
+                Text(resultMessage)
+                    .font(.footnote)
+                    .foregroundStyle(resultIsError ? .red : .green)
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                if isSubmitting {
+                    ProgressView()
+                } else {
+                    Button(L10n.feedbackSend) {
+                        submitFeedback()
+                    }
+                    .disabled(message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .tint(.accentColor)
+                }
+            }
+        }
+        .navigationTitle(L10n.feedbackTitle)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func submitFeedback() {
+        isSubmitting = true
+        resultMessage = nil
+
+        Task {
+            do {
+                let statusCode = try await APIClient().submitFeedback(
+                    host: host,
+                    message: message.trimmingCharacters(in: .whitespacesAndNewlines),
+                    locale: locale,
+                    appVersion: appVersion
+                )
+
+                if statusCode == 429 {
+                    resultMessage = L10n.feedbackRateLimit
+                    resultIsError = true
+                } else if (200...299).contains(statusCode) {
+                    resultMessage = L10n.feedbackSuccess
+                    resultIsError = false
+                    try? await Task.sleep(nanoseconds: 800_000_000)
+                    onDismiss()
+                } else {
+                    resultMessage = L10n.feedbackError
+                    resultIsError = true
+                }
+            } catch {
+                resultMessage = L10n.feedbackError
+                resultIsError = true
+            }
+            isSubmitting = false
+        }
+    }
+}

--- a/client-ios/Sources/UI/Screens/SettingsScreen.swift
+++ b/client-ios/Sources/UI/Screens/SettingsScreen.swift
@@ -9,6 +9,7 @@ struct SettingsScreen: View {
     let isHdVideoExperimentalEnabled: Bool
     let areSavedRoomsShownFirst: Bool
     let areRoomInviteNotificationsEnabled: Bool
+    @Binding var showFeedback: Bool
     let appVersion: String
     let hostError: String?
     let isSaving: Bool
@@ -146,6 +147,20 @@ struct SettingsScreen: View {
                         Text(L10n.settingsInviteNotificationsInfo)
                             .font(.footnote)
                             .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section(L10n.feedbackTitle) {
+                Button {
+                    showFeedback = true
+                } label: {
+                    HStack {
+                        Label(L10n.feedbackSendAction, systemImage: "envelope")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tertiary)
                     }
                 }
             }

--- a/client-ios/project.yml
+++ b/client-ios/project.yml
@@ -31,9 +31,6 @@ targets:
       - path: Resources
         excludes:
           - Info.plist
-      - path: GoogleService-Info.plist
-        optional: true
-        buildPhase: resources
     info:
       path: Resources/Info.plist
       properties:

--- a/client-ios/project.yml
+++ b/client-ios/project.yml
@@ -31,6 +31,9 @@ targets:
       - path: Resources
         excludes:
           - Info.plist
+      - path: GoogleService-Info.plist
+        optional: true
+        buildPhase: resources
     info:
       path: Resources/Info.plist
       properties:

--- a/client/src/components/FeedbackDialog.tsx
+++ b/client/src/components/FeedbackDialog.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+import { useToast } from '../contexts/ToastContext';
+
+interface FeedbackDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const MAX_LENGTH = 2000;
+
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, onClose }) => {
+    const { t, i18n } = useTranslation();
+    const { showToast } = useToast();
+    const [message, setMessage] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+    const dialogRef = React.useRef<HTMLDivElement>(null);
+    const previousFocusedElementRef = React.useRef<HTMLElement | null>(null);
+    const titleId = React.useId();
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        previousFocusedElementRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const focusTimer = window.setTimeout(() => {
+            textareaRef.current?.focus();
+        }, 10);
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onClose();
+                return;
+            }
+            if (event.key !== 'Tab' || !dialogRef.current) return;
+
+            const focusableElements = Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                )
+            ).filter((el) => !el.hasAttribute('disabled'));
+            if (focusableElements.length === 0) {
+                event.preventDefault();
+                dialogRef.current.focus();
+                return;
+            }
+
+            const first = focusableElements[0];
+            const last = focusableElements[focusableElements.length - 1];
+
+            if (event.shiftKey) {
+                if (document.activeElement === first || !dialogRef.current.contains(document.activeElement)) {
+                    event.preventDefault();
+                    last.focus();
+                }
+                return;
+            }
+
+            if (document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.clearTimeout(focusTimer);
+            document.removeEventListener('keydown', handleKeyDown);
+            previousFocusedElementRef.current?.focus();
+            previousFocusedElementRef.current = null;
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmed = message.trim();
+        if (!trimmed || isSubmitting) return;
+
+        setIsSubmitting(true);
+        try {
+            const resp = await fetch('/api/feedback', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    message: trimmed,
+                    platform: 'web',
+                    locale: i18n.language,
+                    userAgent: navigator.userAgent,
+                }),
+            });
+
+            if (resp.status === 429) {
+                showToast('error', t('feedback_rate_limit'));
+            } else if (!resp.ok) {
+                showToast('error', t('feedback_error'));
+            } else {
+                showToast('success', t('feedback_success'));
+                setMessage('');
+                onClose();
+            }
+        } catch {
+            showToast('error', t('feedback_error'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div
+                ref={dialogRef}
+                className="modal-content"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                tabIndex={-1}
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="modal-header">
+                    <h3 id={titleId}>{t('feedback_title')}</h3>
+                    <button className="modal-close" onClick={onClose} aria-label={t('cancel')}>
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="modal-body">
+                    <div className="form-group" style={{ width: '100%' }}>
+                        <textarea
+                            ref={textareaRef}
+                            value={message}
+                            onChange={e => setMessage(e.target.value)}
+                            placeholder={t('feedback_placeholder')}
+                            maxLength={MAX_LENGTH}
+                            rows={5}
+                            style={{
+                                background: 'var(--bg-color)',
+                                border: '1px solid rgba(255, 255, 255, 0.2)',
+                                color: 'var(--text-primary)',
+                                padding: '0.75rem 1rem',
+                                borderRadius: '8px',
+                                fontSize: '1rem',
+                                width: '100%',
+                                boxSizing: 'border-box',
+                                resize: 'vertical',
+                                minHeight: '120px',
+                                fontFamily: 'inherit',
+                            }}
+                        />
+                        <p style={{ textAlign: 'right', margin: '4px 0 0' }}>
+                            {message.length}/{MAX_LENGTH}
+                        </p>
+                    </div>
+
+                    <div className="modal-footer">
+                        <button type="button" className="btn-secondary" onClick={onClose}>
+                            {t('cancel')}
+                        </button>
+                        <button type="submit" className="btn-primary" disabled={!message.trim() || isSubmitting}>
+                            {t('feedback_submit')}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Github, Activity, Download } from 'lucide-react';
+import { Github, Activity, Download, MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '../contexts/ToastContext';
+import { FeedbackDialog } from './FeedbackDialog';
 
 interface BeforeInstallPromptEvent extends Event {
     prompt: () => Promise<void>;
@@ -13,6 +14,7 @@ const Footer: React.FC = () => {
     const { showToast } = useToast();
     const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
     const [isStandalone, setIsStandalone] = useState(false);
+    const [showFeedback, setShowFeedback] = useState(false);
 
     useEffect(() => {
         const handler = (e: Event) => {
@@ -87,6 +89,11 @@ const Footer: React.FC = () => {
                     {t('footer_device_check')}
                 </a>
 
+                <button onClick={() => setShowFeedback(true)} className="footer-link">
+                    <MessageSquare className="icon" />
+                    {t('footer_feedback')}
+                </button>
+
                 {!isStandalone && (
                     <button onClick={handleInstall} className="footer-link">
                         <Download className="icon" />
@@ -98,6 +105,8 @@ const Footer: React.FC = () => {
             <p style={{ color: 'var(--text-secondary)', fontSize: '0.8rem', opacity: 0.6 }}>
                 &copy; {new Date().getFullYear()} Serenada. {t('benefit_opensource_title')}
             </p>
+
+            <FeedbackDialog isOpen={showFeedback} onClose={() => setShowFeedback(false)} />
         </footer>
     );
 };

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -84,7 +84,14 @@ const resources = {
             "remove": "Remove",
             "create": "Create",
             "save": "Save",
-            "cancel": "Cancel"
+            "cancel": "Cancel",
+            "footer_feedback": "Feedback",
+            "feedback_title": "Send Feedback",
+            "feedback_placeholder": "Describe your issue or suggestion...",
+            "feedback_submit": "Send",
+            "feedback_success": "Thank you for your feedback!",
+            "feedback_rate_limit": "Please wait before sending more feedback.",
+            "feedback_error": "Failed to send feedback. Please try again."
         }
     },
     ru: {
@@ -168,7 +175,14 @@ const resources = {
             "remove": "Удалить",
             "create": "Создать",
             "save": "Сохранить",
-            "cancel": "Отмена"
+            "cancel": "Отмена",
+            "footer_feedback": "Отзыв",
+            "feedback_title": "Отправить отзыв",
+            "feedback_placeholder": "Опишите проблему или предложение...",
+            "feedback_submit": "Отправить",
+            "feedback_success": "Спасибо за ваш отзыв!",
+            "feedback_rate_limit": "Подождите перед отправкой нового отзыва.",
+            "feedback_error": "Не удалось отправить отзыв. Попробуйте еще раз."
         }
     },
     es: {
@@ -252,7 +266,14 @@ const resources = {
             "remove": "Eliminar",
             "create": "Crear",
             "save": "Guardar",
-            "cancel": "Cancelar"
+            "cancel": "Cancelar",
+            "footer_feedback": "Comentarios",
+            "feedback_title": "Enviar comentarios",
+            "feedback_placeholder": "Describe tu problema o sugerencia...",
+            "feedback_submit": "Enviar",
+            "feedback_success": "¡Gracias por tus comentarios!",
+            "feedback_rate_limit": "Espera antes de enviar más comentarios.",
+            "feedback_error": "No se pudo enviar. Inténtalo de nuevo."
         }
     },
     fr: {
@@ -336,7 +357,14 @@ const resources = {
             "remove": "Supprimer",
             "create": "Créer",
             "save": "Enregistrer",
-            "cancel": "Annuler"
+            "cancel": "Annuler",
+            "footer_feedback": "Retour",
+            "feedback_title": "Envoyer un retour",
+            "feedback_placeholder": "Décrivez votre problème ou suggestion...",
+            "feedback_submit": "Envoyer",
+            "feedback_success": "Merci pour votre retour !",
+            "feedback_rate_limit": "Veuillez patienter avant d'envoyer un autre retour.",
+            "feedback_error": "Échec de l'envoi. Veuillez réessayer."
         }
     }
 };

--- a/server/feedback.go
+++ b/server/feedback.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type TelegramService struct {
@@ -88,7 +89,7 @@ func handleFeedback(tg *TelegramService) http.HandlerFunc {
 			http.Error(w, "Missing message", http.StatusBadRequest)
 			return
 		}
-		if len(msg) > 2000 {
+		if utf8.RuneCountInString(msg) > 2000 {
 			http.Error(w, "Message too long (max 2000 characters)", http.StatusBadRequest)
 			return
 		}
@@ -96,6 +97,7 @@ func handleFeedback(tg *TelegramService) http.HandlerFunc {
 		platform := strings.TrimSpace(req.Platform)
 		locale := strings.TrimSpace(req.Locale)
 		version := strings.TrimSpace(req.Version)
+		userAgent := strings.TrimSpace(req.UserAgent)
 
 		// Format the Telegram message
 		var sb strings.Builder
@@ -113,6 +115,9 @@ func handleFeedback(tg *TelegramService) http.HandlerFunc {
 			}
 			sb.WriteString(strings.Join(parts, " | "))
 			sb.WriteString("\n")
+		}
+		if userAgent != "" {
+			sb.WriteString("UA: " + userAgent + "\n")
 		}
 		sb.WriteString("---\n")
 		sb.WriteString(msg)

--- a/server/feedback.go
+++ b/server/feedback.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type TelegramService struct {
+	botToken   string
+	chatID     string
+	httpClient *http.Client
+}
+
+func initTelegramFromEnv() *TelegramService {
+	token := strings.TrimSpace(os.Getenv("TELEGRAM_BOT_TOKEN"))
+	chatID := strings.TrimSpace(os.Getenv("TELEGRAM_CHAT_ID"))
+	if token == "" || chatID == "" {
+		log.Printf("[FEEDBACK] Telegram not configured (set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID)")
+		return nil
+	}
+	log.Printf("[FEEDBACK] Telegram configured for chat %s", chatID)
+	return &TelegramService{
+		botToken: token,
+		chatID:   chatID,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (s *TelegramService) SendMessage(text string) error {
+	payload := map[string]string{
+		"chat_id": s.chatID,
+		"text":    text,
+	}
+	body, _ := json.Marshal(payload)
+
+	endpoint := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", s.botToken)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("telegram API returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+type FeedbackRequest struct {
+	Message   string `json:"message"`
+	Platform  string `json:"platform"`
+	Locale    string `json:"locale"`
+	Version   string `json:"version"`
+	UserAgent string `json:"userAgent"`
+}
+
+func handleFeedback(tg *TelegramService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req FeedbackRequest
+		if err := json.NewDecoder(io.LimitReader(r.Body, 8*1024)).Decode(&req); err != nil {
+			http.Error(w, "Invalid body", http.StatusBadRequest)
+			return
+		}
+
+		msg := strings.TrimSpace(req.Message)
+		if msg == "" {
+			http.Error(w, "Missing message", http.StatusBadRequest)
+			return
+		}
+		if len(msg) > 2000 {
+			http.Error(w, "Message too long (max 2000 characters)", http.StatusBadRequest)
+			return
+		}
+
+		platform := strings.TrimSpace(req.Platform)
+		locale := strings.TrimSpace(req.Locale)
+		version := strings.TrimSpace(req.Version)
+
+		// Format the Telegram message
+		var sb strings.Builder
+		sb.WriteString("Feedback from Serenada\n")
+		if platform != "" || locale != "" || version != "" {
+			parts := []string{}
+			if platform != "" {
+				parts = append(parts, "Platform: "+platform)
+			}
+			if locale != "" {
+				parts = append(parts, "Locale: "+locale)
+			}
+			if version != "" {
+				parts = append(parts, "v"+version)
+			}
+			sb.WriteString(strings.Join(parts, " | "))
+			sb.WriteString("\n")
+		}
+		sb.WriteString("---\n")
+		sb.WriteString(msg)
+		text := sb.String()
+
+		if tg != nil {
+			go func() {
+				if err := tg.SendMessage(text); err != nil {
+					log.Printf("[FEEDBACK] Telegram send failed: %v", err)
+				}
+			}()
+		} else {
+			log.Printf("[FEEDBACK] %s", text)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}
+}

--- a/server/feedback_test.go
+++ b/server/feedback_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleFeedback_ValidRequest(t *testing.T) {
+	handler := handleFeedback(nil) // nil telegram — just logs
+
+	body, _ := json.Marshal(FeedbackRequest{
+		Message:  "The camera freezes after 5 minutes",
+		Platform: "web",
+		Locale:   "en",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]bool
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !resp["ok"] {
+		t.Fatalf("expected ok=true")
+	}
+}
+
+func TestHandleFeedback_MissingMessage(t *testing.T) {
+	handler := handleFeedback(nil)
+
+	body, _ := json.Marshal(FeedbackRequest{
+		Message:  "",
+		Platform: "android",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFeedback_MessageTooLong(t *testing.T) {
+	handler := handleFeedback(nil)
+
+	body, _ := json.Marshal(FeedbackRequest{
+		Message:  strings.Repeat("a", 2001),
+		Platform: "ios",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFeedback_WrongMethod(t *testing.T) {
+	handler := handleFeedback(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/feedback", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleFeedback_InvalidJSON(t *testing.T) {
+	handler := handleFeedback(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/feedback", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -34,6 +34,9 @@ func main() {
 		log.Fatal("Failed to init push service: ", err)
 	}
 
+	// Initialize Telegram feedback service
+	telegramService := initTelegramFromEnv()
+
 	// Simple CORS middleware for API
 	enableCors := func(h http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +85,8 @@ func main() {
 	roomIDLimiter := NewIPLimiter(30.0/60.0, 10)
 	// Push: 10 requests per minute
 	pushLimiter := NewIPLimiter(10.0/60.0, 5)
+	// Feedback: 3 requests per minute
+	feedbackLimiter := NewIPLimiter(3.0/60.0, 3)
 
 	http.HandleFunc("/ws", rateLimitMiddleware(wsLimiter, func(w http.ResponseWriter, r *http.Request) {
 		if wsHang {
@@ -110,6 +115,9 @@ func main() {
 	http.HandleFunc("/api/push/notify", withTimeout(rateLimitMiddleware(pushLimiter, enableCors(handlePushNotify(hub))), 10*time.Second))
 	http.HandleFunc("/api/push/snapshot", withTimeout(rateLimitMiddleware(pushLimiter, enableCors(handlePushSnapshot)), 10*time.Second))
 	http.HandleFunc("/api/push/snapshot/", withTimeout(enableCors(handlePushSnapshot), 10*time.Second))
+
+	// Feedback Route
+	http.HandleFunc("/api/feedback", withTimeout(rateLimitMiddleware(feedbackLimiter, enableCors(handleFeedback(telegramService))), 10*time.Second))
 
 	http.HandleFunc("/device-check", withTimeout(handleDeviceCheck, 15*time.Second))
 

--- a/server/main.go
+++ b/server/main.go
@@ -117,7 +117,7 @@ func main() {
 	http.HandleFunc("/api/push/snapshot/", withTimeout(enableCors(handlePushSnapshot), 10*time.Second))
 
 	// Feedback Route
-	http.HandleFunc("/api/feedback", withTimeout(rateLimitMiddleware(feedbackLimiter, enableCors(handleFeedback(telegramService))), 10*time.Second))
+	http.HandleFunc("/api/feedback", withTimeout(enableCors(rateLimitMiddleware(feedbackLimiter, handleFeedback(telegramService))), 10*time.Second))
 
 	http.HandleFunc("/device-check", withTimeout(handleDeviceCheck, 15*time.Second))
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/feedback` server endpoint that forwards user-submitted feedback to a configured Telegram bot chat (fire-and-forget, with stdout fallback when unconfigured). Rate limited to 3 req/min per IP.
- Web: "Feedback" button in the footer opens a modal dialog with a textarea (2000 char limit), success/error toasts.
- Android: new "Feedback" section in Settings with an AlertDialog for composing and submitting feedback.
- iOS: new "Feedback" section in Settings navigating to a dedicated FeedbackScreen.
- All platforms include platform/locale/version metadata and are localized in en, ru, es, fr. Docs updated (README, CLAUDE.md, DEPLOY.md, .env.example).

## Test plan
- [ ] Start server locally, submit feedback from web client, verify Telegram message arrives (or stdout log if unconfigured)
- [ ] Submit 4 times rapidly — confirm 4th returns 429
- [ ] Verify Android Settings shows Feedback section, dialog submits successfully
- [ ] Verify iOS Settings shows Feedback section, FeedbackScreen submits successfully
- [ ] Run `cd server && go test ./...` — all pass
- [ ] Run `cd client && npm run build` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)