### PR TITLE
Fix bootstrap/validate gaps

### DIFF
--- a/tools/worktree-bootstrap.sh
+++ b/tools/worktree-bootstrap.sh
@@ -253,5 +253,5 @@ if [ "$FAILURES" -gt 0 ]; then
     exit 1
 else
     log_ok "Bootstrap complete"
-    log_info "Verify with: SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh $TARGET"
+    log_info "Verify with: SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh '${TARGET}'"
 fi

--- a/tools/worktree-bootstrap.sh
+++ b/tools/worktree-bootstrap.sh
@@ -33,14 +33,15 @@ die() { log_error "$@"; exit 1; }
 
 # --- Resolve paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Find the main working tree (first entry from `git worktree list`)
+# Find the main working tree (source for copying gitignored files)
 MAIN_REPO="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
 if [ -z "$MAIN_REPO" ] || [ ! -d "$MAIN_REPO" ]; then
-    MAIN_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+    MAIN_REPO="$DEFAULT_ROOT"
 fi
 
-TARGET="${1:-$MAIN_REPO}"
+TARGET="${1:-$DEFAULT_ROOT}"
 ORIGINAL_TARGET="$TARGET"
 if [[ "$TARGET" != /* ]]; then
     TARGET="$(cd "$TARGET" 2>/dev/null && pwd || true)"
@@ -68,6 +69,17 @@ if [ "${SKIP_ENV:-}" != "1" ]; then
     elif [ -f "$TARGET/.env.example" ]; then
         log_info "Creating .env from .env.example"
         cp "$TARGET/.env.example" "$TARGET/.env"
+        # Replace placeholder secrets with random values so validate won't warn
+        if command -v openssl >/dev/null 2>&1; then
+            for key in TURN_SECRET TURN_TOKEN_SECRET ROOM_ID_SECRET; do
+                NEW_VAL=$(openssl rand -hex 32)
+                sed -i.bak "s/^${key}=dev-.*/${key}=${NEW_VAL}/" "$TARGET/.env"
+            done
+            rm -f "$TARGET/.env.bak"
+            log_ok ".env secrets generated"
+        else
+            log_warn ".env created but contains placeholder secrets (openssl not found)"
+        fi
         record "env:from-example"
     else
         log_warn "No .env or .env.example found"
@@ -241,4 +253,5 @@ if [ "$FAILURES" -gt 0 ]; then
     exit 1
 else
     log_ok "Bootstrap complete"
+    log_info "Verify with: SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh $TARGET"
 fi

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -89,8 +89,8 @@ fi
 if [ "${SKIP_ENV:-}" = "1" ]; then
     check_skip ".env (SKIP_ENV=1)"
 elif [ -f "$TARGET/.env" ]; then
-    # Check for placeholder secrets
-    if grep -qE 'dev-secret|dev-room-id-secret|change-me' "$TARGET/.env" 2>/dev/null; then
+    # Check for placeholder secrets (ignore commented lines)
+    if grep -v '^\s*#' "$TARGET/.env" 2>/dev/null | grep -qE 'dev-secret|dev-room-id-secret|change-me'; then
         check_warn ".env exists but contains placeholder secrets"
     else
         check_pass ".env configured"

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -12,6 +12,8 @@
 #   SKIP_IOS=1       Skip iOS client checks
 #   SKIP_BUILD=1     Skip compilation checks (only verify deps/structure)
 #   SKIP_TEST=1      Skip test execution
+#   SKIP_ENV=1       Skip .env checks
+#   SKIP_DOCKER=1    Skip Docker checks
 #   VERBOSE=1        Show command output
 
 set -euo pipefail
@@ -84,7 +86,9 @@ else
 fi
 
 # .env
-if [ -f "$TARGET/.env" ]; then
+if [ "${SKIP_ENV:-}" = "1" ]; then
+    check_skip ".env (SKIP_ENV=1)"
+elif [ -f "$TARGET/.env" ]; then
     # Check for placeholder secrets
     if grep -qE 'dev-secret|dev-room-id-secret|change-me' "$TARGET/.env" 2>/dev/null; then
         check_warn ".env exists but contains placeholder secrets"
@@ -130,16 +134,9 @@ if [ "${SKIP_WEB:-}" = "1" ]; then
 else
     CLIENT="$TARGET/client"
 
-    # node_modules — auto-install if missing and npm is available
+    # node_modules
     if [ -d "$CLIENT/node_modules" ]; then
         check_pass "node_modules installed"
-    elif command -v npm >/dev/null 2>&1 && [ -f "$CLIENT/package.json" ]; then
-        log_info "node_modules missing — running npm ci..."
-        if (cd "$CLIENT" && run_quiet npm ci --no-audit --no-fund); then
-            check_pass "node_modules installed (auto)"
-        else
-            check_fail "node_modules missing and npm ci failed"
-        fi
     else
         check_fail "node_modules missing (run: cd client && npm install)"
     fi
@@ -313,6 +310,13 @@ else
         check_warn "Java not installed (needed for Gradle)"
     fi
 
+    # local.properties (gitignored — bootstrap copies from main repo)
+    if [ -f "$ANDROID/local.properties" ]; then
+        check_pass "local.properties present"
+    else
+        check_warn "local.properties missing (run: tools/worktree-bootstrap.sh)"
+    fi
+
     # Android SDK
     HAS_ANDROID_SDK=false
     if [ -n "${ANDROID_HOME:-}" ] && [ -d "$ANDROID_HOME" ]; then
@@ -404,6 +408,14 @@ else
         fi
     else
         check_warn "WebRTC.xcframework not found"
+    fi
+
+    # GoogleService-Info.plist (gitignored — bootstrap copies from main repo)
+    PLIST_PATH="$IOS/Resources/GoogleService-Info.plist"
+    if [ -f "$PLIST_PATH" ]; then
+        check_pass "GoogleService-Info.plist present"
+    else
+        check_warn "GoogleService-Info.plist missing (push notifications won't work)"
     fi
 
     # xcodebuild
@@ -534,20 +546,24 @@ fi
 echo ""
 echo -e "${BOLD}--- Docker ---${NC}"
 
-if [ -f "$TARGET/docker-compose.yml" ]; then
-    check_pass "docker-compose.yml present"
+if [ "${SKIP_DOCKER:-}" = "1" ]; then
+    check_skip "Docker (SKIP_DOCKER=1)"
 else
-    check_warn "docker-compose.yml missing"
-fi
-
-if command -v docker >/dev/null 2>&1; then
-    if docker info >/dev/null 2>&1; then
-        check_pass "Docker daemon running"
+    if [ -f "$TARGET/docker-compose.yml" ]; then
+        check_pass "docker-compose.yml present"
     else
-        check_warn "Docker installed but daemon not running"
+        check_warn "docker-compose.yml missing"
     fi
-else
-    check_warn "Docker not installed"
+
+    if command -v docker >/dev/null 2>&1; then
+        if docker info >/dev/null 2>&1; then
+            check_pass "Docker daemon running"
+        else
+            check_warn "Docker installed but daemon not running"
+        fi
+    else
+        check_warn "Docker not installed"
+    fi
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Bootstrap now targets the current checkout (not main repo), so worktrees actually get bootstrapped
- Generates real secrets when creating `.env` from `.env.example` instead of leaving placeholders
- Validate gains `SKIP_ENV` and `SKIP_DOCKER` options, plus checks for `local.properties` and `GoogleService-Info.plist`
- Removed web `node_modules` auto-install from validate — validate should validate, not repair
- Bootstrap prints a suggested validate command on success

## Test plan
- [x] `tools/worktree-bootstrap.sh` from worktree copies `.env`, `local.properties`, `GoogleService-Info.plist`
- [x] `SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh` passes with 0 failures after bootstrap
- [x] Full `tools/worktree-validate.sh` passes on main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)