### PR TITLE
Improve worktree bootstrap & validate scripts

### DIFF
--- a/tools/resolve-ios-simulator.sh
+++ b/tools/resolve-ios-simulator.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Resolve the best available iPhone simulator for testing.
+#
+# Outputs a tab-separated line:  UDID\tname\tOS
+#   e.g.  CA6FFD90-98C3-4580-BA33-11A912FC0BA9	iPhone 16	18.4
+#
+# Selection strategy:
+#   1. Prefer booted simulators (avoids cold-boot delay)
+#   2. Among equal boot state, pick the newest iOS runtime
+#   3. Among equal runtime, pick the highest-numbered iPhone model
+#
+# Override: set IOS_SIMULATOR_DEST="name|OS" (e.g. "iPhone 16|18.4")
+#           to skip auto-detection and use a specific simulator.
+#
+# Exits silently (no output) if no simulator is found.
+
+set -euo pipefail
+
+# Allow callers to override with a fixed "name|OS" pair.
+if [ -n "${IOS_SIMULATOR_DEST:-}" ]; then
+  SIM_NAME="${IOS_SIMULATOR_DEST%%|*}"
+  SIM_OS="${IOS_SIMULATOR_DEST##*|}"
+  # Resolve UDID for the overridden simulator.
+  if command -v xcrun >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    SIM_UDID=$(xcrun simctl list devices available -j 2>/dev/null \
+      | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+target_name, target_os = sys.argv[1], sys.argv[2]
+for runtime, devices in data.get('devices', {}).items():
+    m = re.search(r'iOS[.-](\d+)[.-](\d+)', runtime)
+    if not m:
+        continue
+    os_str = f'{m.group(1)}.{m.group(2)}'
+    if os_str != target_os:
+        continue
+    for d in devices:
+        if d.get('name') == target_name and d.get('isAvailable'):
+            print(d['udid'])
+            sys.exit(0)
+" "$SIM_NAME" "$SIM_OS" 2>/dev/null || true)
+    if [ -n "$SIM_UDID" ]; then
+      printf '%s\t%s\t%s\n' "$SIM_UDID" "$SIM_NAME" "$SIM_OS"
+      exit 0
+    fi
+  fi
+  # UDID not resolved but name+OS known — print without UDID so caller
+  # can fall back to name-based destination.
+  printf '\t%s\t%s\n' "$SIM_NAME" "$SIM_OS"
+  exit 0
+fi
+
+# Require xcrun and python3 for auto-detection.
+if ! command -v xcrun >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+xcrun simctl list devices available -j 2>/dev/null \
+  | python3 -c "
+import sys, json, re
+
+data = json.load(sys.stdin)
+candidates = []
+for runtime, devices in data.get('devices', {}).items():
+    m = re.search(r'iOS[.-](\d+)[.-](\d+)', runtime)
+    if not m:
+        continue
+    os_ver = (int(m.group(1)), int(m.group(2)))
+    for d in devices:
+        name = d.get('name', '')
+        if not name.startswith('iPhone') or not d.get('isAvailable', False):
+            continue
+        booted = 1 if d.get('state') == 'Booted' else 0
+        model_nums = [int(x) for x in re.findall(r'\d+', name)]
+        # Sort key: booted first, then newest OS, then highest model number
+        candidates.append((booted, os_ver, model_nums, d['udid'], name))
+
+if not candidates:
+    sys.exit(0)
+
+best = max(candidates)
+_, os_ver, _, udid, name = best
+print(f'{udid}\t{name}\t{os_ver[0]}.{os_ver[1]}')
+" 2>/dev/null || true

--- a/tools/run-sdk-tests.sh
+++ b/tools/run-sdk-tests.sh
@@ -57,55 +57,27 @@ fi
 
 # ── iOS SDK ──────────────────────────────────────────────────────────
 if [[ "${SKIP_IOS:-}" != "1" ]]; then
-  # Pick the best available iPhone simulator, outputting "name|OS" so we can
-  # build a precise xcodebuild destination (avoids OS:latest mismatch).
-  IOS_DEST="${IOS_SIMULATOR_DEST:-}"
-  if [[ -z "$IOS_DEST" ]]; then
-    IOS_DEST=$(xcrun simctl list devices available -j 2>/dev/null \
-      | python3 -c "
-import sys, json, re
-
-data = json.load(sys.stdin)
-# Collect (name, os_version) for every available iPhone
-candidates = []
-for runtime, devices in data.get('devices', {}).items():
-    # runtime looks like 'com.apple.CoreSimulator.SimRuntime.iOS-18-4'
-    m = re.search(r'iOS[.-](\d+)[.-](\d+)', runtime)
-    if not m:
-        continue
-    os_ver = (int(m.group(1)), int(m.group(2)))
-    for d in devices:
-        name = d.get('name', '')
-        if name.startswith('iPhone') and d.get('isAvailable', False):
-            candidates.append((name, os_ver))
-
-if not candidates:
-    sys.exit(0)
-
-# Prefer the newest iPhone on the newest iOS runtime
-def sort_key(item):
-    name, os_ver = item
-    nums = [int(x) for x in re.findall(r'\d+', name)]
-    return (os_ver, nums)
-
-best = max(candidates, key=sort_key)
-print(f'{best[0]}|{best[1][0]}.{best[1][1]}')
-" 2>/dev/null || true)
-  fi
-  if [[ -z "$IOS_DEST" ]]; then
+  IOS_SIM_LINE=$("$REPO_ROOT/tools/resolve-ios-simulator.sh" || true)
+  if [[ -z "$IOS_SIM_LINE" ]]; then
     echo "  ⚠ No available iPhone simulator found — skipping iOS tests"
     skipped+=("iOS SDK (no simulator)")
   else
-    IOS_SIM_NAME="${IOS_DEST%%|*}"
-    IOS_SIM_OS="${IOS_DEST##*|}"
+    IOS_SIM_UDID=$(echo "$IOS_SIM_LINE" | cut -f1)
+    IOS_SIM_NAME=$(echo "$IOS_SIM_LINE" | cut -f2)
+    IOS_SIM_OS=$(echo "$IOS_SIM_LINE" | cut -f3)
     echo "  Using simulator: $IOS_SIM_NAME (iOS $IOS_SIM_OS)"
+    if [[ -n "$IOS_SIM_UDID" ]]; then
+      IOS_XCODE_DEST="platform=iOS Simulator,id=$IOS_SIM_UDID"
+    else
+      IOS_XCODE_DEST="platform=iOS Simulator,name=$IOS_SIM_NAME,OS=$IOS_SIM_OS"
+    fi
     run_suite "iOS SDK" bash -c "
       cd '$REPO_ROOT/client-ios' &&
       xcodegen generate -q 2>/dev/null &&
       xcodebuild test \
         -project SerenadaiOS.xcodeproj \
         -scheme SerenadaiOS \
-        -destination 'platform=iOS Simulator,name=$IOS_SIM_NAME,OS=$IOS_SIM_OS' \
+        -destination '$IOS_XCODE_DEST' \
         -only-testing:SerenadaiOSTests \
         -quiet
     "

--- a/tools/worktree-bootstrap.sh
+++ b/tools/worktree-bootstrap.sh
@@ -33,14 +33,15 @@ die() { log_error "$@"; exit 1; }
 
 # --- Resolve paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Find the main working tree (first entry from `git worktree list`)
+# Find the main working tree (source for copying gitignored files)
 MAIN_REPO="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
 if [ -z "$MAIN_REPO" ] || [ ! -d "$MAIN_REPO" ]; then
-    MAIN_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+    MAIN_REPO="$DEFAULT_ROOT"
 fi
 
-TARGET="${1:-$MAIN_REPO}"
+TARGET="${1:-$DEFAULT_ROOT}"
 ORIGINAL_TARGET="$TARGET"
 if [[ "$TARGET" != /* ]]; then
     TARGET="$(cd "$TARGET" 2>/dev/null && pwd || true)"
@@ -68,6 +69,17 @@ if [ "${SKIP_ENV:-}" != "1" ]; then
     elif [ -f "$TARGET/.env.example" ]; then
         log_info "Creating .env from .env.example"
         cp "$TARGET/.env.example" "$TARGET/.env"
+        # Replace placeholder secrets with random values so validate won't warn
+        if command -v openssl >/dev/null 2>&1; then
+            for key in TURN_SECRET TURN_TOKEN_SECRET ROOM_ID_SECRET; do
+                NEW_VAL=$(openssl rand -hex 32)
+                sed -i.bak "s/^${key}=dev-.*/${key}=${NEW_VAL}/" "$TARGET/.env"
+            done
+            rm -f "$TARGET/.env.bak"
+            log_ok ".env secrets generated"
+        else
+            log_warn ".env created but contains placeholder secrets (openssl not found)"
+        fi
         record "env:from-example"
     else
         log_warn "No .env or .env.example found"
@@ -241,4 +253,5 @@ if [ "$FAILURES" -gt 0 ]; then
     exit 1
 else
     log_ok "Bootstrap complete"
+    log_info "Verify with: SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh '${TARGET}'"
 fi

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -12,6 +12,8 @@
 #   SKIP_IOS=1       Skip iOS client checks
 #   SKIP_BUILD=1     Skip compilation checks (only verify deps/structure)
 #   SKIP_TEST=1      Skip test execution
+#   SKIP_ENV=1       Skip .env checks
+#   SKIP_DOCKER=1    Skip Docker checks
 #   VERBOSE=1        Show command output
 
 set -euo pipefail
@@ -84,9 +86,11 @@ else
 fi
 
 # .env
-if [ -f "$TARGET/.env" ]; then
-    # Check for placeholder secrets
-    if grep -qE 'dev-secret|dev-room-id-secret|change-me' "$TARGET/.env" 2>/dev/null; then
+if [ "${SKIP_ENV:-}" = "1" ]; then
+    check_skip ".env (SKIP_ENV=1)"
+elif [ -f "$TARGET/.env" ]; then
+    # Check for placeholder secrets (ignore commented lines)
+    if grep -v '^\s*#' "$TARGET/.env" 2>/dev/null | grep -qE 'dev-secret|dev-room-id-secret|change-me'; then
         check_warn ".env exists but contains placeholder secrets"
     else
         check_pass ".env configured"
@@ -130,16 +134,9 @@ if [ "${SKIP_WEB:-}" = "1" ]; then
 else
     CLIENT="$TARGET/client"
 
-    # node_modules — auto-install if missing and npm is available
+    # node_modules
     if [ -d "$CLIENT/node_modules" ]; then
         check_pass "node_modules installed"
-    elif command -v npm >/dev/null 2>&1 && [ -f "$CLIENT/package.json" ]; then
-        log_info "node_modules missing — running npm ci..."
-        if (cd "$CLIENT" && run_quiet npm ci --no-audit --no-fund); then
-            check_pass "node_modules installed (auto)"
-        else
-            check_fail "node_modules missing and npm ci failed"
-        fi
     else
         check_fail "node_modules missing (run: cd client && npm install)"
     fi
@@ -313,6 +310,13 @@ else
         check_warn "Java not installed (needed for Gradle)"
     fi
 
+    # local.properties (gitignored — bootstrap copies from main repo)
+    if [ -f "$ANDROID/local.properties" ]; then
+        check_pass "local.properties present"
+    else
+        check_warn "local.properties missing (run: tools/worktree-bootstrap.sh)"
+    fi
+
     # Android SDK
     HAS_ANDROID_SDK=false
     if [ -n "${ANDROID_HOME:-}" ] && [ -d "$ANDROID_HOME" ]; then
@@ -404,6 +408,14 @@ else
         fi
     else
         check_warn "WebRTC.xcframework not found"
+    fi
+
+    # GoogleService-Info.plist (gitignored — bootstrap copies from main repo)
+    PLIST_PATH="$IOS/Resources/GoogleService-Info.plist"
+    if [ -f "$PLIST_PATH" ]; then
+        check_pass "GoogleService-Info.plist present"
+    else
+        check_warn "GoogleService-Info.plist missing (push notifications won't work)"
     fi
 
     # xcodebuild
@@ -534,20 +546,24 @@ fi
 echo ""
 echo -e "${BOLD}--- Docker ---${NC}"
 
-if [ -f "$TARGET/docker-compose.yml" ]; then
-    check_pass "docker-compose.yml present"
+if [ "${SKIP_DOCKER:-}" = "1" ]; then
+    check_skip "Docker (SKIP_DOCKER=1)"
 else
-    check_warn "docker-compose.yml missing"
-fi
-
-if command -v docker >/dev/null 2>&1; then
-    if docker info >/dev/null 2>&1; then
-        check_pass "Docker daemon running"
+    if [ -f "$TARGET/docker-compose.yml" ]; then
+        check_pass "docker-compose.yml present"
     else
-        check_warn "Docker installed but daemon not running"
+        check_warn "docker-compose.yml missing"
     fi
-else
-    check_warn "Docker not installed"
+
+    if command -v docker >/dev/null 2>&1; then
+        if docker info >/dev/null 2>&1; then
+            check_pass "Docker daemon running"
+        else
+            check_warn "Docker installed but daemon not running"
+        fi
+    else
+        check_warn "Docker not installed"
+    fi
 fi
 
 # ============================================================

--- a/tools/worktree-validate.sh
+++ b/tools/worktree-validate.sh
@@ -413,47 +413,22 @@ else
         check_warn "xcodebuild not found"
     fi
 
-    # Resolve a simulator destination — try several iPhone models, prefer booted ones
+    # Resolve a simulator destination using the shared helper
     IOS_SIM_ID=""
     IOS_SIM_NAME=""
-    if command -v xcrun >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
-        IOS_SIM_LINE=$(xcrun simctl list devices available -j 2>/dev/null \
-            | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-# Preferred device names in order — pick first available, preferring booted
-preferred = ['iPhone 16', 'iPhone 16 Pro', 'iPhone 15', 'iPhone 15 Pro', 'iPhone 14']
-best = None
-for runtime, devices in data.get('devices', {}).items():
-    if 'iOS' not in runtime:
-        continue
-    for d in devices:
-        if not d.get('isAvailable'):
-            continue
-        name = d.get('name', '')
-        try:
-            rank = preferred.index(name)
-        except ValueError:
-            # Accept any iPhone as a last resort
-            if 'iPhone' in name:
-                rank = len(preferred)
-            else:
-                continue
-        booted = 1 if d.get('state') != 'Booted' else 0
-        candidate = (rank, booted, d['udid'], name)
-        if best is None or candidate < best:
-            best = candidate
-if best:
-    # Tab-separated so shell can split udid from multi-word name
-    print(best[2] + '\t' + best[3])
-" 2>/dev/null || true)
+    IOS_SIM_OS=""
+    RESOLVE_SCRIPT="$SCRIPT_DIR/resolve-ios-simulator.sh"
+    if [ -x "$RESOLVE_SCRIPT" ]; then
+        IOS_SIM_LINE=$("$RESOLVE_SCRIPT" || true)
         if [ -n "$IOS_SIM_LINE" ]; then
-            IFS=$'\t' read -r IOS_SIM_ID IOS_SIM_NAME <<< "$IOS_SIM_LINE"
+            IOS_SIM_ID=$(echo "$IOS_SIM_LINE" | cut -f1)
+            IOS_SIM_NAME=$(echo "$IOS_SIM_LINE" | cut -f2)
+            IOS_SIM_OS=$(echo "$IOS_SIM_LINE" | cut -f3)
         fi
     fi
 
-    # Fallback when python3 is unavailable: use name-based destination
-    if [ -z "$IOS_SIM_ID" ] && command -v xcrun >/dev/null 2>&1; then
+    # Fallback when resolve script is unavailable: use name-based destination
+    if [ -z "$IOS_SIM_ID" ] && [ -z "$IOS_SIM_NAME" ] && command -v xcrun >/dev/null 2>&1; then
         IOS_SIM_NAME="iPhone 16"
     fi
 


### PR DESCRIPTION
## Summary
- **worktree-bootstrap.sh**: Fix default target to use repo root (not main worktree), auto-generate random secrets from `.env.example` via openssl, add post-bootstrap verify hint
- **worktree-validate.sh**: Add `SKIP_ENV` and `SKIP_DOCKER` flags, ignore commented lines when checking placeholder secrets, remove auto-install side effect from validate, add `local.properties` and `GoogleService-Info.plist` checks, extract simulator resolution to shared `resolve-ios-simulator.sh` helper
- **resolve-ios-simulator.sh**: New shared helper for iOS simulator selection (used by validate and run-sdk-tests)
- **run-sdk-tests.sh**: Use shared `resolve-ios-simulator.sh` instead of inline logic

## Test plan
- [ ] Run `tools/worktree-bootstrap.sh` on a fresh worktree — verify `.env` gets generated secrets
- [ ] Run `SKIP_BUILD=1 SKIP_TEST=1 tools/worktree-validate.sh` — verify structure checks pass
- [ ] Run `tools/worktree-validate.sh` with `SKIP_ENV=1` and `SKIP_DOCKER=1` — verify sections are skipped
- [ ] Verify `tools/resolve-ios-simulator.sh` returns a valid simulator on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)