### PR TITLE
Add proximityMonitoringEnabled SDK config (off by default)

### DIFF
--- a/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
+++ b/client-android/app/src/main/java/app/serenada/android/call/CallManager.kt
@@ -145,6 +145,7 @@ class CallManager(context: Context) : RoomWatcherDelegate {
                 defaultVideoEnabled = settingsStore.isDefaultCameraEnabled,
                 isHdVideoExperimentalEnabled = settingsStore.isHdVideoExperimentalEnabled,
                 transports = transports,
+                proximityMonitoringEnabled = true,
             ),
             context = appContext,
         )

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaConfig.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaConfig.kt
@@ -16,6 +16,8 @@ data class SerenadaConfig(
     val isHdVideoExperimentalEnabled: Boolean = false,
     /** Preferred signaling transports in priority order (default: WS then SSE). */
     val transports: List<SerenadaTransport> = listOf(SerenadaTransport.WS, SerenadaTransport.SSE),
+    /** Whether the proximity sensor is used to switch audio to the earpiece and pause video (default false). */
+    val proximityMonitoringEnabled: Boolean = false,
 )
 
 /** Available signaling transport types. */

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -324,6 +324,7 @@ class SerenadaSession internal constructor(
     private val callAudioSessionController: SessionAudioController = audioController ?: CallAudioSessionController(
         context = appContext,
         handler = handler,
+        proximityMonitoringEnabled = config.proximityMonitoringEnabled,
         onProximityChanged = { near ->
             logger?.log(SerenadaLogLevel.DEBUG, "Session", "Proximity sensor changed: ${if (near) "NEAR" else "FAR"}")
         },

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CallAudioSessionController.kt
@@ -18,6 +18,7 @@ import app.serenada.core.SerenadaLogger
 internal class CallAudioSessionController(
     context: Context,
     private val handler: Handler,
+    private val proximityMonitoringEnabled: Boolean,
     private val onProximityChanged: (Boolean) -> Unit,
     private val onAudioEnvironmentChanged: () -> Unit,
     private val logger: SerenadaLogger? = null,
@@ -78,7 +79,9 @@ internal class CallAudioSessionController(
             audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
             audioManager.isMicrophoneMute = false
             startAudioDeviceMonitoring()
-            startProximityMonitoring()
+            if (proximityMonitoringEnabled) {
+                startProximityMonitoring()
+            }
             applyCallAudioRouting()
             onAudioEnvironmentChanged()
         }.onSuccess {

--- a/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
@@ -50,8 +50,9 @@ internal final class CallAudioSessionController: SessionAudioController {
             logger?.log(.error, tag: "Audio", "failed to activate audio session: \(error)")
         }
 
+        startAudioRouteMonitoring()
         if proximityMonitoringEnabled {
-            startMonitoring()
+            startProximityMonitoring()
         }
         applyCallAudioRouting()
         onAudioEnvironmentChanged()
@@ -59,12 +60,13 @@ internal final class CallAudioSessionController: SessionAudioController {
 
     public func deactivate() {
         guard audioSessionActive else {
-            stopMonitoring()
+            stopProximityMonitoring()
             return
         }
 
         audioSessionActive = false
-        stopMonitoring()
+        stopAudioRouteMonitoring()
+        stopProximityMonitoring()
 
         do {
             try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
@@ -77,15 +79,21 @@ internal final class CallAudioSessionController: SessionAudioController {
         proximityMonitoringActive && isProximityNear && !isScreenSharing && !isBluetoothHeadsetConnected()
     }
 
-    private func startMonitoring() {
-        guard !proximityMonitoringActive else { return }
-
+    private func startAudioRouteMonitoring() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAudioRouteChange(_:)),
             name: AVAudioSession.routeChangeNotification,
             object: nil
         )
+    }
+
+    private func stopAudioRouteMonitoring() {
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
+    }
+
+    private func startProximityMonitoring() {
+        guard !proximityMonitoringActive else { return }
 
         UIDevice.current.isProximityMonitoringEnabled = true
         NotificationCenter.default.addObserver(
@@ -99,13 +107,12 @@ internal final class CallAudioSessionController: SessionAudioController {
         isProximityNear = UIDevice.current.proximityState
     }
 
-    private func stopMonitoring() {
+    private func stopProximityMonitoring() {
         guard proximityMonitoringActive else {
             isProximityNear = false
             return
         }
 
-        NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIDevice.proximityStateDidChangeNotification, object: nil)
 
         UIDevice.current.isProximityMonitoringEnabled = false

--- a/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CallAudioSessionController.swift
@@ -7,6 +7,7 @@ internal final class CallAudioSessionController: SessionAudioController {
     private var onProximityChanged: (Bool) -> Void
     private var onAudioEnvironmentChanged: () -> Void
     private let logger: SerenadaLogger?
+    private let proximityMonitoringEnabled: Bool
 
     private let audioSession = AVAudioSession.sharedInstance()
 
@@ -15,10 +16,12 @@ internal final class CallAudioSessionController: SessionAudioController {
     private var isProximityNear = false
 
     public init(
+        proximityMonitoringEnabled: Bool,
         onProximityChanged: @escaping (Bool) -> Void,
         onAudioEnvironmentChanged: @escaping () -> Void,
         logger: SerenadaLogger? = nil
     ) {
+        self.proximityMonitoringEnabled = proximityMonitoringEnabled
         self.onProximityChanged = onProximityChanged
         self.onAudioEnvironmentChanged = onAudioEnvironmentChanged
         self.logger = logger
@@ -47,7 +50,9 @@ internal final class CallAudioSessionController: SessionAudioController {
             logger?.log(.error, tag: "Audio", "failed to activate audio session: \(error)")
         }
 
-        startMonitoring()
+        if proximityMonitoringEnabled {
+            startMonitoring()
+        }
         applyCallAudioRouting()
         onAudioEnvironmentChanged()
     }
@@ -95,6 +100,11 @@ internal final class CallAudioSessionController: SessionAudioController {
     }
 
     private func stopMonitoring() {
+        guard proximityMonitoringActive else {
+            isProximityNear = false
+            return
+        }
+
         NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIDevice.proximityStateDidChangeNotification, object: nil)
 

--- a/client-ios/SerenadaCore/Sources/SerenadaConfig.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaConfig.swift
@@ -23,19 +23,24 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
     public var defaultVideoEnabled: Bool
     /// Preferred signaling transports in priority order. Defaults to `[.ws, .sse]`.
     public var transports: [SerenadaTransport]
+    /// Whether the proximity sensor is used to switch audio to the earpiece and pause video.
+    /// Defaults to `false`.
+    public var proximityMonitoringEnabled: Bool
 
     public init(
         serverHost: String? = nil,
         signalingProvider: SignalingProvider? = nil,
         defaultAudioEnabled: Bool = true,
         defaultVideoEnabled: Bool = true,
-        transports: [SerenadaTransport] = [.ws, .sse]
+        transports: [SerenadaTransport] = [.ws, .sse],
+        proximityMonitoringEnabled: Bool = false
     ) {
         self.serverHost = serverHost
         self.signalingProvider = signalingProvider
         self.defaultAudioEnabled = defaultAudioEnabled
         self.defaultVideoEnabled = defaultVideoEnabled
         self.transports = transports
+        self.proximityMonitoringEnabled = proximityMonitoringEnabled
     }
 
     public static func == (lhs: SerenadaConfig, rhs: SerenadaConfig) -> Bool {
@@ -43,6 +48,7 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
             && lhs.defaultAudioEnabled == rhs.defaultAudioEnabled
             && lhs.defaultVideoEnabled == rhs.defaultVideoEnabled
             && lhs.transports == rhs.transports
+            && lhs.proximityMonitoringEnabled == rhs.proximityMonitoringEnabled
             && haveSameProvider(lhs.signalingProvider, rhs.signalingProvider)
     }
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -71,7 +71,8 @@ public final class SerenadaCore {
                 signalingProvider: nil,
                 defaultAudioEnabled: config.defaultAudioEnabled,
                 defaultVideoEnabled: config.defaultVideoEnabled,
-                transports: config.transports
+                transports: config.transports,
+                proximityMonitoringEnabled: config.proximityMonitoringEnabled
             )
         } else {
             sessionConfig = config

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -184,7 +184,8 @@ public final class SerenadaSession: ObservableObject {
                 signalingProvider: nil,
                 defaultAudioEnabled: config.defaultAudioEnabled,
                 defaultVideoEnabled: config.defaultVideoEnabled,
-                transports: config.transports
+                transports: config.transports,
+                proximityMonitoringEnabled: config.proximityMonitoringEnabled
             )
             : config
         self.init(

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -240,6 +240,7 @@ public final class SerenadaSession: ObservableObject {
         }
         self.providerDelegateProxy = SignalingProviderDelegateProxy(session: nil)
         self.callAudioSessionController = audioController ?? CallAudioSessionController(
+            proximityMonitoringEnabled: config.proximityMonitoringEnabled,
             onProximityChanged: { _ in }, onAudioEnvironmentChanged: {}, logger: logger
         )
         self.webRtcEngine = mediaEngine ?? WebRtcEngine(

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -387,7 +387,8 @@ final class CallManager: ObservableObject {
             config: SerenadaConfig(
                 serverHost: host,
                 defaultAudioEnabled: settingsStore.isDefaultMicrophoneEnabled,
-                defaultVideoEnabled: settingsStore.isDefaultCameraEnabled
+                defaultVideoEnabled: settingsStore.isDefaultCameraEnabled,
+                proximityMonitoringEnabled: true
             )
         )
         core.logger = PrintSerenadaLogger()


### PR DESCRIPTION
## Summary
- Adds `proximityMonitoringEnabled` to `SerenadaConfig` on both iOS and Android (defaults to `false`)
- When disabled, proximity sensor is not registered — no earpiece switching or video pausing on face-near
- Host apps explicitly pass `true` to preserve existing behavior; third-party integrators get it off by default
- Fixes iOS `stopMonitoring()` to guard on `proximityMonitoringActive` before tearing down, matching Android's pattern

## Test plan
- [ ] Verify proximity sensor works on iOS host app (earpiece switch + video pause on face-near)
- [ ] Verify proximity sensor works on Android host app
- [ ] Verify sample apps build without passing the new param (defaults to off)
- [ ] Verify no proximity side effects when `proximityMonitoringEnabled = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)