### PR TITLE
Resilience Phase 1: identity, tombstones, epoch, dirty-pair, content-state

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/CallError.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/CallError.kt
@@ -9,6 +9,13 @@ sealed class CallError {
     object ConnectionFailed : CallError()
     object RoomFull : CallError()
     object RoomEnded : CallError()
+    /**
+     * The persisted reconnect credential is no longer valid (expired or
+     * rejected). The SDK must clear stored reconnect state and surface a
+     * dedicated terminal error so the host app can route the user back to
+     * a fresh start instead of looping reconnects.
+     */
+    object SessionExpired : CallError()
     object PermissionDenied : CallError()
     data class ServerError(val message: String) : CallError()
     data class Unknown(val message: String) : CallError()
@@ -19,6 +26,7 @@ sealed class CallError {
         is ConnectionFailed -> "Connection failed"
         is RoomFull -> "Room is full"
         is RoomEnded -> "Call ended"
+        is SessionExpired -> "Session expired"
         is PermissionDenied -> "Permission denied"
         is ServerError -> message
         is Unknown -> message

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -1,6 +1,8 @@
 package app.serenada.core
 
 import android.os.Handler
+import app.serenada.core.call.Participant
+import app.serenada.core.call.ReconnectOutcome
 import app.serenada.core.call.SessionSignaling
 import app.serenada.core.call.SignalingClient
 import app.serenada.core.call.SignalingMessage
@@ -182,9 +184,16 @@ internal class SerenadaServerProvider(
             }
             "error" -> {
                 message.payload.toErrorPayload()?.let { payload ->
+                    val code = payload.code ?: "UNKNOWN"
+                    // Terminal codes that invalidate persisted reconnect
+                    // authority. Drop the stored token so a future join can
+                    // not try to reclaim the (gone) slot.
+                    if (code == "ROOM_ENDED" || code == "INVALID_RECONNECT_TOKEN") {
+                        clearReconnect()
+                    }
                     listener?.onError(
                         ErrorEvent(
-                            code = payload.code ?: "UNKNOWN",
+                            code = code,
                             message = payload.message ?: "Unknown error",
                         )
                     )
@@ -222,16 +231,7 @@ internal class SerenadaServerProvider(
         currentHostPeerId = payload.hostCid
         currentTurnToken = payload.turnToken
         payload.turnTokenTTLMs?.let { scheduleTurnRefresh(it) } ?: clearTurnRefresh()
-        val participants = payload.participants.map { participant ->
-            SignalingProviderParticipant(
-                peerId = participant.cid,
-                joinedAt = participant.joinedAt,
-                displayName = participant.displayName,
-                audioEnabled = participant.audioEnabled,
-                videoEnabled = participant.videoEnabled,
-                connectionStatus = participant.signalingStatus,
-            )
-        }
+        val participants = payload.participants.map { it.toProviderParticipant() }
         previousParticipants = linkedMapOf<String, SignalingProviderParticipant>().apply {
             participants.forEach { put(it.peerId, it) }
         }
@@ -241,6 +241,8 @@ internal class SerenadaServerProvider(
                 participants = participants,
                 hostPeerId = payload.hostCid,
                 maxParticipants = payload.maxParticipants,
+                epoch = payload.epoch,
+                reconnectOutcome = payload.reconnect.toProviderOutcome(),
             )
         )
     }
@@ -248,16 +250,7 @@ internal class SerenadaServerProvider(
     private fun handleRoomState(message: SignalingMessage) {
         val payload = message.payload.toRoomStatePayload() ?: return
         currentHostPeerId = payload.hostCid
-        val participants = payload.participants.map { participant ->
-            SignalingProviderParticipant(
-                peerId = participant.cid,
-                joinedAt = participant.joinedAt,
-                displayName = participant.displayName,
-                audioEnabled = participant.audioEnabled,
-                videoEnabled = participant.videoEnabled,
-                connectionStatus = participant.signalingStatus,
-            )
-        }
+        val participants = payload.participants.map { it.toProviderParticipant() }
         emitParticipantDiffs(participants)
         previousParticipants = linkedMapOf<String, SignalingProviderParticipant>().apply {
             participants.forEach { put(it.peerId, it) }
@@ -267,8 +260,34 @@ internal class SerenadaServerProvider(
                 participants = participants,
                 hostPeerId = payload.hostCid,
                 maxParticipants = payload.maxParticipants,
+                epoch = payload.epoch,
             )
         )
+    }
+
+    private fun Participant.toProviderParticipant(): SignalingProviderParticipant =
+        SignalingProviderParticipant(
+            peerId = cid,
+            joinedAt = joinedAt,
+            displayName = displayName,
+            audioEnabled = audioEnabled,
+            videoEnabled = videoEnabled,
+            connectionStatus = signalingStatus,
+            contentState = contentState?.let {
+                SignalingProviderParticipantContentState(
+                    active = it.active,
+                    contentType = it.contentType,
+                    updatedAtMs = it.updatedAtMs,
+                    epoch = it.epoch,
+                )
+            },
+        )
+
+    private fun ReconnectOutcome?.toProviderOutcome(): JoinReconnectOutcome? = when (this) {
+        ReconnectOutcome.FRESH -> JoinReconnectOutcome.FRESH
+        ReconnectOutcome.REATTACHED -> JoinReconnectOutcome.REATTACHED
+        ReconnectOutcome.RECOVERED -> JoinReconnectOutcome.RECOVERED
+        null -> null
     }
 
     private fun emitParticipantDiffs(participants: List<SignalingProviderParticipant>) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
@@ -25,6 +25,13 @@ data class JoinOptions(
  */
 enum class ParticipantSignalingStatus { ACTIVE, SUSPENDED }
 
+data class SignalingProviderParticipantContentState(
+    val active: Boolean,
+    val contentType: String? = null,
+    val updatedAtMs: Long? = null,
+    val epoch: Long? = null,
+)
+
 data class SignalingProviderParticipant(
     val peerId: String,
     val joinedAt: Long? = null,
@@ -32,19 +39,33 @@ data class SignalingProviderParticipant(
     val audioEnabled: Boolean? = null,
     val videoEnabled: Boolean? = null,
     val connectionStatus: ParticipantSignalingStatus = ParticipantSignalingStatus.ACTIVE,
+    val contentState: SignalingProviderParticipantContentState? = null,
 )
+
+/**
+ * Disposition of a join, surfaced by the server in `joined.reconnect`.
+ * Drives whether the SDK preserves media-active peer connections,
+ * schedules dirty-pair renegotiation, or starts ground-up.
+ */
+enum class JoinReconnectOutcome { FRESH, REATTACHED, RECOVERED }
 
 data class JoinedEvent(
     val peerId: String,
     val participants: List<SignalingProviderParticipant>,
     val hostPeerId: String? = null,
     val maxParticipants: Int? = null,
+    /** Server room-state epoch on this transport; monotonic per room. */
+    val epoch: Long? = null,
+    /** How the server treated this join. Null means an older provider that did not surface this field. */
+    val reconnectOutcome: JoinReconnectOutcome? = null,
 )
 
 data class RoomStateEvent(
     val participants: List<SignalingProviderParticipant>,
     val hostPeerId: String? = null,
     val maxParticipants: Int? = null,
+    /** Server room-state epoch on this transport; monotonic per room. */
+    val epoch: Long? = null,
 )
 
 data class PeerEvent(

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/RoomState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/RoomState.kt
@@ -6,6 +6,12 @@ internal data class RoomState(
     val hostCid: String,
     val participants: List<Participant>,
     val maxParticipants: Int? = null,
+    /**
+     * Server room-state epoch. Monotonic per room. SDKs gate ICE restart on
+     * receiving an authoritative post-reconnect snapshot, instead of acting
+     * on a stale in-memory peer map.
+     */
+    val epoch: Long? = null,
 )
 
 internal data class Participant(
@@ -15,4 +21,36 @@ internal data class Participant(
     val audioEnabled: Boolean? = null,
     val videoEnabled: Boolean? = null,
     val signalingStatus: ParticipantSignalingStatus = ParticipantSignalingStatus.ACTIVE,
+    /**
+     * Latest ephemeral content metadata for this participant (screen share,
+     * content camera mode). Stored on the server's participant record so a
+     * peer reconnecting after a suspension can reconstruct UI without
+     * waiting for the sender to toggle again.
+     */
+    val contentState: ParticipantContentState? = null,
 )
+
+internal data class ParticipantContentState(
+    val active: Boolean,
+    val contentType: String? = null,
+    val updatedAtMs: Long? = null,
+    val epoch: Long? = null,
+)
+
+/**
+ * Disposition of a join, surfaced by the server in `joined.reconnect`.
+ * Drives whether the SDK preserves media-active peer connections,
+ * schedules dirty-pair renegotiation, or starts ground-up.
+ */
+internal enum class ReconnectOutcome {
+    FRESH, REATTACHED, RECOVERED;
+
+    companion object {
+        fun fromWireValue(value: String?): ReconnectOutcome? = when (value) {
+            "fresh" -> FRESH
+            "reattached" -> REATTACHED
+            "recovered" -> RECOVERED
+            else -> null
+        }
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
@@ -157,6 +157,7 @@ internal class SignalingMessageRouter(
             "CONNECTION_FAILED" -> CallError.ConnectionFailed
             "JOIN_TIMEOUT" -> CallError.SignalingTimeout
             "ROOM_ENDED" -> CallError.RoomEnded
+            "INVALID_RECONNECT_TOKEN" -> CallError.SessionExpired
             else -> if (event.message.isNotBlank()) CallError.ServerError(event.message)
             else CallError.Unknown("Unknown error")
         }
@@ -201,6 +202,7 @@ internal class SignalingMessageRouter(
             "CONNECTION_FAILED" -> CallError.ConnectionFailed
             "JOIN_TIMEOUT" -> CallError.SignalingTimeout
             "ROOM_ENDED" -> CallError.RoomEnded
+            "INVALID_RECONNECT_TOKEN" -> CallError.SessionExpired
             else -> if (payload?.message != null) CallError.ServerError(payload.message)
             else CallError.Unknown("Unknown error")
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
@@ -152,16 +152,7 @@ internal class SignalingMessageRouter(
 
     fun processErrorEvent(event: ErrorEvent) {
         assertMainThread()
-        val callError = when (event.code) {
-            "ROOM_CAPACITY_UNSUPPORTED", "ROOM_FULL" -> CallError.RoomFull
-            "CONNECTION_FAILED" -> CallError.ConnectionFailed
-            "JOIN_TIMEOUT" -> CallError.SignalingTimeout
-            "ROOM_ENDED" -> CallError.RoomEnded
-            "INVALID_RECONNECT_TOKEN" -> CallError.SessionExpired
-            else -> if (event.message.isNotBlank()) CallError.ServerError(event.message)
-            else CallError.Unknown("Unknown error")
-        }
-        onError(callError)
+        onError(mapError(event.code, event.message))
     }
 
     // --- Private handlers ---
@@ -197,16 +188,17 @@ internal class SignalingMessageRouter(
 
     private fun handleError(msg: SignalingMessage) {
         val payload = msg.payload.toErrorPayload()
-        val callError = when (payload?.code) {
-            "ROOM_CAPACITY_UNSUPPORTED", "ROOM_FULL" -> CallError.RoomFull
-            "CONNECTION_FAILED" -> CallError.ConnectionFailed
-            "JOIN_TIMEOUT" -> CallError.SignalingTimeout
-            "ROOM_ENDED" -> CallError.RoomEnded
-            "INVALID_RECONNECT_TOKEN" -> CallError.SessionExpired
-            else -> if (payload?.message != null) CallError.ServerError(payload.message)
-            else CallError.Unknown("Unknown error")
-        }
-        onError(callError)
+        onError(mapError(payload?.code, payload?.message))
+    }
+
+    private fun mapError(code: String?, message: String?): CallError = when (code) {
+        "ROOM_CAPACITY_UNSUPPORTED", "ROOM_FULL" -> CallError.RoomFull
+        "CONNECTION_FAILED" -> CallError.ConnectionFailed
+        "JOIN_TIMEOUT" -> CallError.SignalingTimeout
+        "ROOM_ENDED" -> CallError.RoomEnded
+        "INVALID_RECONNECT_TOKEN" -> CallError.SessionExpired
+        else -> if (!message.isNullOrBlank()) CallError.ServerError(message)
+        else CallError.Unknown("Unknown error")
     }
 
     private fun parseRoomState(payload: JSONObject?): RoomState? {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
@@ -15,18 +15,23 @@ internal data class JoinedPayload(
     val turnToken: String?,
     val turnTokenTTLMs: Long?,
     val reconnectToken: String?,
+    val reconnectTokenTTLMs: Long?,
     val maxParticipants: Int?,
+    val epoch: Long?,
+    val reconnect: ReconnectOutcome?,
 )
 
 internal data class RoomStatePayload(
     val hostCid: String?,
     val participants: List<Participant>,
     val maxParticipants: Int?,
+    val epoch: Long?,
 )
 
 internal data class ErrorPayload(
     val code: String?,
     val message: String?,
+    val reason: String?,
 )
 
 internal data class ContentStatePayload(
@@ -41,6 +46,16 @@ internal data class MediaStatePayload(
     val videoEnabled: Boolean?,
 )
 
+internal data class RelayFailedPayload(
+    val reason: String,
+    val targets: List<String>,
+    val of: String?,
+)
+
+internal data class NegotiationDirtyPayload(
+    val withCid: String,
+)
+
 // --- Extension parsers ---
 
 internal fun JSONObject?.toJoinedPayload(): JoinedPayload? {
@@ -51,7 +66,10 @@ internal fun JSONObject?.toJoinedPayload(): JoinedPayload? {
         turnToken = optString("turnToken").ifBlank { null },
         turnTokenTTLMs = if (has("turnTokenTTLMs")) optLong("turnTokenTTLMs", 0).takeIf { it > 0 } else null,
         reconnectToken = optString("reconnectToken").ifBlank { null },
+        reconnectTokenTTLMs = if (has("reconnectTokenTTLMs")) optLong("reconnectTokenTTLMs", 0).takeIf { it > 0 } else null,
         maxParticipants = optInt("maxParticipants", 0).takeIf { it > 0 },
+        epoch = if (has("epoch")) optLong("epoch", -1).takeIf { it >= 0 } else null,
+        reconnect = ReconnectOutcome.fromWireValue(optString("reconnect").ifBlank { null }),
     )
 }
 
@@ -61,6 +79,7 @@ internal fun JSONObject?.toRoomStatePayload(): RoomStatePayload? {
         hostCid = optString("hostCid").ifBlank { null },
         participants = optJSONArray("participants").toParticipantList(),
         maxParticipants = optInt("maxParticipants", 0).takeIf { it > 0 },
+        epoch = if (has("epoch")) optLong("epoch", -1).takeIf { it >= 0 } else null,
     )
 }
 
@@ -69,7 +88,31 @@ internal fun JSONObject?.toErrorPayload(): ErrorPayload? {
     return ErrorPayload(
         code = optString("code").trim().ifBlank { null },
         message = optString("message").trim().ifBlank { null },
+        reason = optString("reason").trim().ifBlank { null },
     )
+}
+
+internal fun JSONObject?.toRelayFailedPayload(): RelayFailedPayload? {
+    this ?: return null
+    val reason = optString("reason").ifBlank { return null }
+    val targetsArray = optJSONArray("targets") ?: return null
+    val targets = mutableListOf<String>()
+    for (i in 0 until targetsArray.length()) {
+        val item = targetsArray.optString(i)
+        if (item.isNotBlank()) targets.add(item)
+    }
+    if (targets.isEmpty()) return null
+    return RelayFailedPayload(
+        reason = reason,
+        targets = targets,
+        of = optString("of").ifBlank { null },
+    )
+}
+
+internal fun JSONObject?.toNegotiationDirtyPayload(): NegotiationDirtyPayload? {
+    this ?: return null
+    val withCid = optString("with").ifBlank { return null }
+    return NegotiationDirtyPayload(withCid = withCid)
 }
 
 internal fun JSONObject?.toContentStatePayload(): ContentStatePayload? {
@@ -110,6 +153,7 @@ internal fun JSONArray?.toParticipantList(): List<Participant> {
             } else {
                 ParticipantSignalingStatus.ACTIVE
             }
+            val contentState = p.optJSONObject("contentState")?.toParticipantContentState()
             result.add(Participant(
                 cid = cid,
                 joinedAt = p.optLong("joinedAt").takeIf { it > 0 },
@@ -117,8 +161,21 @@ internal fun JSONArray?.toParticipantList(): List<Participant> {
                 audioEnabled = if (p.has("audioEnabled")) p.optBoolean("audioEnabled") else null,
                 videoEnabled = if (p.has("videoEnabled")) p.optBoolean("videoEnabled") else null,
                 signalingStatus = status,
+                contentState = contentState,
             ))
         }
     }
     return result
+}
+
+private fun JSONObject.toParticipantContentState(): ParticipantContentState? {
+    if (!has("active")) return null
+    val active = optBoolean("active")
+    val rawType = optString("contentType").ifBlank { null }
+    return ParticipantContentState(
+        active = active,
+        contentType = if (active) rawType else null,
+        updatedAtMs = if (has("updatedAtMs")) optLong("updatedAtMs", -1).takeIf { it >= 0 } else null,
+        epoch = if (has("epoch")) optLong("epoch", -1).takeIf { it >= 0 } else null,
+    )
 }

--- a/client-ios/Resources/en.lproj/Localizable.strings
+++ b/client-ios/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "call_status_in_call" = "In call";
 "call_status_left_room" = "Left room";
 "call_status_room_ended" = "Room ended";
+"call_status_session_expired" = "Session expired. Please rejoin the call.";
 
 "call_local_camera_off" = "Your camera is off";
 "call_camera_off" = "Camera off";

--- a/client-ios/Resources/es.lproj/Localizable.strings
+++ b/client-ios/Resources/es.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "call_status_in_call" = "En llamada";
 "call_status_left_room" = "Has salido de la sala";
 "call_status_room_ended" = "Sala finalizada";
+"call_status_session_expired" = "Sesión expirada. Vuelve a unirte a la llamada.";
 
 "call_local_camera_off" = "Tu cámara está apagada";
 "call_camera_off" = "Cámara apagada";

--- a/client-ios/Resources/fr.lproj/Localizable.strings
+++ b/client-ios/Resources/fr.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "call_status_in_call" = "En appel";
 "call_status_left_room" = "Salle quittée";
 "call_status_room_ended" = "Salle terminée";
+"call_status_session_expired" = "Session expirée. Rejoignez l’appel.";
 
 "call_local_camera_off" = "Votre caméra est désactivée";
 "call_camera_off" = "Caméra désactivée";

--- a/client-ios/Resources/ru.lproj/Localizable.strings
+++ b/client-ios/Resources/ru.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "call_status_in_call" = "В звонке";
 "call_status_left_room" = "Вы вышли из комнаты";
 "call_status_room_ended" = "Комната завершена";
+"call_status_session_expired" = "Сессия истекла. Подключитесь к звонку заново.";
 
 "call_local_camera_off" = "Ваша камера выключена";
 "call_camera_off" = "Камера выключена";

--- a/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
@@ -84,7 +84,7 @@ final class SignalingMessageRouter {
 
     func processJoinedEvent(_ event: JoinedEvent) {
         let participants = dedupeParticipants(
-            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
+            participants: event.participants.map(Self.toParticipant),
             localPeerId: event.peerId,
             makeLocalParticipant: { Participant(cid: $0, joinedAt: nil) }
         )
@@ -96,7 +96,12 @@ final class SignalingMessageRouter {
         )
         let roomState: RoomState?
         if let host, !host.isEmpty {
-            roomState = RoomState(hostCid: host, participants: participants, maxParticipants: event.maxParticipants)
+            roomState = RoomState(
+                hostCid: host,
+                participants: participants,
+                maxParticipants: event.maxParticipants,
+                epoch: event.epoch
+            )
         } else {
             roomState = nil
         }
@@ -107,7 +112,7 @@ final class SignalingMessageRouter {
     func processRoomStateEvent(_ event: RoomStateEvent) {
         let localPeerId = getClientId()
         let participants = dedupeParticipants(
-            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
+            participants: event.participants.map(Self.toParticipant),
             localPeerId: localPeerId,
             makeLocalParticipant: { Participant(cid: $0, joinedAt: nil) }
         )
@@ -123,8 +128,32 @@ final class SignalingMessageRouter {
             return
         }
         onRoomState(
-            RoomState(hostCid: host, participants: participants, maxParticipants: event.maxParticipants),
+            RoomState(
+                hostCid: host,
+                participants: participants,
+                maxParticipants: event.maxParticipants,
+                epoch: event.epoch
+            ),
             hint
+        )
+    }
+
+    private static func toParticipant(_ p: SignalingProviderParticipant) -> Participant {
+        Participant(
+            cid: p.peerId,
+            joinedAt: p.joinedAt,
+            displayName: p.displayName,
+            audioEnabled: p.audioEnabled,
+            videoEnabled: p.videoEnabled,
+            signalingStatus: p.signalingStatus,
+            contentState: p.contentState.map {
+                ParticipantContentState(
+                    active: $0.active,
+                    contentType: $0.contentType,
+                    updatedAtMs: $0.updatedAtMs,
+                    epoch: $0.epoch
+                )
+            }
         )
     }
 
@@ -155,7 +184,7 @@ final class SignalingMessageRouter {
     }
 
     func processErrorEvent(_ event: ErrorEvent) {
-        let payload = ErrorPayload(code: event.code, message: event.message)
+        let payload = ErrorPayload(code: event.code, message: event.message, reason: nil)
         onError(payload.toCallError())
     }
 
@@ -194,7 +223,8 @@ final class SignalingMessageRouter {
 
         guard let resolvedHostCid, !resolvedHostCid.isEmpty else { return nil }
         let maxParticipants = obj["maxParticipants"]?.intValue
-        return RoomState(hostCid: resolvedHostCid, participants: participants, maxParticipants: maxParticipants)
+        let epoch = obj["epoch"]?.intValue.map(Int64.init)
+        return RoomState(hostCid: resolvedHostCid, participants: participants, maxParticipants: maxParticipants, epoch: epoch)
     }
 
     static func turnToken(from payload: JSONValue?) -> String? {

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -123,6 +123,11 @@ public enum CallError: Equatable, Sendable {
     case roomFull
     /// Room was ended by another participant or the server.
     case roomEnded
+    /// The persisted reconnect credential is no longer valid (expired or
+    /// rejected). The SDK must clear stored reconnect state and surface a
+    /// dedicated terminal error so the host app can route the user back to
+    /// a fresh start instead of looping reconnects.
+    case sessionExpired
     /// Required media permissions were denied.
     case permissionDenied
     /// Server returned an error.

--- a/client-ios/SerenadaCore/Sources/Models/Participant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/Participant.swift
@@ -11,6 +11,38 @@ public enum ParticipantSignalingStatus: String, Codable, Equatable {
     case suspended
 }
 
+/// Latest ephemeral content metadata for a participant (screen share,
+/// content camera mode, etc.). Persisted on the server's participant record
+/// so a peer reconnecting after a suspension reconstructs UI without waiting
+/// for the sender to toggle again.
+public struct ParticipantContentState: Codable, Equatable {
+    public let active: Bool
+    public let contentType: String?
+    public let updatedAtMs: Int64?
+    public let epoch: Int64?
+
+    public init(
+        active: Bool,
+        contentType: String? = nil,
+        updatedAtMs: Int64? = nil,
+        epoch: Int64? = nil
+    ) {
+        self.active = active
+        self.contentType = contentType
+        self.updatedAtMs = updatedAtMs
+        self.epoch = epoch
+    }
+}
+
+/// Disposition of a join, surfaced by the server in `joined.reconnect`.
+/// Drives whether the SDK preserves media-active peer connections,
+/// schedules dirty-pair renegotiation, or starts ground-up.
+public enum ReconnectOutcome: String, Codable, Equatable, Sendable {
+    case fresh
+    case reattached
+    case recovered
+}
+
 public struct Participant: Codable, Equatable {
     public let cid: String
     public let joinedAt: Int64?
@@ -18,6 +50,7 @@ public struct Participant: Codable, Equatable {
     public let audioEnabled: Bool?
     public let videoEnabled: Bool?
     public let signalingStatus: ParticipantSignalingStatus
+    public let contentState: ParticipantContentState?
 
     public init(
         cid: String,
@@ -25,7 +58,8 @@ public struct Participant: Codable, Equatable {
         displayName: String? = nil,
         audioEnabled: Bool? = nil,
         videoEnabled: Bool? = nil,
-        signalingStatus: ParticipantSignalingStatus = .active
+        signalingStatus: ParticipantSignalingStatus = .active,
+        contentState: ParticipantContentState? = nil
     ) {
         self.cid = cid
         self.joinedAt = joinedAt
@@ -33,5 +67,6 @@ public struct Participant: Codable, Equatable {
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.signalingStatus = signalingStatus
+        self.contentState = contentState
     }
 }

--- a/client-ios/SerenadaCore/Sources/Models/RoomState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/RoomState.swift
@@ -4,10 +4,20 @@ internal struct RoomState: Codable, Equatable {
     public let hostCid: String
     public let participants: [Participant]
     public let maxParticipants: Int?
+    /// Server room-state epoch. Monotonic per room. SDKs gate ICE restart
+    /// on receiving an authoritative post-reconnect snapshot, instead of
+    /// acting on a stale in-memory peer map.
+    public let epoch: Int64?
 
-    public init(hostCid: String, participants: [Participant], maxParticipants: Int?) {
+    public init(
+        hostCid: String,
+        participants: [Participant],
+        maxParticipants: Int?,
+        epoch: Int64? = nil
+    ) {
         self.hostCid = hostCid
         self.participants = participants
         self.maxParticipants = maxParticipants
+        self.epoch = epoch
     }
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -193,9 +193,16 @@ extension SerenadaServerProvider: SignalingClientListener {
             delegate?.signalingProviderDidEndRoom(RoomEndedEvent(by: endedBy, reason: reason))
         case "error":
             let payload = ErrorPayload(from: message.payload)
+            let code = payload.code ?? "UNKNOWN"
+            // Terminal codes that invalidate persisted reconnect authority.
+            // Drop the stored token so a future join cannot try to reclaim
+            // the (gone) slot.
+            if code == "ROOM_ENDED" || code == "INVALID_RECONNECT_TOKEN" {
+                clearReconnect()
+            }
             delegate?.signalingProviderDidReceiveError(
                 ErrorEvent(
-                    code: payload.code ?? "UNKNOWN",
+                    code: code,
                     message: payload.message ?? "Unknown error"
                 )
             )
@@ -239,9 +246,7 @@ private extension SerenadaServerProvider {
         }
 
         let participants = dedupeProviderParticipants(
-            participants: (payload.participants ?? []).map {
-                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
-            },
+            participants: (payload.participants ?? []).map(toProviderParticipant),
             localPeerId: peerId
         )
         previousParticipants = Dictionary(uniqueKeysWithValues: participants.map { ($0.peerId, $0) })
@@ -250,8 +255,29 @@ private extension SerenadaServerProvider {
                 peerId: peerId,
                 participants: participants,
                 hostPeerId: payload.hostCid,
-                maxParticipants: payload.maxParticipants
+                maxParticipants: payload.maxParticipants,
+                epoch: payload.epoch,
+                reconnectOutcome: payload.reconnect
             )
+        )
+    }
+
+    private func toProviderParticipant(_ p: Participant) -> SignalingProviderParticipant {
+        SignalingProviderParticipant(
+            peerId: p.cid,
+            joinedAt: p.joinedAt,
+            displayName: p.displayName,
+            audioEnabled: p.audioEnabled,
+            videoEnabled: p.videoEnabled,
+            signalingStatus: p.signalingStatus,
+            contentState: p.contentState.map {
+                SignalingProviderParticipantContentState(
+                    active: $0.active,
+                    contentType: $0.contentType,
+                    updatedAtMs: $0.updatedAtMs,
+                    epoch: $0.epoch
+                )
+            }
         )
     }
 
@@ -290,9 +316,7 @@ private extension SerenadaServerProvider {
     func roomStateEvent(from payload: JSONValue?) -> RoomStateEvent? {
         guard let object = payload?.objectValue else { return nil }
         let participants = dedupeProviderParticipants(
-            participants: (parseParticipants(from: object["participants"]?.arrayValue) ?? []).map {
-                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
-            },
+            participants: (parseParticipants(from: object["participants"]?.arrayValue) ?? []).map(toProviderParticipant),
             localPeerId: clientId
         )
         var hostPeerId = object["hostCid"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -305,7 +329,8 @@ private extension SerenadaServerProvider {
         return RoomStateEvent(
             participants: participants,
             hostPeerId: hostPeerId,
-            maxParticipants: object["maxParticipants"]?.intValue
+            maxParticipants: object["maxParticipants"]?.intValue,
+            epoch: object["epoch"]?.intValue.map(Int64.init)
         )
     }
 

--- a/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
@@ -15,16 +15,36 @@ func parseParticipants(from arrayValue: [JSONValue]?) -> [Participant]? {
         let videoEnabled = obj["videoEnabled"]?.boolValue
         // Unknown status values fall back to .active per protocol spec.
         let signalingStatus: ParticipantSignalingStatus = (obj["connectionStatus"]?.stringValue == "suspended") ? .suspended : .active
+        let contentState = parseContentState(from: obj["contentState"])
         result.append(Participant(
             cid: cid,
             joinedAt: joinedAt,
             displayName: displayName,
             audioEnabled: audioEnabled,
             videoEnabled: videoEnabled,
-            signalingStatus: signalingStatus
+            signalingStatus: signalingStatus,
+            contentState: contentState
         ))
     }
     return result
+}
+
+/// Parse the latest ephemeral content state for a participant, surfaced in
+/// `joined`/`room_state` so a peer reconnecting after a suspension can
+/// restore screen-share / content-camera UI without waiting for the sender
+/// to toggle again.
+func parseContentState(from value: JSONValue?) -> ParticipantContentState? {
+    guard let obj = value?.objectValue else { return nil }
+    guard let active = obj["active"]?.boolValue else { return nil }
+    let contentType = active ? obj["contentType"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty : nil
+    let updatedAtMs = obj["updatedAtMs"]?.intValue.map(Int64.init)
+    let epoch = obj["epoch"]?.intValue.map(Int64.init)
+    return ParticipantContentState(
+        active: active,
+        contentType: contentType,
+        updatedAtMs: updatedAtMs,
+        epoch: epoch
+    )
 }
 
 // MARK: - Typed Signaling Payloads
@@ -37,12 +57,18 @@ struct JoinedPayload {
     let turnToken: String?
     let turnTokenTTLMs: Int?
     let reconnectToken: String?
+    let reconnectTokenTTLMs: Int?
     let participantCount: Int?
+    /// Server room-state epoch on this transport; monotonic per room.
+    let epoch: Int64?
+    /// How the server treated this join. nil for older servers.
+    let reconnect: ReconnectOutcome?
 
     init(from payload: JSONValue?) {
         guard let obj = payload?.objectValue else {
             hostCid = nil; participants = nil; maxParticipants = nil; turnToken = nil
-            turnTokenTTLMs = nil; reconnectToken = nil; participantCount = nil
+            turnTokenTTLMs = nil; reconnectToken = nil; reconnectTokenTTLMs = nil
+            participantCount = nil; epoch = nil; reconnect = nil
             return
         }
 
@@ -51,6 +77,13 @@ struct JoinedPayload {
         turnToken = obj["turnToken"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         turnTokenTTLMs = obj["turnTokenTTLMs"]?.intValue
         reconnectToken = obj["reconnectToken"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        reconnectTokenTTLMs = obj["reconnectTokenTTLMs"]?.intValue
+        epoch = obj["epoch"]?.intValue.map(Int64.init)
+        if let raw = obj["reconnect"]?.stringValue {
+            reconnect = ReconnectOutcome(rawValue: raw)
+        } else {
+            reconnect = nil
+        }
 
         if let parsed = parseParticipants(from: obj["participants"]?.arrayValue) {
             participants = parsed
@@ -62,22 +95,78 @@ struct JoinedPayload {
     }
 }
 
+/// Payload for "room_state" message — server-emitted authoritative snapshot.
+/// Used as the post-reconnect sync point that gates SDK ICE restart.
+struct RoomStatePayload {
+    let hostCid: String?
+    let participants: [Participant]?
+    let maxParticipants: Int?
+    let epoch: Int64?
+
+    init(from payload: JSONValue?) {
+        guard let obj = payload?.objectValue else {
+            hostCid = nil; participants = nil; maxParticipants = nil; epoch = nil; return
+        }
+        hostCid = obj["hostCid"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        maxParticipants = obj["maxParticipants"]?.intValue
+        epoch = obj["epoch"]?.intValue.map(Int64.init)
+        participants = parseParticipants(from: obj["participants"]?.arrayValue)
+    }
+}
+
+/// Payload for "relay_failed" — server tells the sender that an offer/
+/// answer/ice could not be delivered because the target was suspended.
+struct RelayFailedPayload {
+    let reason: String
+    let targets: [String]
+    let of: String?
+
+    init?(from payload: JSONValue?) {
+        guard let obj = payload?.objectValue else { return nil }
+        guard let reason = obj["reason"]?.stringValue, !reason.isEmpty else { return nil }
+        guard let raw = obj["targets"]?.arrayValue else { return nil }
+        let targets = raw.compactMap { $0.stringValue }.filter { !$0.isEmpty }
+        guard !targets.isEmpty else { return nil }
+        self.reason = reason
+        self.targets = targets
+        self.of = obj["of"]?.stringValue?.nilIfEmpty
+    }
+}
+
+/// Payload for "negotiation_dirty" — server tells the sender that a
+/// previously-suspended peer has reattached AND there were missed offer/
+/// answer/ice messages during the suspension. The SDK should perform fresh
+/// glare-safe negotiation for the named CID.
+struct NegotiationDirtyPayload {
+    let withCid: String
+
+    init?(from payload: JSONValue?) {
+        guard let obj = payload?.objectValue else { return nil }
+        guard let raw = obj["with"]?.stringValue, !raw.isEmpty else { return nil }
+        self.withCid = raw
+    }
+}
+
 /// Payload for "error" message — server reports an error.
 struct ErrorPayload {
     let code: String?
     let message: String?
+    /// Optional reason for terminal codes (e.g. ROOM_ENDED → "ended_by_host").
+    let reason: String?
 
-    init(code: String?, message: String?) {
+    init(code: String?, message: String?, reason: String? = nil) {
         self.code = code
         self.message = message
+        self.reason = reason
     }
 
     init(from payload: JSONValue?) {
         guard let obj = payload?.objectValue else {
-            code = nil; message = nil; return
+            code = nil; message = nil; reason = nil; return
         }
         code = obj["code"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         message = obj["message"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        reason = obj["reason"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
     }
 
     func toCallError() -> CallError {
@@ -90,6 +179,8 @@ struct ErrorPayload {
             return .signalingTimeout
         case "ROOM_ENDED":
             return .roomEnded
+        case "INVALID_RECONNECT_TOKEN":
+            return .sessionExpired
         case .some:
             return .serverError(message ?? code ?? "Server error")
         default:

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -30,6 +30,25 @@ public struct JoinOptions: Equatable, Sendable {
     }
 }
 
+public struct SignalingProviderParticipantContentState: Equatable, Sendable {
+    public let active: Bool
+    public let contentType: String?
+    public let updatedAtMs: Int64?
+    public let epoch: Int64?
+
+    public init(
+        active: Bool,
+        contentType: String? = nil,
+        updatedAtMs: Int64? = nil,
+        epoch: Int64? = nil
+    ) {
+        self.active = active
+        self.contentType = contentType
+        self.updatedAtMs = updatedAtMs
+        self.epoch = epoch
+    }
+}
+
 public struct SignalingProviderParticipant: Equatable, Sendable {
     public let peerId: String
     public let joinedAt: Int64?
@@ -37,6 +56,7 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
     public let audioEnabled: Bool?
     public let videoEnabled: Bool?
     public let signalingStatus: ParticipantSignalingStatus
+    public let contentState: SignalingProviderParticipantContentState?
 
     public init(
         peerId: String,
@@ -44,7 +64,8 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
         displayName: String? = nil,
         audioEnabled: Bool? = nil,
         videoEnabled: Bool? = nil,
-        signalingStatus: ParticipantSignalingStatus = .active
+        signalingStatus: ParticipantSignalingStatus = .active,
+        contentState: SignalingProviderParticipantContentState? = nil
     ) {
         self.peerId = peerId
         self.joinedAt = joinedAt
@@ -52,6 +73,7 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.signalingStatus = signalingStatus
+        self.contentState = contentState
     }
 }
 
@@ -60,17 +82,25 @@ public struct JoinedEvent: Equatable, Sendable {
     public let participants: [SignalingProviderParticipant]
     public let hostPeerId: String?
     public let maxParticipants: Int?
+    /// Server room-state epoch on this transport; monotonic per room.
+    public let epoch: Int64?
+    /// How the server treated this join. nil for older providers.
+    public let reconnectOutcome: ReconnectOutcome?
 
     public init(
         peerId: String,
         participants: [SignalingProviderParticipant],
         hostPeerId: String? = nil,
-        maxParticipants: Int? = nil
+        maxParticipants: Int? = nil,
+        epoch: Int64? = nil,
+        reconnectOutcome: ReconnectOutcome? = nil
     ) {
         self.peerId = peerId
         self.participants = participants
         self.hostPeerId = hostPeerId
         self.maxParticipants = maxParticipants
+        self.epoch = epoch
+        self.reconnectOutcome = reconnectOutcome
     }
 }
 
@@ -78,15 +108,19 @@ public struct RoomStateEvent: Equatable, Sendable {
     public let participants: [SignalingProviderParticipant]
     public let hostPeerId: String?
     public let maxParticipants: Int?
+    /// Server room-state epoch on this transport; monotonic per room.
+    public let epoch: Int64?
 
     public init(
         participants: [SignalingProviderParticipant],
         hostPeerId: String? = nil,
-        maxParticipants: Int? = nil
+        maxParticipants: Int? = nil,
+        epoch: Int64? = nil
     ) {
         self.participants = participants
         self.hostPeerId = hostPeerId
         self.maxParticipants = maxParticipants
+        self.epoch = epoch
     }
 }
 

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -625,11 +625,7 @@ final class CallManager: ObservableObject {
         case .roomEnded:
             return L10n.callStatusRoomEnded
         case .sessionExpired:
-            // The persisted reconnect credential is gone — the user needs
-            // to start a new call from scratch. Use the room-ended copy as
-            // the closest existing localized string until a dedicated
-            // session-expired message is added to L10n.
-            return L10n.callStatusRoomEnded
+            return L10n.callStatusSessionExpired
         case .permissionDenied:
             return L10n.callStatusConnectionFailed
         case .serverError(let message), .unknown(let message):

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -624,6 +624,12 @@ final class CallManager: ObservableObject {
             return L10n.errorRoomCapacityUnsupported
         case .roomEnded:
             return L10n.callStatusRoomEnded
+        case .sessionExpired:
+            // The persisted reconnect credential is gone — the user needs
+            // to start a new call from scratch. Use the room-ended copy as
+            // the closest existing localized string until a dedicated
+            // session-expired message is added to L10n.
+            return L10n.callStatusRoomEnded
         case .permissionDenied:
             return L10n.callStatusConnectionFailed
         case .serverError(let message), .unknown(let message):

--- a/client-ios/Sources/Core/Utils/L10n.swift
+++ b/client-ios/Sources/Core/Utils/L10n.swift
@@ -122,6 +122,7 @@ enum L10n {
     static var callStatusInCall: String { text("call_status_in_call") }
     static var callStatusLeftRoom: String { text("call_status_left_room") }
     static var callStatusRoomEnded: String { text("call_status_room_ended") }
+    static var callStatusSessionExpired: String { text("call_status_session_expired") }
 
     static var callLocalCameraOff: String { text("call_local_camera_off") }
     static var callCameraOff: String { text("call_camera_off") }

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -235,6 +235,10 @@ export class SignalingEngine {
         this.turnToken = null;
         this.turnTokenTTLMs = null;
         this.turnTokenExpiresAtMs = null;
+        this.lastReconnectOutcome = null;
+        this.lastEpoch = null;
+        this.awaitingPostReconnectSnapshot = false;
+        this.epochAtDisconnect = null;
         this.notifyStateChange();
     }
 
@@ -354,15 +358,7 @@ export class SignalingEngine {
                 break;
             }
             case 'room_ended':
-                this.clearJoinTimers();
-                this.roomState = null;
-                this.currentRoomId = null;
-                this.needsRejoin = false;
-                this.clearReconnectStorage();
-                this.lastReconnectOutcome = null;
-                this.lastEpoch = null;
-                this.awaitingPostReconnectSnapshot = false;
-                this.epochAtDisconnect = null;
+                this.resetForTerminal();
                 break;
             case 'negotiation_dirty':
             case 'relay_failed': {
@@ -400,15 +396,7 @@ export class SignalingEngine {
                         errorPayload.code === 'ROOM_ENDED' ||
                         errorPayload.code === 'INVALID_RECONNECT_TOKEN'
                     ) {
-                        this.clearJoinTimers();
-                        this.roomState = null;
-                        this.currentRoomId = null;
-                        this.needsRejoin = false;
-                        this.clearReconnectStorage();
-                        this.lastReconnectOutcome = null;
-                        this.lastEpoch = null;
-                        this.awaitingPostReconnectSnapshot = false;
-                        this.epochAtDisconnect = null;
+                        this.resetForTerminal();
                     }
                 }
                 break;
@@ -655,6 +643,22 @@ export class SignalingEngine {
 
     private notifyStateChange(): void {
         [...this.stateListeners].forEach(l => l());
+    }
+
+    // Drops in-room state, persisted reconnect authority, and the
+    // post-reconnect gate. Called for any terminal event that means the
+    // current session is over and should not influence a future join:
+    // server `room_ended`, terminal error codes, etc.
+    private resetForTerminal(): void {
+        this.clearJoinTimers();
+        this.roomState = null;
+        this.currentRoomId = null;
+        this.needsRejoin = false;
+        this.clearReconnectStorage();
+        this.lastReconnectOutcome = null;
+        this.lastEpoch = null;
+        this.awaitingPostReconnectSnapshot = false;
+        this.epochAtDisconnect = null;
     }
 
     // Session storage helpers

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -361,17 +361,21 @@ export class SignalingEngine {
                 this.clearReconnectStorage();
                 this.lastReconnectOutcome = null;
                 this.lastEpoch = null;
+                this.awaitingPostReconnectSnapshot = false;
+                this.epochAtDisconnect = null;
                 break;
             case 'negotiation_dirty':
             case 'relay_failed': {
-                // Pure forwarding to message listeners — MediaEngine handles
-                // the renegotiation/back-off behavior. Parsing here surfaces
-                // shape errors early and keeps the listeners on the typed
-                // path.
-                if (msg.type === 'relay_failed') {
-                    parseRelayFailedPayload(msg.payload);
-                } else {
-                    parseNegotiationDirtyPayload(msg.payload);
+                // Validate payload shape and drop anything malformed before
+                // it reaches downstream listeners. MediaEngine handles the
+                // actual renegotiation/back-off behavior off the listener
+                // stream.
+                const parsed = msg.type === 'relay_failed'
+                    ? parseRelayFailedPayload(msg.payload)
+                    : parseNegotiationDirtyPayload(msg.payload);
+                if (!parsed) {
+                    this.logger?.log('warning', 'Signaling', `Ignoring malformed ${msg.type} payload`);
+                    return;
                 }
                 break;
             }
@@ -403,6 +407,8 @@ export class SignalingEngine {
                         this.clearReconnectStorage();
                         this.lastReconnectOutcome = null;
                         this.lastEpoch = null;
+                        this.awaitingPostReconnectSnapshot = false;
+                        this.epochAtDisconnect = null;
                     }
                 }
                 break;

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -1,10 +1,17 @@
-import type { RoomState, SignalingMessage } from './types.js';
+import type { ReconnectOutcome, RoomState, SignalingMessage } from './types.js';
 import type { RoomStatuses } from './roomStatuses.js';
 import type { SignalingTransport, TransportKind } from './transports/types.js';
 import type { SerenadaLogger } from '../types.js';
 import { createSignalingTransport } from './transports/index.js';
 import { mergeRoomStatusesPayload, mergeRoomStatusUpdatePayload } from './roomStatuses.js';
-import { parseJoinedPayload, parseRoomStatePayload, parseErrorPayload, parseTurnRefreshedPayload } from './payloads.js';
+import {
+    parseJoinedPayload,
+    parseRoomStatePayload,
+    parseErrorPayload,
+    parseTurnRefreshedPayload,
+    parseRelayFailedPayload,
+    parseNegotiationDirtyPayload,
+} from './payloads.js';
 import { formatError } from '../formatError.js';
 import {
     RECONNECT_BACKOFF_BASE_MS,
@@ -36,8 +43,24 @@ export class SignalingEngine {
     roomState: RoomState | null = null;
     turnToken: string | null = null;
     turnTokenTTLMs: number | null = null;
-    error: { code: string; message: string } | null = null;
+    error: { code: string; message: string; reason?: string } | null = null;
     roomStatuses: RoomStatuses = {};
+    /** Most-recent reconnect outcome reported by the server in `joined`. */
+    lastReconnectOutcome: ReconnectOutcome | null = null;
+    /**
+     * Highest room-state epoch observed so far. Advances monotonically (per
+     * room) on every membership change. Used by MediaEngine to gate ICE
+     * restart on an authoritative post-reconnect snapshot.
+     */
+    lastEpoch: number | null = null;
+    /** Epoch at the moment the transport was last observed disconnected. */
+    epochAtDisconnect: number | null = null;
+    /**
+     * True from disconnect until we've seen a fresh authoritative snapshot
+     * for the current room on the new transport. Consumers should suppress
+     * ICE restart while this flag is set.
+     */
+    awaitingPostReconnectSnapshot = false;
 
     // Config
     private wsUrl: string;
@@ -101,6 +124,8 @@ export class SignalingEngine {
         this.clearJoinTimers();
         this.clearPingInterval();
         this.clearTurnRefreshTimer();
+        this.awaitingPostReconnectSnapshot = false;
+        this.epochAtDisconnect = null;
         if (this.transport) {
             this.transport.close();
             this.transport = null;
@@ -255,10 +280,15 @@ export class SignalingEngine {
                 if (!joined) break;
                 this.clearJoinTimers();
                 this.joinAcked = true;
+                this.lastReconnectOutcome = joined.reconnect ?? null;
+                if (joined.epoch !== undefined) {
+                    this.lastEpoch = joined.epoch;
+                }
                 this.roomState = {
                     hostCid: joined.hostCid,
                     participants: joined.participants,
                     maxParticipants: joined.maxParticipants,
+                    epoch: joined.epoch,
                 };
                 if (joined.turnToken) {
                     this.turnToken = joined.turnToken;
@@ -273,6 +303,14 @@ export class SignalingEngine {
                     this.persistReconnectStorage();
                 }
                 this.persistClientId();
+                this.logger?.log(
+                    'debug',
+                    'Signaling',
+                    `joined outcome=${joined.reconnect ?? 'fresh'} epoch=${joined.epoch ?? 'n/a'}`
+                );
+                // joined alone is not the authoritative post-reconnect
+                // snapshot — wait for the dedicated room_state that the
+                // server emits immediately after.
                 break;
             }
             case 'turn-refreshed': {
@@ -297,6 +335,21 @@ export class SignalingEngine {
                 const roomState = parseRoomStatePayload(msg.payload);
                 if (roomState) {
                     this.roomState = roomState;
+                    if (roomState.epoch !== undefined) {
+                        this.lastEpoch = roomState.epoch;
+                    }
+                    // First room_state seen after a transport reconnect is the
+                    // authoritative sync point. Clear the gate so MediaEngine
+                    // can proceed with renegotiation against confirmed state.
+                    if (this.awaitingPostReconnectSnapshot) {
+                        this.awaitingPostReconnectSnapshot = false;
+                        this.epochAtDisconnect = null;
+                        this.logger?.log(
+                            'debug',
+                            'Signaling',
+                            `Post-reconnect snapshot received (epoch=${roomState.epoch ?? 'n/a'})`
+                        );
+                    }
                 }
                 break;
             }
@@ -306,7 +359,22 @@ export class SignalingEngine {
                 this.currentRoomId = null;
                 this.needsRejoin = false;
                 this.clearReconnectStorage();
+                this.lastReconnectOutcome = null;
+                this.lastEpoch = null;
                 break;
+            case 'negotiation_dirty':
+            case 'relay_failed': {
+                // Pure forwarding to message listeners — MediaEngine handles
+                // the renegotiation/back-off behavior. Parsing here surfaces
+                // shape errors early and keeps the listeners on the typed
+                // path.
+                if (msg.type === 'relay_failed') {
+                    parseRelayFailedPayload(msg.payload);
+                } else {
+                    parseNegotiationDirtyPayload(msg.payload);
+                }
+                break;
+            }
             case 'room_statuses':
                 if (msg.payload) {
                     this.roomStatuses = mergeRoomStatusesPayload(this.roomStatuses, msg.payload);
@@ -321,6 +389,21 @@ export class SignalingEngine {
                 const errorPayload = parseErrorPayload(msg.payload);
                 if (errorPayload) {
                     this.error = errorPayload;
+                    // Terminal errors that invalidate persisted reconnect
+                    // state. The session is over for this CID — clear the
+                    // token so a future join can't try to reclaim it.
+                    if (
+                        errorPayload.code === 'ROOM_ENDED' ||
+                        errorPayload.code === 'INVALID_RECONNECT_TOKEN'
+                    ) {
+                        this.clearJoinTimers();
+                        this.roomState = null;
+                        this.currentRoomId = null;
+                        this.needsRejoin = false;
+                        this.clearReconnectStorage();
+                        this.lastReconnectOutcome = null;
+                        this.lastEpoch = null;
+                    }
                 }
                 break;
             }
@@ -392,6 +475,13 @@ export class SignalingEngine {
                 }
                 this.transport = null;
                 this.needsRejoin = !!this.currentRoomId;
+                // We may miss membership transitions while disconnected. Set
+                // the gate so consumers wait for an authoritative
+                // post-reconnect snapshot before scheduling renegotiation.
+                if (this.currentRoomId) {
+                    this.epochAtDisconnect = this.lastEpoch;
+                    this.awaitingPostReconnectSnapshot = true;
+                }
 
                 if (this.shouldFallback(targetKind, reason) && this.tryNextTransport(reason)) {
                     this.notifyStateChange();

--- a/client/packages/core/src/signaling/payloads.ts
+++ b/client/packages/core/src/signaling/payloads.ts
@@ -1,4 +1,4 @@
-import type { RoomParticipant, RoomState } from './types.js';
+import type { ParticipantContentState, ReconnectOutcome, RoomParticipant, RoomState } from './types.js';
 
 export interface JoinedPayload {
     hostCid: string | null;
@@ -6,12 +6,50 @@ export interface JoinedPayload {
     turnToken?: string;
     turnTokenTTLMs?: number;
     reconnectToken?: string;
+    /**
+     * How long (ms) the server is willing to honor `reconnectToken`. SDKs
+     * that persist the token across launches should clear it once this
+     * window has elapsed.
+     */
+    reconnectTokenTTLMs?: number;
     maxParticipants?: number;
+    /** Server-reported room state epoch. Monotonic. */
+    epoch?: number;
+    /**
+     * Disposition of this join. SDKs use this to decide whether to keep
+     * media-active peer connections (`reattached`/`recovered`) or treat the
+     * call as ground-up new (`fresh`).
+     */
+    reconnect?: ReconnectOutcome;
 }
 
 export interface ErrorPayload {
     code: string;
     message: string;
+    /** Optional reason for terminal codes (e.g. ROOM_ENDED → "ended_by_host"). */
+    reason?: string;
+}
+
+/**
+ * Server tells the sender that an offer/answer/ice could not be delivered
+ * because the target was suspended. The SDK should suppress further
+ * negotiation toward those CIDs and wait for a `negotiation_dirty` message
+ * after the peer reattaches.
+ */
+export interface RelayFailedPayload {
+    reason: 'target_suspended' | (string & {});
+    targets: string[];
+    of?: string;
+}
+
+/**
+ * Server tells the sender that a previously-suspended peer has reattached
+ * AND that the sender had pending negotiation traffic to it during the
+ * suspension. The SDK should perform glare-safe fresh negotiation /
+ * ICE restart for the named CID, NOT replay the original SDP.
+ */
+export interface NegotiationDirtyPayload {
+    with: string;
 }
 
 export interface TurnRefreshedPayload {
@@ -35,6 +73,18 @@ export interface IceCandidatePayload {
     candidate: RTCIceCandidateInit;
 }
 
+function parseContentState(raw: unknown): ParticipantContentState | undefined {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+    const rec = raw as Record<string, unknown>;
+    if (typeof rec.active !== 'boolean') return undefined;
+    return {
+        active: rec.active,
+        contentType: typeof rec.contentType === 'string' && rec.contentType !== '' ? rec.contentType : undefined,
+        updatedAtMs: typeof rec.updatedAtMs === 'number' ? rec.updatedAtMs : undefined,
+        epoch: typeof rec.epoch === 'number' ? rec.epoch : undefined,
+    };
+}
+
 function parseParticipants(raw: unknown): RoomParticipant[] | null {
     if (!Array.isArray(raw)) return null;
     const result: RoomParticipant[] = [];
@@ -51,9 +101,15 @@ function parseParticipants(raw: unknown): RoomParticipant[] | null {
             // Only the recognized status value is forwarded; absent/unknown
             // is left undefined and treated as active downstream.
             connectionStatus: rec.connectionStatus === 'suspended' ? 'suspended' : undefined,
+            contentState: parseContentState(rec.contentState),
         });
     }
     return result;
+}
+
+function parseReconnectOutcome(raw: unknown): ReconnectOutcome | undefined {
+    if (raw === 'fresh' || raw === 'reattached' || raw === 'recovered') return raw;
+    return undefined;
 }
 
 export function parseJoinedPayload(raw: Record<string, unknown> | undefined): JoinedPayload | null {
@@ -66,7 +122,10 @@ export function parseJoinedPayload(raw: Record<string, unknown> | undefined): Jo
         turnToken: typeof raw.turnToken === 'string' ? raw.turnToken : undefined,
         turnTokenTTLMs: typeof raw.turnTokenTTLMs === 'number' ? raw.turnTokenTTLMs : undefined,
         reconnectToken: typeof raw.reconnectToken === 'string' ? raw.reconnectToken : undefined,
+        reconnectTokenTTLMs: typeof raw.reconnectTokenTTLMs === 'number' ? raw.reconnectTokenTTLMs : undefined,
         maxParticipants: typeof raw.maxParticipants === 'number' ? raw.maxParticipants : undefined,
+        epoch: typeof raw.epoch === 'number' ? raw.epoch : undefined,
+        reconnect: parseReconnectOutcome(raw.reconnect),
     };
 }
 
@@ -78,6 +137,7 @@ export function parseRoomStatePayload(raw: Record<string, unknown> | undefined):
         hostCid: typeof raw.hostCid === 'string' ? raw.hostCid : null,
         participants,
         maxParticipants: typeof raw.maxParticipants === 'number' ? raw.maxParticipants : undefined,
+        epoch: typeof raw.epoch === 'number' ? raw.epoch : undefined,
     };
 }
 
@@ -87,7 +147,27 @@ export function parseErrorPayload(raw: Record<string, unknown> | undefined): Err
     return {
         code: typeof raw.code === 'string' ? raw.code : 'UNKNOWN',
         message: raw.message,
+        reason: typeof raw.reason === 'string' && raw.reason !== '' ? raw.reason : undefined,
     };
+}
+
+export function parseRelayFailedPayload(raw: Record<string, unknown> | undefined): RelayFailedPayload | null {
+    if (!raw) return null;
+    if (typeof raw.reason !== 'string') return null;
+    if (!Array.isArray(raw.targets)) return null;
+    const targets = raw.targets.filter((t): t is string => typeof t === 'string' && t !== '');
+    if (targets.length === 0) return null;
+    return {
+        reason: raw.reason as RelayFailedPayload['reason'],
+        targets,
+        of: typeof raw.of === 'string' && raw.of !== '' ? raw.of : undefined,
+    };
+}
+
+export function parseNegotiationDirtyPayload(raw: Record<string, unknown> | undefined): NegotiationDirtyPayload | null {
+    if (!raw) return null;
+    if (typeof raw.with !== 'string' || raw.with === '') return null;
+    return { with: raw.with };
 }
 
 export function parseTurnRefreshedPayload(raw: Record<string, unknown> | undefined): TurnRefreshedPayload | null {

--- a/client/packages/core/src/signaling/types.ts
+++ b/client/packages/core/src/signaling/types.ts
@@ -1,5 +1,18 @@
 export type ParticipantConnectionStatus = 'active' | 'suspended';
 
+/**
+ * Latest ephemeral content metadata for a participant (screen share, content
+ * camera mode, etc.). Persisted on the server's participant record so a peer
+ * reconnecting after a suspension reconstructs its UI without waiting for the
+ * sender to toggle again.
+ */
+export type ParticipantContentState = {
+    active: boolean;
+    contentType?: string;
+    updatedAtMs?: number;
+    epoch?: number;
+};
+
 export type RoomParticipant = {
     cid: string;
     joinedAt?: number;
@@ -10,13 +23,28 @@ export type RoomParticipant = {
     // open across a signaling drop — peers MUST keep the existing peer
     // connection alive until the participant returns or is fully removed.
     connectionStatus?: ParticipantConnectionStatus;
+    contentState?: ParticipantContentState;
 };
 
 export type RoomState = {
     hostCid: string | null;
     participants: RoomParticipant[];
     maxParticipants?: number;
+    /**
+     * Monotonic counter advanced by the server on every membership-mutating
+     * operation. SDKs gate ICE restart on receiving an authoritative
+     * post-reconnect room_state with epoch >= the last seen value, instead
+     * of acting on a stale in-memory peer map.
+     */
+    epoch?: number;
 };
+
+/**
+ * Outcome reported by the server in `joined.reconnect`. Drives whether the
+ * SDK preserves media-active peer connections, schedules dirty-pair
+ * renegotiation, or starts ground-up.
+ */
+export type ReconnectOutcome = 'fresh' | 'reattached' | 'recovered';
 
 export type SignalingMessage = {
     v: number;

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -69,6 +69,7 @@ export type CallErrorCode =
     | 'connectionFailed'
     | 'roomFull'
     | 'roomEnded'
+    | 'sessionExpired'
     | 'permissionDenied'
     | 'serverError'
     | 'webrtcUnavailable'

--- a/client/packages/core/test/signaling/payloads.test.ts
+++ b/client/packages/core/test/signaling/payloads.test.ts
@@ -7,6 +7,8 @@ import {
     parseOfferPayload,
     parseAnswerPayload,
     parseIceCandidatePayload,
+    parseRelayFailedPayload,
+    parseNegotiationDirtyPayload,
 } from '../../src/signaling/payloads';
 
 describe('parseJoinedPayload', () => {
@@ -328,5 +330,129 @@ describe('parseIceCandidatePayload', () => {
             from: 'c',
             candidate: validCandidate,
         });
+    });
+});
+
+describe('parseJoinedPayload — Phase 1 fields', () => {
+    it('parses reconnect outcome and epoch', () => {
+        const result = parseJoinedPayload({
+            hostCid: 'h',
+            participants: [{ cid: 'a' }],
+            reconnect: 'recovered',
+            epoch: 7,
+            reconnectTokenTTLMs: 600_000,
+        });
+        expect(result?.reconnect).toBe('recovered');
+        expect(result?.epoch).toBe(7);
+        expect(result?.reconnectTokenTTLMs).toBe(600_000);
+    });
+
+    it('rejects unknown reconnect outcome values', () => {
+        const result = parseJoinedPayload({
+            hostCid: 'h',
+            participants: [{ cid: 'a' }],
+            reconnect: 'banana',
+        });
+        expect(result?.reconnect).toBeUndefined();
+    });
+
+    it('parses participant content state', () => {
+        const result = parseJoinedPayload({
+            hostCid: 'h',
+            participants: [
+                {
+                    cid: 'a',
+                    contentState: { active: true, contentType: 'screen', updatedAtMs: 1000, epoch: 3 },
+                },
+                {
+                    cid: 'b',
+                    contentState: { active: false },
+                },
+                {
+                    cid: 'c',
+                    contentState: { active: 'nope' },
+                },
+            ],
+        });
+        expect(result?.participants[0].contentState).toEqual({
+            active: true,
+            contentType: 'screen',
+            updatedAtMs: 1000,
+            epoch: 3,
+        });
+        expect(result?.participants[1].contentState).toEqual({
+            active: false,
+            contentType: undefined,
+            updatedAtMs: undefined,
+            epoch: undefined,
+        });
+        expect(result?.participants[2].contentState).toBeUndefined();
+    });
+});
+
+describe('parseRoomStatePayload — Phase 1 fields', () => {
+    it('parses epoch and content state', () => {
+        const result = parseRoomStatePayload({
+            hostCid: 'h',
+            participants: [
+                { cid: 'a', contentState: { active: true, contentType: 'screen' } },
+            ],
+            epoch: 12,
+        });
+        expect(result?.epoch).toBe(12);
+        expect(result?.participants[0].contentState?.active).toBe(true);
+        expect(result?.participants[0].contentState?.contentType).toBe('screen');
+    });
+});
+
+describe('parseErrorPayload — Phase 1 fields', () => {
+    it('parses reason field', () => {
+        expect(parseErrorPayload({ code: 'ROOM_ENDED', message: 'gone', reason: 'ended_by_host' })).toEqual({
+            code: 'ROOM_ENDED',
+            message: 'gone',
+            reason: 'ended_by_host',
+        });
+    });
+
+    it('omits reason when not a string', () => {
+        const result = parseErrorPayload({ code: 'X', message: 'y', reason: 42 });
+        expect(result?.reason).toBeUndefined();
+    });
+});
+
+describe('parseRelayFailedPayload', () => {
+    it('parses target_suspended payload', () => {
+        expect(parseRelayFailedPayload({ reason: 'target_suspended', targets: ['C-1'], of: 'offer' })).toEqual({
+            reason: 'target_suspended',
+            targets: ['C-1'],
+            of: 'offer',
+        });
+    });
+
+    it('returns null on empty targets list', () => {
+        expect(parseRelayFailedPayload({ reason: 'target_suspended', targets: [] })).toBeNull();
+    });
+
+    it('returns null when reason missing', () => {
+        expect(parseRelayFailedPayload({ targets: ['C-1'] })).toBeNull();
+    });
+
+    it('drops non-string entries from targets', () => {
+        const result = parseRelayFailedPayload({ reason: 'target_suspended', targets: ['C-1', 7, ''] });
+        expect(result?.targets).toEqual(['C-1']);
+    });
+});
+
+describe('parseNegotiationDirtyPayload', () => {
+    it('parses well-formed payload', () => {
+        expect(parseNegotiationDirtyPayload({ with: 'C-2' })).toEqual({ with: 'C-2' });
+    });
+
+    it('returns null when `with` missing', () => {
+        expect(parseNegotiationDirtyPayload({})).toBeNull();
+    });
+
+    it('returns null when `with` empty', () => {
+        expect(parseNegotiationDirtyPayload({ with: '' })).toBeNull();
     });
 });

--- a/docs/resilience-failure-modes.md
+++ b/docs/resilience-failure-modes.md
@@ -1,7 +1,7 @@
 # Resilience Failure Modes — Audit & Fix Plan
 
-**Status:** Draft
-**Date:** 2026-04-26
+**Status:** Phase 1 implemented (server + Web/Android/iOS SDKs); Phase 2 & 3 outstanding.
+**Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed)
 **Scope:** Web, Android, iOS SDKs and the Go signaling server
 
 ## Background
@@ -58,32 +58,44 @@ must preserve the core UX model:
 
 ## Priority Summary
 
-| # | Failure Mode                                              | User-visible Symptom                                      | Severity | Effort |
-|---|-----------------------------------------------------------|-----------------------------------------------------------|----------|--------|
-| 1 | Negotiation messages missed while peer is suspended       | Stuck call setup, missing media after reconnect           | Critical | M      |
-| 2 | Reconnect creates a new CID instead of preserving identity | App thinks it rejoined; peers see duplicate/empty state   | Critical | S      |
-| 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      |
-| 4 | ICE restart fires on stale peer map at reconnect          | Offers to ghost CIDs, missing offers to new peers         | High     | S      |
-| 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      |
-| 6 | No explicit "you are suspended / about to be evicted"     | UI can't show countdown; apps can't make smart choices    | Medium   | S      |
-| 7 | SSE transport hijack via SID reuse                        | Security: another connection can take over an SSE session | Critical | S      |
-| 8 | iOS background suspension keeps SDK in stale "connected"  | After long background, signaling appears alive but isn't  | High     | M      |
-| 9 | TURN credentials expire while signaling is down           | Relay path fails; cannot recover even when signaling back | Medium   | S      |
-| 10| Push-to-rejoin races with local cleanup                   | Duplicate sessions, ghost slot on server                  | High     | M      |
-| 11| `end_room` doesn't notify suspended peers                 | Suspended peer reconnect-loops a dead room                | Medium   | XS     |
-| 12| WS↔SSE failover creates split SIDs server-side            | Brief duplicate-attached state, peer flicker              | Medium   | M      |
-| 13| Buffered signaling payloads become stale across reconnect | SDP collisions / out-of-order offer-answer state          | Medium   | S      |
-| 14| Android foreground-service lifecycle drift                | Orphaned service after process kill blocks next call      | Medium   | S      |
-| 15| Reconnect-token replay can reclaim active CIDs            | Security: attacker can evict and impersonate a participant | Critical | M      |
-| 16| Ephemeral content state lost while peer is suspended      | Screen share / content layout gets stale after reconnect  | High     | S      |
+| # | Failure Mode                                              | User-visible Symptom                                      | Severity | Effort | Status |
+|---|-----------------------------------------------------------|-----------------------------------------------------------|----------|--------|--------|
+| 1 | Negotiation messages missed while peer is suspended       | Stuck call setup, missing media after reconnect           | Critical | M      | Phase 1 (server) · SDK glare-safe renegotiation pending |
+| 2 | Reconnect creates a new CID instead of preserving identity | App thinks it rejoined; peers see duplicate/empty state   | Critical | S      | Phase 1 ✅ |
+| 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      | Phase 1 (server cleanup gate) · SDK presentation timer + emission pending |
+| 4 | ICE restart fires on stale peer map at reconnect          | Offers to ghost CIDs, missing offers to new peers         | High     | S      | Phase 1 (server epoch + post-reconnect snapshot) · SDK MediaEngine wiring pending |
+| 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      | Phase 2 |
+| 6 | No explicit "you are suspended / about to be evicted"     | UI can't show countdown; apps can't make smart choices    | Medium   | S      | Phase 2 |
+| 7 | SSE transport hijack via SID reuse                        | Security: another connection can take over an SSE session | Critical | S      | Phase 2 — server `TODO(#7)` placed; needs SDK `resumeSse` first |
+| 8 | iOS background suspension keeps SDK in stale "connected"  | After long background, signaling appears alive but isn't  | High     | M      | Phase 2 |
+| 9 | TURN credentials expire while signaling is down           | Relay path fails; cannot recover even when signaling back | Medium   | S      | Phase 3 |
+| 10| Push-to-rejoin races with local cleanup                   | Duplicate sessions, ghost slot on server                  | High     | M      | Phase 2 |
+| 11| `end_room` doesn't notify suspended peers                 | Suspended peer reconnect-loops a dead room                | Medium   | XS     | Phase 1 ✅ (tombstone + ROOM_ENDED) |
+| 12| WS↔SSE failover creates split SIDs server-side            | Brief duplicate-attached state, peer flicker              | Medium   | M      | Phase 3 — depends on #7 + #15 |
+| 13| Buffered signaling payloads become stale across reconnect | SDP collisions / out-of-order offer-answer state          | Medium   | S      | Phase 1 (server epoch + dirty-pair) · SDK enqueue tagging + flush-time discard pending |
+| 14| Android foreground-service lifecycle drift                | Orphaned service after process kill blocks next call      | Medium   | S      | Phase 3 |
+| 15| Reconnect-token replay can reclaim active CIDs            | Security: attacker can evict and impersonate a participant | Critical | M      | Phase 1 (token expiry) · transport-resume coupling Phase 2 |
+| 16| Ephemeral content state lost while peer is suspended      | Screen share / content layout gets stale after reconnect  | High     | S      | Phase 1 ✅ |
 
 Severity legend: Critical = corruption or security; High = correctness break;
 Medium = degraded UX or recoverable.
 Effort: XS < 1d, S = 1-3d, M = 3-7d.
 
+Status legend: **Phase 1 ✅** = fully landed (server + all 3 SDKs); **Phase 1
+(server)** = server-side protocol in place, SDK-side consumption staged for
+follow-up; **Phase 2** / **Phase 3** = not started, see *Suggested ordering*.
+
 ---
 
 ## 1. Negotiation messages missed while a peer is suspended
+
+**Status (2026-04-25):** Server side landed. `handleRelay` now records a
+dirty pair on the room when an offer/answer/ice targets a CID without an
+attached transport, replies `relay_failed{target_suspended,targets,of}` to
+the sender, and emits `negotiation_dirty{with}` to active peers right after
+the reattach snapshot. SDKs parse both new messages but glare-safe
+renegotiation scheduling in `MediaEngine` / `WebRtcEngine` /
+`PeerNegotiationEngine` is the remaining piece.
 
 ### Symptom
 
@@ -172,6 +184,15 @@ senders stop waiting forever for an answer that will never arrive.
 ---
 
 ## 2. Reconnect creates a new CID instead of preserving identity
+
+**Status (2026-04-25):** Landed end-to-end. `joined.payload.reconnect` now
+reports `"fresh" | "reattached" | "recovered"`, and a valid reconnect token
+that targets a missing participant record recreates the slot under the
+requested CID. SDKs parse the outcome (`lastReconnectOutcome` /
+`JoinReconnectOutcome` / `ReconnectOutcome`) and surface `sessionExpired`
+on `INVALID_RECONNECT_TOKEN`, clearing persisted reconnect state. Tombstone
+checks (#11) gate the `"recovered"` path so a deliberately-ended room never
+silently turns into a fresh participant.
 
 ### Symptom
 
@@ -275,6 +296,13 @@ the boundary.
 
 ## 3. Suspension conflates signaling loss with media death
 
+**Status (2026-04-25):** Server-side cleanup gate landed. Active peers can
+send a new `media_liveness{cids:[...]}` hint and the server defers
+hard-eviction while a recent observation exists for the CID
+(`mediaLivenessFreshnessWindow = 30s`,
+`hardEvictMediaActiveDeferral = 30s`). SDK-side periodic emission and the
+per-participant presentation timer (#6 surface) are the remaining pieces.
+
 ### Symptom
 
 Remote peer A's signaling transport drops. Server marks A
@@ -375,6 +403,15 @@ authorization or proof of identity.
 
 ## 4. ICE restart fires against stale peer map on reconnect
 
+**Status (2026-04-25):** Server-side ready. `Room.Epoch` advances on every
+membership-mutating operation; `joined` and `room_state` carry `epoch`; and
+the server now sends an authoritative `room_state` snapshot on the new
+transport immediately after every successful `joined`, regardless of
+whether membership changed. The Web `SignalingEngine` records
+`epochAtDisconnect` and exposes `awaitingPostReconnectSnapshot` for
+`MediaEngine` to gate ICE restart on. Wiring that gate into the actual ICE
+restart scheduler in each SDK is the remaining piece.
+
 ### Symptom
 
 Signaling reconnects after a 30 s drop. The SDK's cached `roomState` shows
@@ -439,6 +476,8 @@ top of existing reconnect flow.
 ---
 
 ## 5. Process death without clean teardown
+
+**Status (2026-04-25):** Not started — Phase 2.
 
 ### Symptom
 
@@ -528,6 +567,14 @@ rejoin dead calls.
 
 ## 6. No explicit "you are suspended / about to be evicted" signal
 
+**Status (2026-04-25):** Not started — Phase 2. The shared resilience
+constants needed for the countdown
+(`peerSuspendedUiTimeoutMs`, `suspendHardEvictionTimeoutMs`,
+`epochResyncTimeoutMs`, `turnRefreshSafetyMarginMs`,
+`foregroundForcePingTimeoutMs`) are not yet added to
+`scripts/check-resilience-constants.mjs`; do that as part of the Phase 2
+slice.
+
 ### Symptom
 
 The SDK can't tell the difference between "I'm reconnecting and the server is
@@ -593,6 +640,11 @@ Low. State surface only.
 ---
 
 ## 7. SSE transport hijack via SID reuse
+
+**Status (2026-04-25):** Deferred to Phase 2. A `TODO(#7)` is placed at
+`server/sse.go` next to `replaceClient` so the hardening lands in lockstep
+with SDK `resumeSse` support. Shipping the server change without the SDK
+piece would break legitimate in-flight SSE transport flaps.
 
 ### Symptom
 
@@ -682,6 +734,8 @@ behind a server feature flag for one release; clients gain `resumeSse` first.
 
 ## 8. iOS background suspension keeps SDK in stale "connected" state
 
+**Status (2026-04-25):** Not started — Phase 2.
+
 ### Symptom
 
 User backgrounds the iOS app during a call. iOS suspends the process, freezing
@@ -734,6 +788,8 @@ Low. Additive lifecycle observers; the synthetic ping is cheap.
 ---
 
 ## 9. TURN credentials expire while signaling is down
+
+**Status (2026-04-25):** Not started — Phase 3.
 
 ### Symptom
 
@@ -788,6 +844,8 @@ changes.
 ---
 
 ## 10. Push-to-rejoin races with local cleanup
+
+**Status (2026-04-25):** Not started — Phase 2.
 
 ### Symptom
 
@@ -856,6 +914,13 @@ decision, not as part of this race fix.
 
 ## 11. `end_room` doesn't notify suspended peers
 
+**Status (2026-04-25):** Landed end-to-end. `Hub.tombstones` records ended
+rooms with a 5-minute TTL; reconnect attempts presenting valid token
+authority for a tombstoned RID receive a structured
+`error{code:"ROOM_ENDED", reason:"ended_by_host"}`. SDKs map ROOM_ENDED to
+the existing terminal `roomEnded` error and clear persisted reconnect
+state.
+
 ### Symptom
 
 Host calls `end_room` while peer P is suspended. Server stops P's
@@ -905,6 +970,9 @@ Very low. Pure server-side addition.
 ---
 
 ## 12. WS↔SSE failover creates split SIDs server-side
+
+**Status (2026-04-25):** Not started — Phase 3 (depends on #7 + #15
+hardening shipping first).
 
 ### Symptom
 
@@ -958,6 +1026,12 @@ it would create a new takeover path.
 ---
 
 ## 13. Buffered signaling payloads become stale across reconnect
+
+**Status (2026-04-25):** Server-side support already in place via #1's
+dirty-pair tracking and #4's epoch-stamped snapshots. SDK enqueue tagging
+(timestamp + epoch at enqueue, discard at flush, and tail-drop on ICE
+candidate overflow) is the remaining piece — staged for the same MediaEngine
+slice that wires up #4's gate.
 
 ### Symptom
 
@@ -1015,6 +1089,8 @@ wait forever.
 
 ## 14. Android foreground-service lifecycle drift
 
+**Status (2026-04-25):** Not started — Phase 3.
+
 ### Symptom
 
 `SerenadaSession` crashes (uncaught exception, OOM in WebRTC native code,
@@ -1060,6 +1136,15 @@ Low. Additive guards on a host-app lifecycle.
 ---
 
 ## 15. Reconnect-token replay can reclaim active CIDs
+
+**Status (2026-04-25):** Token expiry landed. Reconnect tokens are now
+HMAC-bound to `(cid, rid, expiresAt)` with format `<hmac>.<expiresAtUnix>`,
+TTL = `suspendHardEvictionTimeout`. `validateReconnectToken` returns
+`(ok, expired)` and the join handler maps both to
+`INVALID_RECONNECT_TOKEN`. Coupling token authority to the
+`transportResumeId` proof from #12 — so a leaked token alone cannot
+replace an active transport — is Phase 2 work and ships together with #7
+and #12.
 
 ### Symptom
 
@@ -1133,6 +1218,14 @@ device-bound proof as a future hardening option if the product needs it.
 ---
 
 ## 16. Ephemeral content state lost while peer is suspended
+
+**Status (2026-04-25):** Landed end-to-end. `roomParticipant.ContentState`
+captures the latest `{active, contentType, updatedAtMs, epoch}` at
+`handleRelay` time and the value is included in every `joined` /
+`room_state` participant entry. SDKs parse `ParticipantContentState` on
+all three platforms; UI reconciliation (showing a "loading media" state
+while the SDP catches up to a stale-but-active share) is a follow-up that
+sits on top of the existing parser.
 
 ### Symptom
 
@@ -1306,6 +1399,88 @@ Out of scope for this document, listed for visibility:
   it deserves a fresh look.
 
 ## Change Log
+
+### 2026-04-25 — Phase 1 implementation landed
+
+- **Server (`server/signaling.go`, `server/sse.go`)**:
+  - Added `Hub.tombstones` (5-minute TTL) populated by `handleEndRoom`;
+    reconnect attempts presenting valid token authority for a tombstoned
+    RID receive `error{code:"ROOM_ENDED", reason:"ended_by_host"}`.
+  - Reworked `handleJoin` to surface
+    `joined.payload.reconnect: "fresh" | "reattached" | "recovered"` and
+    to recreate the participant record under the requested CID when a
+    valid reconnect token's room is gone.
+  - Reformatted reconnect tokens as
+    `hex(HMAC-SHA256(secret, cid|rid|expiresAt)).<expiresAtUnix>` with TTL
+    capped at `suspendHardEvictionTimeout`; `validateReconnectToken`
+    returns `(ok, expired)` and old-format tokens are rejected.
+  - Added `Room.Epoch` (monotonic, advanced on every join/leave/suspend/
+    reattach/evict/end_room) plumbed into `joined` and `room_state`. The
+    server now emits an authoritative `room_state` snapshot on the new
+    transport immediately after every successful `joined`.
+  - Added `Room.negotiationDirty` and rewrote `handleRelay` so that
+    offer/answer/ice to suspended targets is no longer silently dropped:
+    the dirty pair is recorded, the sender receives
+    `relay_failed{target_suspended,targets,of}`, and on reattach the
+    server emits `negotiation_dirty{with}` to the affected peers right
+    after the post-reconnect snapshot.
+  - Added new `media_liveness{cids:[...]}` message and
+    `Room.mediaLiveness`. `hardEvictSuspended` now defers eviction while
+    a recent liveness hint exists
+    (`mediaLivenessFreshnessWindow = 30s`,
+    `hardEvictMediaActiveDeferral = 30s`).
+  - Persisted latest content state on `roomParticipant.ContentState`;
+    `handleRelay` for `content_state` updates the record and the value
+    is included in every `joined` / `room_state` participant entry.
+  - SSE pending-session model (#7) deliberately deferred behind a
+    `TODO(#7)` next to `replaceClient`; the proper fix needs the matching
+    SDK `resumeSse` envelope and ships in Phase 2.
+
+- **All three SDKs**:
+  - Parse the new fields (`epoch`, `reconnect`, `reconnectTokenTTLMs`,
+    `participants[].contentState`, `error.reason`) and the new payload
+    types (`relay_failed`, `negotiation_dirty`).
+  - Map `INVALID_RECONNECT_TOKEN` to a new dedicated terminal error
+    (`sessionExpired` / `SessionExpired` / `.sessionExpired`) and clear
+    persisted reconnect storage on either `ROOM_ENDED` or
+    `INVALID_RECONNECT_TOKEN`.
+  - Web `SignalingEngine` additionally tracks
+    `lastReconnectOutcome`, `lastEpoch`, `epochAtDisconnect`, and
+    `awaitingPostReconnectSnapshot` so `MediaEngine` can gate ICE restart
+    on a confirmed post-reconnect snapshot.
+
+- **Tests / CI**:
+  - Added `server/resilience_phase1_test.go` covering reconnect outcomes,
+    recovered-CID, ROOM_ENDED tombstone, expired-token rejection, epoch
+    advancement, post-reconnect snapshot, dirty-pair + `relay_failed`,
+    `negotiation_dirty` on reattach, content-state replay, and
+    media-liveness deferral.
+  - Added Web payload tests for the new fields and parsers.
+  - Server (Go), Web (vitest, 301), Android (gradle), iOS
+    (xcodebuild, 246) all green.
+  - `scripts/check-resilience-constants.mjs` and
+    `scripts/check-version-parity.mjs` green.
+
+- **Docs**:
+  - `docs/serenada_protocol_v1.md` updated with the new fields on
+    `joined` / `room_state`, the new error codes
+    (`ROOM_ENDED`, `INVALID_RECONNECT_TOKEN`), and three new message
+    types (`relay_failed`, `negotiation_dirty`, `media_liveness`).
+  - This document's priority table now carries a Status column and each
+    failure-mode section has a `**Status:**` line summarizing what
+    landed in Phase 1 and what remains.
+
+- **Deferred to follow-up slices**:
+  - SDK MediaEngine consumption of `negotiation_dirty` /
+    `relay_failed` / post-reconnect snapshot gate (#1, #4, #13 SDK side).
+  - Periodic `media_liveness` emission from SDKs (#3 SDK side) and the
+    per-participant suspended UI presentation timer (#3 / #6 surface).
+  - Stale buffered offer/ICE discard in the SDK enqueue/flush path (#13).
+  - SSE pending-session + `resumeSse` (#7) shipped together with the
+    transport-resume coupling (#12) and the active-replacement guard
+    (#15 part 2).
+  - Process-death recovery (#5), iOS background-foreground forced ping
+    (#8), push-to-rejoin lifecycle serialization (#10).
 
 ### 2026-04-26
 

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -162,7 +162,11 @@ Acknowledges join success and provides room state.
       { "cid": "C-c3d4...", "joinedAt": 1735171215000 }
     ],
     "turnToken": "T-abc123yz...",
-    "turnTokenExpiresAt": 1735174800
+    "turnTokenExpiresAt": 1735174800,
+    "reconnectToken": "ab12...c3.1735174800",
+    "reconnectTokenTTLMs": 600000,
+    "epoch": 7,
+    "reconnect": "reattached"
   }
 }
 ```
@@ -170,20 +174,33 @@ Acknowledges join success and provides room state.
 **Fields in payload**
 - `hostCid` *(string)*: client ID of the current host.
 - `maxParticipants` *(number)*: current effective room capacity. For a newly created group-requested room, this is `2` until the second distinct participant joins and locks the final room capacity.
-- `participants` *(array)*: list of current participants. Each entry has `cid` *(string)*, `joinedAt` *(number, optional)*, `displayName` *(string, optional)*, `audioEnabled` *(boolean, optional)*, `videoEnabled` *(boolean, optional)*, and `connectionStatus` *(string, optional)*. See section 4.3 for the meaning of `connectionStatus`.
+- `participants` *(array)*: list of current participants. Each entry has `cid` *(string)*, `joinedAt` *(number, optional)*, `displayName` *(string, optional)*, `audioEnabled` *(boolean, optional)*, `videoEnabled` *(boolean, optional)*, `connectionStatus` *(string, optional)*, and `contentState` *(object, optional)*. See section 4.3 for the meaning of `connectionStatus` and `contentState`.
 - `turnToken` *(string, optional)*: temporary token for fetching TURN credentials from `/api/turn-credentials`. Only present on successful join.
 - `turnTokenExpiresAt` *(number, optional)*: unix timestamp (seconds) when the token expires.
+- `reconnectToken` *(string, optional)*: opaque proof bound to `(cid, rid, expiresAt)` that the SDK persists and presents on a future `join` to reattach or recover the same CID. Format is implementation-defined; clients should treat it as opaque.
+- `reconnectTokenTTLMs` *(number, optional)*: how long (ms) the server will accept this reconnect token. SDKs that persist the token across launches should clear it once the window has elapsed.
+- `epoch` *(number, optional)*: monotonic room state epoch advanced by the server on every membership-mutating operation. SDKs gate ICE restart on receiving an authoritative post-reconnect snapshot rather than acting on a stale in-memory peer map.
+- `reconnect` *(string, optional)*: outcome of this join. Values: `"fresh"` (server created a new participant identity — CID may be new), `"reattached"` (server attached the new transport to a still-present participant slot), `"recovered"` (the previous participant record was gone but the reconnect token still validated, so the server recreated the record with the requested CID). Older servers may omit this field; SDKs should treat absent as `"fresh"`.
 
 **Client behavior**
 - Store `sid`, `cid`, and `turnToken`.
 - Immediately fetch ICE servers using the `turnToken` via the `token` query param on `/api/turn-credentials`.
+- Persist `reconnectToken` (with `reconnectTokenTTLMs`) so a future join can reattach or recover identity.
+- For `"reattached"`/`"recovered"` outcomes, keep media-active `RTCPeerConnection`s in place; renegotiate only for pairs the server flags via `negotiation_dirty` (section 4.10) or that the SDK considers stale based on local heuristics.
+- For `"fresh"` outcomes, the SDK may treat the call as ground-up new; an existing `RTCPeerConnection` should still only be torn down if no media has flowed recently.
+- Wait for the authoritative `room_state` snapshot the server emits immediately after `joined` before scheduling renegotiation against this transport's view of the peer set.
 - If another participant is already present, proceed to WebRTC negotiation using the rules in section 5.
+
+The server emits an authoritative `room_state` (section 4.3) immediately after every successful `joined`, even when membership did not change during the outage. SDKs use that broadcast as the reliable post-reconnect sync point.
 
 ---
 
 ### 4.3 `room_state` (server → client)
 Sent when participants join/leave, host changes, or a participant's transport
-state transitions between connected and suspended.
+state transitions between connected and suspended. Also delivered to a
+single client immediately after every successful `joined` so the SDK has a
+reliable post-reconnect sync point even when membership did not change
+during the outage.
 
 ```json
 {
@@ -193,13 +210,24 @@ state transitions between connected and suspended.
   "payload": {
     "hostCid": "C-a1b2...",
     "maxParticipants": 4,
+    "epoch": 7,
     "participants": [
       { "cid": "C-a1b2...", "joinedAt": 1735171200000, "displayName": "Alice" },
-      { "cid": "C-c3d4...", "joinedAt": 1735171215000, "connectionStatus": "suspended" }
+      { "cid": "C-c3d4...", "joinedAt": 1735171215000, "connectionStatus": "suspended", "contentState": { "active": true, "contentType": "screen" } }
     ]
   }
 }
 ```
+
+**Payload `epoch`**
+
+`epoch` is a monotonic counter advanced by the server on every
+membership-mutating operation (join, leave, suspend, reattach, evict, host
+transfer, end_room). SDKs use it to gate ICE restart on an authoritative
+post-reconnect snapshot rather than acting on a stale in-memory peer map.
+Older servers may omit this field. Forward compatibility: SDKs should
+tolerate `epoch` being absent and only act on epoch comparisons when the
+server has supplied them.
 
 **Participant `connectionStatus`**
 
@@ -217,6 +245,28 @@ Each participant entry may carry an optional `connectionStatus` field. Values:
 
 Unknown `connectionStatus` values must be treated as `"active"` for forward
 compatibility.
+
+**Participant `contentState`**
+
+Each participant entry may carry an optional `contentState` object that
+describes the participant's latest ephemeral content metadata (screen
+share, content camera mode, etc.). Persisting this on the participant
+record means a peer reconnecting after a suspension reconstructs UI from
+the next `room_state` without waiting for the sender to toggle content
+again.
+
+Fields:
+- `active` *(boolean, required)*: whether content is currently being
+  shared. When `false`, `contentType` is omitted.
+- `contentType` *(string, optional)*: free-form content kind (for
+  example `"screen"`).
+- `updatedAtMs` *(number, optional)*: unix-ms timestamp of the last
+  content state transition.
+- `epoch` *(number, optional)*: room state epoch at which the latest
+  content state transition was recorded.
+
+Older servers may omit `contentState` entirely; SDKs should treat that as
+"unknown — preserve current local state" rather than implicitly clearing.
 
 **Client behavior**
 - Update UI for "waiting for someone to join" vs "in call".
@@ -431,7 +481,100 @@ Standard error message.
 - `NOT_HOST` — non-host attempted `end_room`
 - `SERVER_NOT_CONFIGURED` — room ID secret missing on server
 - `INVALID_ROOM_ID` — room ID failed validation
+- `INVALID_RECONNECT_TOKEN` — supplied `reconnectToken` failed signature/expiry validation. SDKs MUST clear persisted reconnect state and surface a dedicated terminal error (e.g. `sessionExpired`) instead of looping reconnect attempts.
+- `ROOM_ENDED` — the room was explicitly ended (host `end_room`) within the server-side tombstone window. Returned to a reconnect attempt that presents valid reconnect authority for a now-gone room. Payload may include `"reason": "ended_by_host"`. SDKs MUST treat this as terminal and clear persisted reconnect state.
 - `INTERNAL` — unexpected server error
+
+---
+
+### 4.14 `relay_failed` (server → client)
+
+Notifies a sender that a previously-routable peer message could not be
+delivered because the target was suspended at the time. Emitted only for
+negotiation traffic (`offer`, `answer`, `ice`); `content_state` is handled
+via the participant content metadata in section 4.3.
+
+```json
+{
+  "v": 1,
+  "type": "relay_failed",
+  "rid": "AbC123",
+  "payload": {
+    "reason": "target_suspended",
+    "targets": ["C-c3d4..."],
+    "of": "offer"
+  }
+}
+```
+
+**Client behavior**
+- Suppress further negotiation toward the named CIDs while they remain
+  suspended. Old offers/ICE may have already moved on; replaying them is
+  worse than missing them.
+- Wait for `negotiation_dirty` (section 4.15) once the peer reattaches,
+  then perform glare-safe fresh negotiation/ICE restart for that pair.
+
+---
+
+### 4.15 `negotiation_dirty` (server → client)
+
+Tells the sender that a previously-suspended peer has reattached AND that
+the sender had pending negotiation traffic to it during the suspension.
+Emitted after the authoritative post-reconnect `room_state` so SDKs can
+schedule fresh negotiation against confirmed state.
+
+```json
+{
+  "v": 1,
+  "type": "negotiation_dirty",
+  "rid": "AbC123",
+  "payload": {
+    "with": "C-c3d4..."
+  }
+}
+```
+
+**Client behavior**
+- Schedule a glare-safe fresh negotiation or ICE restart for the named
+  CID. Do NOT replay the previously-buffered SDP/ICE.
+
+---
+
+### 4.16 `media_liveness` (client → server)
+
+Hint reported by an active client that it is currently receiving inbound
+media from one or more remote CIDs. The server uses this to defer
+hard-eviction of a suspended participant when at least one peer still sees
+its media — a participant whose signaling transport is late to recover but
+whose media is still flowing should not be removed solely because the
+directory clock fired.
+
+```json
+{
+  "v": 1,
+  "type": "media_liveness",
+  "rid": "AbC123",
+  "payload": {
+    "cids": ["C-c3d4...", "C-e5f6..."]
+  }
+}
+```
+
+**Server behavior**
+- Records the most recent unix-ms timestamp at which any active peer
+  reported inbound media for each CID.
+- During hard-eviction, defers removal while a recent liveness report
+  exists; re-evaluates after a short window. Liveness is a cleanup hint
+  only — it never authorizes anything else and never extends the slot
+  indefinitely.
+
+**Client behavior**
+- Send periodically while in a call (recommended every ~5 s) for any
+  remote CID whose inbound media is currently flowing. Send immediately
+  after a successful reconnect for any peer whose `RTCPeerConnection`
+  survived the outage.
+- Older servers ignore unknown message types — the hint is purely
+  additive.
 
 ---
 

--- a/server/resilience_phase1_test.go
+++ b/server/resilience_phase1_test.go
@@ -235,6 +235,105 @@ func TestReconnectAfterEndRoomReturnsRoomEnded(t *testing.T) {
 	_ = hostJoined
 }
 
+// TestFreshJoinClearsTombstoneSoNewParticipantsCanReconnect locks in the
+// fix for the bug where ending a room and immediately recreating it via a
+// fresh join left the tombstone in place. Any reconnect with a valid
+// token (including one issued for the new room session) would then be
+// rejected with ROOM_ENDED until the tombstone TTL expired.
+func TestFreshJoinClearsTombstoneSoNewParticipantsCanReconnect(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	// Session 1: host joins and ends the room → tombstone created.
+	host1 := fakeClient(hub)
+	hub.registerClient(host1)
+	hub.handleMessage(host1, joinPayload(rid, 4, 4))
+	captureJoined(t, host1)
+
+	endMsg := Message{V: 1, Type: "end_room", RID: rid}
+	endBytes, _ := json.Marshal(endMsg)
+	hub.handleMessage(host1, endBytes)
+
+	if t1 := hub.lookupTombstone(rid); t1 == nil {
+		t.Fatal("expected tombstone after end_room")
+	}
+
+	// Session 2: someone does a FRESH join to the same RID. Tombstone
+	// should be cleared once the room is alive again.
+	host2 := fakeClient(hub)
+	hub.registerClient(host2)
+	hub.handleMessage(host2, joinPayload(rid, 4, 4))
+	host2Joined := captureJoined(t, host2)
+	if host2Joined.Reconnect != reconnectOutcomeFresh {
+		t.Fatalf("expected fresh outcome on second join, got %q", host2Joined.Reconnect)
+	}
+	if t2 := hub.lookupTombstone(rid); t2 != nil {
+		t.Fatal("expected tombstone to be cleared after a fresh join recreates the room")
+	}
+
+	// Now the new participant must be able to reconnect with the token
+	// they were just issued, without hitting the stale ROOM_ENDED gate.
+	hub.disconnectClient(host2)
+
+	host2b := fakeClient(hub)
+	hub.registerClient(host2b)
+	hub.handleMessage(host2b, joinWithReconnect(rid, host2Joined.CID, host2Joined.ReconnectToken))
+	rejoined := captureJoined(t, host2b)
+	if rejoined.Reconnect != reconnectOutcomeReattached {
+		t.Fatalf("expected reattach for new-room participant, got %q", rejoined.Reconnect)
+	}
+}
+
+// TestMalformedContentStateDoesNotClearStoredValue locks in the fix for
+// the bug where a content_state payload missing a boolean `active` field
+// would destructively clear the participant's previously-stored content
+// state instead of being ignored.
+func TestMalformedContentStateDoesNotClearStoredValue(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	captureJoined(t, b)
+	drainMessages(a)
+	drainMessages(b)
+
+	// A starts a screen share.
+	csPayload, _ := json.Marshal(map[string]interface{}{
+		"active":      true,
+		"contentType": "screen",
+	})
+	hub.handleMessage(a, mustMarshal(Message{V: 1, Type: "content_state", RID: rid, Payload: csPayload}))
+
+	// A sends a malformed update missing the boolean `active`. This must
+	// NOT clobber the stored state.
+	bogusPayload, _ := json.Marshal(map[string]interface{}{
+		"contentType": "huh",
+	})
+	hub.handleMessage(a, mustMarshal(Message{V: 1, Type: "content_state", RID: rid, Payload: bogusPayload}))
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	room.mu.Lock()
+	p := room.participantByCID(a.cid)
+	room.mu.Unlock()
+	if p == nil || p.ContentState == nil {
+		t.Fatal("expected stored content state to survive malformed update")
+	}
+	if !p.ContentState.Active || p.ContentState.ContentType != "screen" {
+		t.Fatalf("expected active=true contentType=screen, got %+v", p.ContentState)
+	}
+}
+
 func TestExpiredReconnectTokenIsRejected(t *testing.T) {
 	t.Setenv("TURN_SECRET", "test-reconnect-secret")
 	rid := mustTestRoomID(t)

--- a/server/resilience_phase1_test.go
+++ b/server/resilience_phase1_test.go
@@ -1,0 +1,587 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// helpers ---------------------------------------------------------------------
+
+type joinedFields struct {
+	CID                 string        `json:"-"`
+	Reconnect           string        `json:"reconnect"`
+	Epoch               int64         `json:"epoch"`
+	ReconnectToken      string        `json:"reconnectToken"`
+	ReconnectTokenTTLMs int64         `json:"reconnectTokenTTLMs"`
+	Participants        []Participant `json:"participants"`
+}
+
+func captureJoined(t *testing.T, c *Client) joinedFields {
+	t.Helper()
+	for _, msg := range drainMessages(c) {
+		if msg.Type != "joined" {
+			continue
+		}
+		var f joinedFields
+		if err := json.Unmarshal(msg.Payload, &f); err != nil {
+			t.Fatalf("parse joined payload: %v", err)
+		}
+		f.CID = msg.CID
+		return f
+	}
+	t.Fatal("expected joined message")
+	return joinedFields{}
+}
+
+func captureRoomState(t *testing.T, c *Client) (epoch int64, participants []Participant, ok bool) {
+	t.Helper()
+	for _, msg := range drainMessages(c) {
+		if msg.Type != "room_state" {
+			continue
+		}
+		var f struct {
+			Epoch        int64         `json:"epoch"`
+			Participants []Participant `json:"participants"`
+		}
+		if err := json.Unmarshal(msg.Payload, &f); err != nil {
+			continue
+		}
+		epoch = f.Epoch
+		participants = f.Participants
+		ok = true
+	}
+	return
+}
+
+func joinWithReconnect(rid, cid, token string) []byte {
+	type caps struct {
+		MaxParticipants int `json:"maxParticipants,omitempty"`
+	}
+	payload := struct {
+		Capabilities          caps   `json:"capabilities,omitempty"`
+		CreateMaxParticipants int    `json:"createMaxParticipants,omitempty"`
+		ReconnectCID          string `json:"reconnectCid,omitempty"`
+		ReconnectToken        string `json:"reconnectToken,omitempty"`
+	}{
+		Capabilities:          caps{MaxParticipants: 4},
+		CreateMaxParticipants: 4,
+		ReconnectCID:          cid,
+		ReconnectToken:        token,
+	}
+	body, _ := json.Marshal(payload)
+	msg := Message{V: 1, Type: "join", RID: rid, Payload: body}
+	b, _ := json.Marshal(msg)
+	return b
+}
+
+// Reconnect outcomes ----------------------------------------------------------
+
+func TestJoinedPayloadIncludesReconnectOutcomeAndEpochOnFreshJoin(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+
+	got := captureJoined(t, a)
+	if got.Reconnect != reconnectOutcomeFresh {
+		t.Fatalf("expected reconnect=%q on fresh join, got %q", reconnectOutcomeFresh, got.Reconnect)
+	}
+	if got.Epoch <= 0 {
+		t.Fatalf("expected positive epoch on fresh join, got %d", got.Epoch)
+	}
+	if got.ReconnectToken == "" {
+		t.Fatal("expected reconnect token on fresh join")
+	}
+	if got.ReconnectTokenTTLMs <= 0 {
+		t.Fatalf("expected positive reconnectTokenTTLMs, got %d", got.ReconnectTokenTTLMs)
+	}
+}
+
+func TestReconnectAfterSuspendReportsReattachedOutcome(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+	if first.ReconnectToken == "" {
+		t.Fatal("expected reconnect token from initial join")
+	}
+
+	hub.disconnectClient(a)
+
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, first.ReconnectToken))
+	second := captureJoined(t, a2)
+	if second.Reconnect != reconnectOutcomeReattached {
+		t.Fatalf("expected reconnect=%q after suspend, got %q", reconnectOutcomeReattached, second.Reconnect)
+	}
+	if second.CID != first.CID {
+		t.Fatalf("expected reattach to preserve CID %s, got %s", first.CID, second.CID)
+	}
+	if second.Epoch <= first.Epoch {
+		t.Fatalf("expected epoch to advance after suspend+reattach, first=%d second=%d", first.Epoch, second.Epoch)
+	}
+}
+
+func TestReconnectAfterRoomGCRecoversCID(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	// Hard-evict and confirm the room is gone.
+	hub.disconnectClient(a)
+	hub.mu.RLock()
+	roomBeforeEvict := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if roomBeforeEvict == nil {
+		t.Fatal("expected room to exist after suspend")
+	}
+	hub.hardEvictSuspended(roomBeforeEvict, first.CID)
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if exists {
+		t.Fatal("expected room to be GC'd after sole participant hard-evicted")
+	}
+
+	// Reconnect with the original CID and a still-valid token.
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, first.ReconnectToken))
+	second := captureJoined(t, a2)
+	if second.Reconnect != reconnectOutcomeRecovered {
+		t.Fatalf("expected reconnect=%q after room GC, got %q", reconnectOutcomeRecovered, second.Reconnect)
+	}
+	if second.CID != first.CID {
+		t.Fatalf("expected recovered CID to match original %s, got %s", first.CID, second.CID)
+	}
+}
+
+func TestReconnectAfterEndRoomReturnsRoomEnded(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	host := fakeClient(hub)
+	hub.registerClient(host)
+	hub.handleMessage(host, joinPayload(rid, 4, 4))
+	hostJoined := captureJoined(t, host)
+
+	peer := fakeClient(hub)
+	hub.registerClient(peer)
+	hub.handleMessage(peer, joinPayload(rid, 4, 4))
+	peerJoined := captureJoined(t, peer)
+	drainMessages(host)
+	drainMessages(peer)
+
+	// Suspend peer so it has reason to use its reconnect token next.
+	hub.disconnectClient(peer)
+
+	// Host ends the room.
+	endMsg := Message{V: 1, Type: "end_room", RID: rid}
+	endBytes, _ := json.Marshal(endMsg)
+	hub.handleMessage(host, endBytes)
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if exists {
+		t.Fatal("expected room to be removed after end_room")
+	}
+
+	// Peer reconnects with valid token.
+	peer2 := fakeClient(hub)
+	hub.registerClient(peer2)
+	hub.handleMessage(peer2, joinWithReconnect(rid, peerJoined.CID, peerJoined.ReconnectToken))
+
+	got := drainMessages(peer2)
+	var saw bool
+	for _, msg := range got {
+		if msg.Type != "error" {
+			continue
+		}
+		var p struct {
+			Code   string `json:"code"`
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal(msg.Payload, &p); err != nil {
+			continue
+		}
+		if p.Code == "ROOM_ENDED" {
+			saw = true
+			if p.Reason == "" {
+				t.Fatal("expected ROOM_ENDED to include reason")
+			}
+		}
+	}
+	if !saw {
+		t.Fatalf("expected ROOM_ENDED error after end_room, got %+v", got)
+	}
+	_ = hostJoined
+}
+
+func TestExpiredReconnectTokenIsRejected(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	// Issue an artificially-expired token bound to (cid, rid).
+	expired := issueReconnectTokenWithExpiry(first.CID, rid, time.Now().Add(-10*time.Minute))
+	if expired == "" {
+		t.Fatal("expected non-empty expired token")
+	}
+
+	hub.disconnectClient(a)
+
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, expired))
+
+	var sawRejection bool
+	for _, msg := range drainMessages(a2) {
+		if msg.Type != "error" {
+			continue
+		}
+		var p struct {
+			Code string `json:"code"`
+		}
+		if err := json.Unmarshal(msg.Payload, &p); err != nil {
+			continue
+		}
+		if p.Code == "INVALID_RECONNECT_TOKEN" {
+			sawRejection = true
+		}
+	}
+	if !sawRejection {
+		t.Fatal("expected INVALID_RECONNECT_TOKEN for expired token")
+	}
+}
+
+// roomStateEpoch / post-reconnect snapshot ------------------------------------
+
+func TestEpochAdvancesOnEachMembershipChange(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	second := captureJoined(t, b)
+
+	if second.Epoch <= first.Epoch {
+		t.Fatalf("expected epoch to advance on additional join, first=%d second=%d", first.Epoch, second.Epoch)
+	}
+
+	hub.disconnectClient(a)
+	// Find latest room_state on b.
+	epoch3, _, ok := captureRoomState(t, b)
+	if !ok {
+		t.Fatal("expected room_state broadcast after suspend")
+	}
+	if epoch3 <= second.Epoch {
+		t.Fatalf("expected epoch to advance on suspend, prev=%d after=%d", second.Epoch, epoch3)
+	}
+}
+
+func TestPostReconnectSnapshotSentToReattachedClient(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	drainMessages(b)
+	drainMessages(a)
+
+	hub.disconnectClient(a)
+
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, first.ReconnectToken))
+
+	var sawSnapshot bool
+	var sawJoined bool
+	var snapshotEpoch int64
+	for _, msg := range drainMessages(a2) {
+		if msg.Type == "joined" {
+			sawJoined = true
+		}
+		if msg.Type == "room_state" {
+			sawSnapshot = true
+			var p struct {
+				Epoch int64 `json:"epoch"`
+			}
+			_ = json.Unmarshal(msg.Payload, &p)
+			snapshotEpoch = p.Epoch
+		}
+	}
+	if !sawJoined || !sawSnapshot {
+		t.Fatalf("expected joined + room_state on reconnect, joined=%t snapshot=%t", sawJoined, sawSnapshot)
+	}
+	if snapshotEpoch == 0 {
+		t.Fatal("expected snapshot to carry epoch")
+	}
+}
+
+// Dirty-pair / negotiation_dirty ---------------------------------------------
+
+func TestRelayToSuspendedTargetMarksDirtyAndEmitsRelayFailed(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	bJoined := captureJoined(t, b)
+
+	drainMessages(a)
+	hub.disconnectClient(b)
+	drainMessages(a) // clear the suspended-broadcast
+
+	offerPayload, _ := json.Marshal(map[string]interface{}{
+		"sdp": "v=0\r\n",
+	})
+	msg := Message{V: 1, Type: "offer", RID: rid, To: bJoined.CID, Payload: offerPayload}
+	raw, _ := json.Marshal(msg)
+	hub.handleMessage(a, raw)
+
+	var saw bool
+	for _, m := range drainMessages(a) {
+		if m.Type != "relay_failed" {
+			continue
+		}
+		var p struct {
+			Reason  string   `json:"reason"`
+			Targets []string `json:"targets"`
+			Of      string   `json:"of"`
+		}
+		if err := json.Unmarshal(m.Payload, &p); err != nil {
+			continue
+		}
+		if p.Reason == "target_suspended" && len(p.Targets) == 1 && p.Targets[0] == bJoined.CID && p.Of == "offer" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatal("expected relay_failed for suspended target")
+	}
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	room.mu.Lock()
+	dirty := room.negotiationDirty
+	room.mu.Unlock()
+	if dirty == nil || !dirty[a.cid][bJoined.CID] {
+		t.Fatalf("expected dirty negotiation pair %s→%s, got %+v", a.cid, bJoined.CID, dirty)
+	}
+}
+
+func TestNegotiationDirtyDeliveredOnReattach(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	bJoined := captureJoined(t, b)
+	drainMessages(a)
+
+	hub.disconnectClient(b)
+	drainMessages(a)
+
+	// A attempts to send an offer while B is suspended → marks dirty.
+	offerPayload, _ := json.Marshal(map[string]interface{}{"sdp": "v=0\r\n"})
+	msg := Message{V: 1, Type: "offer", RID: rid, To: bJoined.CID, Payload: offerPayload}
+	raw, _ := json.Marshal(msg)
+	hub.handleMessage(a, raw)
+	drainMessages(a) // consume relay_failed
+
+	// B reattaches.
+	b2 := fakeClient(hub)
+	hub.registerClient(b2)
+	hub.handleMessage(b2, joinWithReconnect(rid, bJoined.CID, bJoined.ReconnectToken))
+
+	var sawDirty bool
+	for _, m := range drainMessages(a) {
+		if m.Type != "negotiation_dirty" {
+			continue
+		}
+		var p struct {
+			With string `json:"with"`
+		}
+		_ = json.Unmarshal(m.Payload, &p)
+		if p.With == bJoined.CID {
+			sawDirty = true
+		}
+	}
+	if !sawDirty {
+		t.Fatal("expected negotiation_dirty notification to A after B reattaches")
+	}
+}
+
+// content_state ---------------------------------------------------------------
+
+func TestContentStatePersistsForReconnectingPeer(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	aJoined := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	bJoined := captureJoined(t, b)
+	drainMessages(a)
+	drainMessages(b)
+
+	// B suspends.
+	hub.disconnectClient(b)
+	drainMessages(a)
+
+	// A starts a screen share via content_state.
+	csPayload, _ := json.Marshal(map[string]interface{}{
+		"active":      true,
+		"contentType": "screen",
+	})
+	hub.handleMessage(a, mustMarshal(Message{V: 1, Type: "content_state", RID: rid, Payload: csPayload}))
+	drainMessages(a)
+
+	// B reconnects.
+	b2 := fakeClient(hub)
+	hub.registerClient(b2)
+	hub.handleMessage(b2, joinWithReconnect(rid, bJoined.CID, bJoined.ReconnectToken))
+
+	var seenContentActive bool
+	for _, m := range drainMessages(b2) {
+		if m.Type != "joined" && m.Type != "room_state" {
+			continue
+		}
+		var p struct {
+			Participants []Participant `json:"participants"`
+		}
+		if err := json.Unmarshal(m.Payload, &p); err != nil {
+			continue
+		}
+		for _, part := range p.Participants {
+			if part.CID == aJoined.CID && part.ContentState != nil && part.ContentState.Active && part.ContentState.ContentType == "screen" {
+				seenContentActive = true
+			}
+		}
+	}
+	if !seenContentActive {
+		t.Fatal("expected reattached B to see A's active content_state via room_state")
+	}
+}
+
+// media_liveness --------------------------------------------------------------
+
+func TestMediaLivenessHintDefersHardEviction(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	bJoined := captureJoined(t, b)
+	drainMessages(a)
+
+	hub.disconnectClient(b)
+
+	// A tells the server it is still receiving media from B.
+	livenessPayload, _ := json.Marshal(map[string]interface{}{
+		"cids": []string{bJoined.CID},
+	})
+	hub.handleMessage(a, mustMarshal(Message{V: 1, Type: "media_liveness", RID: rid, Payload: livenessPayload}))
+
+	// Trigger a hard-evict pass synchronously. With a fresh liveness hint we
+	// should DEFER, not remove.
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	hub.hardEvictSuspended(room, bJoined.CID)
+
+	room.mu.Lock()
+	stillThere := room.participantByCID(bJoined.CID) != nil
+	room.mu.Unlock()
+	if !stillThere {
+		t.Fatal("expected suspended participant with recent liveness to be retained")
+	}
+
+	// Force the liveness window to elapse and try again — should evict now.
+	room.mu.Lock()
+	room.mediaLiveness[bJoined.CID] = time.Now().Add(-2 * mediaLivenessFreshnessWindow).UnixMilli()
+	room.mu.Unlock()
+
+	hub.hardEvictSuspended(room, bJoined.CID)
+	room.mu.Lock()
+	gone := room.participantByCID(bJoined.CID) == nil
+	room.mu.Unlock()
+	if !gone {
+		t.Fatal("expected suspended participant to be evicted once liveness expired")
+	}
+}
+
+// helpers ---------------------------------------------------------------------
+
+func mustMarshal(msg Message) []byte {
+	b, _ := json.Marshal(msg)
+	return b
+}
+
+// Strings helper kept local to keep imports stable.
+var _ = strings.HasPrefix

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -1033,12 +1033,13 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 
 	room.mu.Unlock() // <--- CRITICAL FIX: Unlock before broadcast/send to avoid deadlock/blocking
 
-	// Successful, non-fresh joins clear any stale tombstone for this room —
-	// the room is alive again and future reconnects should not see a stale
-	// terminal error.
-	if outcome != reconnectOutcomeFresh {
-		h.clearTombstone(rid)
-	}
+	// Any successful join means the room is alive again, so clear any stale
+	// tombstone for this RID. Reconnect attempts arriving with a token for a
+	// dead room are already gated above (before they reach this point); by
+	// the time we get here the join has succeeded and a fresh participant
+	// reconnecting later — including the one who just joined — must not be
+	// rejected with ROOM_ENDED for a previous session.
+	h.clearTombstone(rid)
 
 	payload := map[string]interface{}{
 		"hostCid":         hostCID,
@@ -1340,25 +1341,32 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 // applyContentStateUpdate merges the latest content metadata into the
 // sender's participant record so it can be replayed via room_state after a
 // suspension. Caller must hold room.mu.
+//
+// Bails out unless the payload carries a boolean `active` field — a
+// malformed/empty content_state must NOT destructively clear the
+// participant's previously-stored state, since suspended peers depend on
+// the latest known good value at reattach time.
 func applyContentStateUpdate(room *Room, senderCID string, payload map[string]interface{}) {
 	p := room.participantByCID(senderCID)
 	if p == nil {
 		return
 	}
+	active, ok := payload["active"].(bool)
+	if !ok {
+		return
+	}
 	state := &ParticipantContentState{
+		Active:      active,
 		Epoch:       room.Epoch,
 		UpdatedAtMs: time.Now().UnixMilli(),
 	}
-	if active, ok := payload["active"].(bool); ok {
-		state.Active = active
-	}
-	if contentType, ok := payload["contentType"].(string); ok {
-		state.ContentType = contentType
-	}
-	// `active=false` collapses to a cleared state so suspended peers don't see
-	// a stale "screen sharing" indicator after the share stops.
-	if !state.Active {
-		state.ContentType = ""
+	// contentType is meaningful only while a share is active. `active=false`
+	// collapses to a cleared state so suspended peers don't see a stale
+	// "screen sharing" indicator after the share stops.
+	if active {
+		if contentType, ok := payload["contentType"].(string); ok {
+			state.ContentType = contentType
+		}
 	}
 	p.ContentState = state
 }
@@ -1454,13 +1462,16 @@ func (h *Hub) handleMediaLiveness(c *Client, msg Message) {
 	now := time.Now().UnixMilli()
 	room.mu.Lock()
 	defer room.mu.Unlock()
-	// Sender must be an attached participant in this room. Stale-socket
-	// reports get dropped — same authorization rule as relay.
-	if room.cidForClient(c) == "" {
+	// Sender must be an attached participant in this room. Resolve the CID
+	// from the room index, NOT c.cid — stale-socket fields can outlive a
+	// reattach and we should authorize / self-skip against the index, like
+	// handleRelay does.
+	senderCID := room.cidForClient(c)
+	if senderCID == "" {
 		return
 	}
 	for _, reportedCID := range payload.CIDs {
-		if reportedCID == "" || reportedCID == c.cid {
+		if reportedCID == "" || reportedCID == senderCID {
 			continue
 		}
 		if room.participantByCID(reportedCID) == nil {

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,29 @@ const turnTokenTTL = 15 * time.Minute
 // timeout the record is evicted and peers tear down.
 const suspendHardEvictionTimeout = 10 * time.Minute
 
+// reconnectTokenTTL bounds how long a reconnect token can be used to reattach
+// or recover a participant identity. Capped at the same window the server
+// preserves participant records so that a token never outlives the slot it can
+// reclaim.
+const reconnectTokenTTL = suspendHardEvictionTimeout
+
+// roomTombstoneTTL is the window during which an explicitly-ended room is
+// remembered with a structured reason. Reconnect attempts with a valid
+// reconnect token receive ROOM_ENDED instead of being silently turned into a
+// fresh participant in a recreated room.
+const roomTombstoneTTL = 5 * time.Minute
+
+// mediaLivenessFreshnessWindow bounds how recent a peer-reported
+// media_liveness hint must be to defer hard-eviction of a suspended
+// participant. The hint is a cleanup signal only: it may delay eviction but
+// never authorizes anything else.
+const mediaLivenessFreshnessWindow = 30 * time.Second
+
+// hardEvictMediaActiveDeferral is how long hard-eviction is pushed back when
+// at least one active peer recently reported inbound media from the suspended
+// CID. Re-evaluated on each fire.
+const hardEvictMediaActiveDeferral = 30 * time.Second
+
 // ConnectionStatus values broadcast in room_state/joined participant entries.
 // Omitted when "active" (backward compatible with older clients).
 const (
@@ -40,34 +64,90 @@ const (
 	connectionStatusSuspended = "suspended"
 )
 
-// issueReconnectToken generates an HMAC proof that allows a client to reclaim
-// its CID on reconnect. Format: hex(HMAC-SHA256(secret, cid|rid)).
-// The token is bound to (cid, rid) — NOT session id — because the session id
-// changes on every reconnect.
-func issueReconnectToken(cid, rid string) string {
+// Reconnect outcome values reported back to SDKs in joined.payload.reconnect.
+// Drives whether the SDK keeps media-active peer connections, schedules
+// dirty-pair renegotiation, or starts fresh.
+const (
+	reconnectOutcomeFresh      = "fresh"
+	reconnectOutcomeReattached = "reattached"
+	reconnectOutcomeRecovered  = "recovered"
+)
+
+// Tombstone reasons broadcast via the ROOM_ENDED error to reconnect-with-token
+// attempts targeting a room that is no longer present.
+const (
+	tombstoneReasonEndedByHost = "ended_by_host"
+)
+
+// reconnectSecret returns the HMAC secret used to sign and verify reconnect
+// tokens. Falls back to TURN_SECRET so existing deployments keep working
+// without configuration changes.
+func reconnectSecret() []byte {
 	secret := os.Getenv("TURN_TOKEN_SECRET")
 	if secret == "" {
 		secret = os.Getenv("TURN_SECRET")
 	}
 	if secret == "" {
-		return ""
+		return nil
 	}
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(cid + "|" + rid))
-	return hex.EncodeToString(mac.Sum(nil))
+	return []byte(secret)
 }
 
-// validateReconnectToken checks that the provided token matches the expected HMAC.
-func validateReconnectToken(token, cid, rid string) bool {
+// issueReconnectToken generates an HMAC proof bound to (cid, rid, expiresAt).
+// Format: hex(HMAC-SHA256(secret, cid|rid|expiresAt)) || "." || expiresAtUnix.
+// expiresAt is wall-clock unix seconds. The expiry is on-the-wire so the
+// validator can reject expired tokens without server-side state.
+func issueReconnectToken(cid, rid string) string {
+	return issueReconnectTokenWithExpiry(cid, rid, time.Now().Add(reconnectTokenTTL))
+}
+
+func issueReconnectTokenWithExpiry(cid, rid string, expiresAt time.Time) string {
+	secret := reconnectSecret()
+	if secret == nil {
+		return ""
+	}
+	exp := expiresAt.Unix()
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(cid + "|" + rid + "|" + strconv.FormatInt(exp, 10)))
+	return hex.EncodeToString(mac.Sum(nil)) + "." + strconv.FormatInt(exp, 10)
+}
+
+// validateReconnectToken returns ok=true when the token's HMAC verifies and
+// the embedded expiresAt is in the future. expired=true when the token's
+// signature is valid but it has aged out — the SDK should treat the token as
+// dead and clear persisted state. ok=false, expired=false means the token is
+// malformed or the signature does not verify.
+func validateReconnectToken(token, cid, rid string) (ok bool, expired bool) {
 	if token == "" {
-		return false
+		return false, false
 	}
-	expected := issueReconnectToken(cid, rid)
-	if expected == "" {
-		// No secret configured — allow legacy clients (backwards compatible)
-		return true
+	secret := reconnectSecret()
+	if secret == nil {
+		// No secret configured — legacy/dev environments. Accept any token to
+		// preserve current behavior on machines that never set TURN_SECRET.
+		return true, false
 	}
-	return hmac.Equal([]byte(expected), []byte(token))
+	dot := strings.LastIndexByte(token, '.')
+	if dot < 0 {
+		// Pre-expiry-format tokens — clients carrying these need to refresh.
+		return false, true
+	}
+	macHex := token[:dot]
+	expStr := token[dot+1:]
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return false, false
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(cid + "|" + rid + "|" + strconv.FormatInt(exp, 10)))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(macHex)) {
+		return false, false
+	}
+	if time.Now().Unix() > exp {
+		return false, true
+	}
+	return true, false
 }
 
 type TransportKind string
@@ -90,12 +170,25 @@ type Message struct {
 
 // Participant is the wire-format entry broadcast to clients in joined/room_state.
 type Participant struct {
-	CID              string `json:"cid"`
-	JoinedAt         int64  `json:"joinedAt,omitempty"`
-	DisplayName      string `json:"displayName,omitempty"`
-	AudioEnabled     *bool  `json:"audioEnabled,omitempty"`
-	VideoEnabled     *bool  `json:"videoEnabled,omitempty"`
-	ConnectionStatus string `json:"connectionStatus,omitempty"` // "suspended" when transport detached; omitted (= "active") otherwise
+	CID              string                 `json:"cid"`
+	JoinedAt         int64                  `json:"joinedAt,omitempty"`
+	DisplayName      string                 `json:"displayName,omitempty"`
+	AudioEnabled     *bool                  `json:"audioEnabled,omitempty"`
+	VideoEnabled     *bool                  `json:"videoEnabled,omitempty"`
+	ConnectionStatus string                 `json:"connectionStatus,omitempty"` // "suspended" when transport detached; omitted (= "active") otherwise
+	ContentState     *ParticipantContentState `json:"contentState,omitempty"`
+}
+
+// ParticipantContentState is the latest ephemeral content metadata (screen
+// share, content camera mode, etc.) for a participant. Stored on the
+// participant record so it survives suspension and is restored to a peer
+// reattaching after being away. Latest wins — older transitions are not
+// replayed.
+type ParticipantContentState struct {
+	Active      bool   `json:"active"`
+	ContentType string `json:"contentType,omitempty"`
+	UpdatedAtMs int64  `json:"updatedAtMs,omitempty"`
+	Epoch       int64  `json:"epoch,omitempty"`
 }
 
 // roomParticipant is the server-side stable participant record keyed by CID.
@@ -117,11 +210,25 @@ type roomParticipant struct {
 	// hardEvictionTimer fires after suspendHardEvictionTimeout if the participant
 	// has not reattached. It calls hardEvictSuspended to remove the record.
 	hardEvictionTimer *time.Timer
+	// ContentState is the latest ephemeral content metadata for this CID (screen
+	// share active, content camera mode, etc.) so a reattaching peer can
+	// reconstruct UI without waiting for the sender to toggle again.
+	ContentState *ParticipantContentState
+}
+
+// roomTombstone records that a room has explicitly ended. Reconnect attempts
+// against the room within roomTombstoneTTL receive a structured ROOM_ENDED
+// error so SDKs can clear recovery state instead of looping reconnect against
+// a dead RID.
+type roomTombstone struct {
+	Reason    string
+	ExpiresAt time.Time
 }
 
 type Hub struct {
 	rooms                map[string]*Room
 	watchers             map[string]map[*Client]bool // roomID -> set of clients
+	tombstones           map[string]*roomTombstone   // roomID -> termination record (TTL'd)
 	mu                   sync.RWMutex
 	clients              map[*Client]bool
 	clientsBySID         map[string]*Client
@@ -142,7 +249,120 @@ type Room struct {
 	MaxParticipants          int  // effective room capacity; group-capable rooms stay provisional at 2 until participant #2 joins
 	RequestedMaxParticipants int  // creator's requested ceiling, clamped by creator capability and server ceiling
 	CapacityLocked           bool // once true, MaxParticipants is final for the room lifetime
-	mu                       sync.Mutex
+	// Epoch is a monotonic counter advanced on every membership-mutating
+	// operation (join, leave, suspend, reattach, evict, host transfer).
+	// Embedded in joined / room_state so SDKs can detect missed membership
+	// transitions and gate ICE restart on an authoritative post-reconnect
+	// snapshot rather than acting on stale in-memory peer maps.
+	Epoch int64
+	// negotiationDirty[fromCID] is the set of toCIDs that fromCID attempted to
+	// reach via offer/answer/ice while toCID had no attached transport. On
+	// reattach the server notifies the active peers so they can schedule fresh
+	// glare-safe negotiation instead of waiting for an answer that never
+	// arrives.
+	negotiationDirty map[string]map[string]bool
+	// mediaLiveness records the most recent unix-ms timestamp at which an
+	// active peer reported inbound media flowing from the keyed CID. Used as
+	// a cleanup hint only: hard-eviction may be deferred while at least one
+	// peer recently observed media. Never used as authorization.
+	mediaLiveness map[string]int64
+	mu            sync.Mutex
+}
+
+// bumpEpoch increments the room state epoch. Caller must hold r.mu. Returns
+// the new epoch so callers can stamp it onto outgoing payloads without a
+// second lock.
+func (r *Room) bumpEpoch() int64 {
+	r.Epoch++
+	return r.Epoch
+}
+
+// markNegotiationDirty records that fromCID attempted to negotiate with toCID
+// while toCID had no attached transport. Caller must hold r.mu.
+func (r *Room) markNegotiationDirty(fromCID, toCID string) {
+	if r.negotiationDirty == nil {
+		r.negotiationDirty = make(map[string]map[string]bool)
+	}
+	set, ok := r.negotiationDirty[fromCID]
+	if !ok {
+		set = make(map[string]bool)
+		r.negotiationDirty[fromCID] = set
+	}
+	set[toCID] = true
+}
+
+// drainDirtyPartnersFor returns and clears the set of CIDs that previously
+// attempted to negotiate with `cid` while it was suspended. Caller must hold
+// r.mu. The returned slice is a freshly allocated copy.
+func (r *Room) drainDirtyPartnersFor(cid string) []string {
+	if r.negotiationDirty == nil {
+		return nil
+	}
+	out := make([]string, 0)
+	for fromCID, partners := range r.negotiationDirty {
+		if !partners[cid] {
+			continue
+		}
+		out = append(out, fromCID)
+		delete(partners, cid)
+		if len(partners) == 0 {
+			delete(r.negotiationDirty, fromCID)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// dropCIDFromDirty removes the CID from all dirty entries (both as source and
+// target). Called on participant removal. Caller must hold r.mu.
+func (r *Room) dropCIDFromDirty(cid string) {
+	if r.negotiationDirty == nil {
+		return
+	}
+	delete(r.negotiationDirty, cid)
+	for fromCID, partners := range r.negotiationDirty {
+		delete(partners, cid)
+		if len(partners) == 0 {
+			delete(r.negotiationDirty, fromCID)
+		}
+	}
+}
+
+// recordMediaLiveness updates the last-reported inbound-media timestamp for a
+// CID. Caller must hold r.mu. Used to defer hard-eviction while peers still
+// see media from a suspended participant.
+func (r *Room) recordMediaLiveness(cid string, atMs int64) {
+	if r.mediaLiveness == nil {
+		r.mediaLiveness = make(map[string]int64)
+	}
+	if existing, ok := r.mediaLiveness[cid]; ok && existing >= atMs {
+		return
+	}
+	r.mediaLiveness[cid] = atMs
+}
+
+// hasRecentMediaLiveness returns true when at least one peer has reported
+// inbound media for `cid` within the last `window`. Caller must hold r.mu.
+func (r *Room) hasRecentMediaLiveness(cid string, window time.Duration) bool {
+	if r.mediaLiveness == nil {
+		return false
+	}
+	last, ok := r.mediaLiveness[cid]
+	if !ok {
+		return false
+	}
+	return time.Since(time.UnixMilli(last)) <= window
+}
+
+// dropMediaLivenessFor removes any liveness record for the participant. Caller
+// must hold r.mu.
+func (r *Room) dropMediaLivenessFor(cid string) {
+	if r.mediaLiveness == nil {
+		return
+	}
+	delete(r.mediaLiveness, cid)
 }
 
 // Room helper methods. All assume the caller holds room.mu unless noted.
@@ -241,6 +461,7 @@ func (r *Room) snapshotParticipants() []Participant {
 			DisplayName:  p.DisplayName,
 			AudioEnabled: p.AudioEnabled,
 			VideoEnabled: p.VideoEnabled,
+			ContentState: p.ContentState,
 		}
 		if p.Client == nil {
 			entry.ConnectionStatus = connectionStatusSuspended
@@ -300,9 +521,57 @@ func newHub(maxParticipantsLimit int) *Hub {
 	return &Hub{
 		rooms:                make(map[string]*Room),
 		watchers:             make(map[string]map[*Client]bool),
+		tombstones:           make(map[string]*roomTombstone),
 		clients:              make(map[*Client]bool),
 		clientsBySID:         make(map[string]*Client),
 		maxParticipantsLimit: maxParticipantsLimit,
+	}
+}
+
+// recordTombstone marks the room as explicitly ended. Reconnect attempts
+// arriving within roomTombstoneTTL will receive a structured ROOM_ENDED error
+// instead of being silently turned into a fresh participant.
+func (h *Hub) recordTombstone(rid, reason string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.tombstones[rid] = &roomTombstone{
+		Reason:    reason,
+		ExpiresAt: time.Now().Add(roomTombstoneTTL),
+	}
+	h.gcTombstonesLocked()
+}
+
+// lookupTombstone returns the active tombstone for rid, or nil if absent or
+// expired. Expired entries are evicted lazily on lookup.
+func (h *Hub) lookupTombstone(rid string) *roomTombstone {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	t, ok := h.tombstones[rid]
+	if !ok {
+		return nil
+	}
+	if time.Now().After(t.ExpiresAt) {
+		delete(h.tombstones, rid)
+		return nil
+	}
+	return t
+}
+
+// clearTombstone removes any tombstone for the room. Called when an explicit
+// fresh start is requested (no reconnect token, or token validation failed).
+func (h *Hub) clearTombstone(rid string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.tombstones, rid)
+}
+
+// gcTombstonesLocked drops expired tombstones. Must be called with h.mu held.
+func (h *Hub) gcTombstonesLocked() {
+	now := time.Now()
+	for rid, t := range h.tombstones {
+		if now.After(t.ExpiresAt) {
+			delete(h.tombstones, rid)
+		}
 	}
 }
 
@@ -466,6 +735,8 @@ func (h *Hub) handleMessage(c *Client, msgBytes []byte) {
 		h.handleRelay(c, msg)
 	case "participant_media_state":
 		h.handleMediaState(c, msg)
+	case "media_liveness":
+		h.handleMediaLiveness(c, msg)
 	default:
 		log.Printf("[UNKNOWN] Unknown message type: %s", msg.Type)
 	}
@@ -526,6 +797,34 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 	reconnectCID := joinPayload.ReconnectCID
 	reconnectToken := joinPayload.ReconnectToken
 
+	// Validate the reconnect token up-front so authority decisions are made on
+	// the same proof regardless of which case below applies.
+	tokenValid := false
+	if reconnectCID != "" && reconnectToken != "" {
+		valid, expired := validateReconnectToken(reconnectToken, reconnectCID, rid)
+		if !valid {
+			log.Printf("[JOIN] Invalid reconnectToken for CID %s from client %s (expired=%t)", reconnectCID, c.sid, expired)
+			c.sendError(rid, "INVALID_RECONNECT_TOKEN", "Reconnect token validation failed")
+			return
+		}
+		tokenValid = valid
+	}
+
+	// Tombstone gate: if a recent end_room marked this RID as terminated and
+	// the client is presenting reconnect authority for it, surface the
+	// terminal error rather than silently turning the request into a fresh
+	// caller in a recreated room.
+	if reconnectCID != "" && tokenValid {
+		if t := h.lookupTombstone(rid); t != nil {
+			log.Printf("[JOIN] Rejecting reconnect to tombstoned room %s (reason=%s)", rid, t.Reason)
+			h.sendRoomEnded(c, rid, t.Reason)
+			return
+		}
+	}
+
+	// Hub-level lookup. We may need to recreate the room if a valid reconnect
+	// token references a room that has been GC'd (no participants, no
+	// tombstone — e.g. server restart or all participants hard-evicted).
 	h.mu.Lock()
 	room, exists := h.rooms[rid]
 	if !exists {
@@ -552,22 +851,19 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 
 	room.mu.Lock()
 	reusedCID := false
+	recoveredCID := false
 
 	// Reconnect path: a client presenting reconnectCid wants to reclaim an
-	// existing participant slot. Two cases:
+	// existing participant slot. Three cases:
 	//   (a) Suspended participant (Client == nil): the previous transport
 	//       already detached; simply reattach the new Client. No ghost cleanup.
 	//   (b) Active ghost (Client != nil): the previous transport is still
 	//       attached (race on fast reconnect). Detach and clean up hub state.
+	//   (c) No participant record (room was GC'd or recreated): if the
+	//       reconnect token validates, recreate the participant with the
+	//       requested CID so identity survives server-side memory loss.
 	var ghostToEvict *Client
 	if reconnectCID != "" {
-		if reconnectToken != "" && !validateReconnectToken(reconnectToken, reconnectCID, rid) {
-			room.mu.Unlock()
-			log.Printf("[JOIN] Invalid reconnectToken for CID %s from client %s", reconnectCID, c.sid)
-			c.sendError(rid, "INVALID_RECONNECT_TOKEN", "Reconnect token validation failed")
-			return
-		}
-
 		if existing := room.participantByCID(reconnectCID); existing != nil {
 			if existing.Client != nil {
 				// Case (b): active ghost. Detach the old Client from the
@@ -648,11 +944,31 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 
 	// Room full check. Only applies to fresh joins — a reconnect has already
 	// slotted back into its existing record without increasing the count.
-	if !reusedCID && room.participantCount() >= room.MaxParticipants {
+	// A token-validated identity recovery (case c) also slots into the
+	// requested CID without growing the count beyond what we're about to add.
+	if !reusedCID && !(reconnectCID != "" && tokenValid) && room.participantCount() >= room.MaxParticipants {
 		room.mu.Unlock()
 		log.Printf("[JOIN] Room %s is full (%d/%d)", rid, room.participantCount(), room.MaxParticipants)
 		c.sendError(rid, "ROOM_FULL", "Room is full")
 		return
+	}
+
+	// Identity recovery (case c): valid reconnect token but no participant
+	// record. Recreate the participant with the requested CID so the SDK can
+	// preserve media-active peer connections across signaling-only memory
+	// loss. We still bound this by capacity above.
+	if !reusedCID && reconnectCID != "" && tokenValid {
+		if room.participantCount() >= room.MaxParticipants {
+			room.mu.Unlock()
+			log.Printf("[JOIN] Room %s is full while attempting to recover CID %s (%d/%d)", rid, reconnectCID, room.participantCount(), room.MaxParticipants)
+			c.sendError(rid, "ROOM_FULL", "Room is full")
+			return
+		}
+		log.Printf("[JOIN] Recovering CID %s in room %s with valid reconnect token (no prior record)", reconnectCID, rid)
+		c.cid = reconnectCID
+		c.rid = rid
+		room.attachParticipant(reconnectCID, c, time.Now().UnixMilli())
+		recoveredCID = true
 	}
 
 	// Deferred hub-level cleanup of ghost outside room lock to avoid deadlock.
@@ -665,17 +981,25 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 	}
 
 	var (
-		cid string
-		p   *roomParticipant
+		cid     string
+		p       *roomParticipant
+		outcome string
 	)
-	if reusedCID {
+	switch {
+	case reusedCID:
 		cid = reconnectCID
 		p = room.participantByCID(cid)
-	} else {
+		outcome = reconnectOutcomeReattached
+	case recoveredCID:
+		cid = reconnectCID
+		p = room.participantByCID(cid)
+		outcome = reconnectOutcomeRecovered
+	default:
 		cid = generateID("C-")
 		c.cid = cid
 		c.rid = rid
 		p = room.attachParticipant(cid, c, time.Now().UnixMilli())
+		outcome = reconnectOutcomeFresh
 	}
 
 	// Update display name on every join (including reconnect) so users can rename.
@@ -692,17 +1016,36 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 		room.HostCID = cid
 	}
 
-	log.Printf("[JOIN] Client %s assigned CID %s in room %s (maxParticipants=%d). Host: %s", c.sid, cid, rid, room.MaxParticipants, room.HostCID)
+	// Membership-mutating operation — bump the room state epoch so SDKs can
+	// detect changes that happened while their last snapshot is in hand.
+	epoch := room.bumpEpoch()
+
+	// On reattach / recover, surface any negotiations that peers attempted
+	// while we had no transport so the SDK can schedule fresh glare-safe
+	// negotiation rather than waiting for an answer that will never arrive.
+	dirtyPartners := room.drainDirtyPartnersFor(cid)
+
+	log.Printf("[JOIN] Client %s assigned CID %s in room %s (maxParticipants=%d outcome=%s epoch=%d). Host: %s", c.sid, cid, rid, room.MaxParticipants, outcome, epoch, room.HostCID)
 
 	participants := room.snapshotParticipants()
 	roomMaxParticipants := room.MaxParticipants
+	hostCID := room.HostCID
 
 	room.mu.Unlock() // <--- CRITICAL FIX: Unlock before broadcast/send to avoid deadlock/blocking
 
+	// Successful, non-fresh joins clear any stale tombstone for this room —
+	// the room is alive again and future reconnects should not see a stale
+	// terminal error.
+	if outcome != reconnectOutcomeFresh {
+		h.clearTombstone(rid)
+	}
+
 	payload := map[string]interface{}{
-		"hostCid":         room.HostCID,
+		"hostCid":         hostCID,
 		"participants":    participants,
 		"maxParticipants": roomMaxParticipants,
+		"epoch":           epoch,
+		"reconnect":       outcome,
 	}
 
 	// Include TURN token in joined response (gated by valid room ID)
@@ -718,6 +1061,7 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 	// Include reconnectToken for authenticated reconnection
 	if rt := issueReconnectToken(cid, rid); rt != "" {
 		payload["reconnectToken"] = rt
+		payload["reconnectTokenTTLMs"] = int64(reconnectTokenTTL / time.Millisecond)
 	}
 
 	payloadBytes, _ := json.Marshal(payload)
@@ -732,8 +1076,22 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 	})
 	stats.RecordJoinLatency(time.Since(joinStartedAt))
 
-	// Broadcast room_state to others
+	// Always send an authoritative room_state snapshot on the new transport
+	// after a successful reconnect so the SDK has a confirmed sync point
+	// before scheduling renegotiation. For fresh joins the snapshot is
+	// redundant with `joined`, but emitting it uniformly keeps the SDK code
+	// path simple.
+	h.sendRoomStateSnapshot(c, room)
+
+	// Broadcast room_state to others so peers learn about the new/reattached/
+	// recovered participant.
 	h.broadcastRoomState(room)
+
+	// Tell active peers that they have dirty negotiation pairs with this CID
+	// so they can schedule fresh negotiation after the snapshot above.
+	if len(dirtyPartners) > 0 {
+		h.notifyDirtyNegotiation(room, cid, dirtyPartners)
+	}
 
 	// Notify watchers
 	h.broadcastRoomStatusUpdate(rid)
@@ -840,6 +1198,7 @@ func (h *Hub) handleEndRoom(c *Client, msg Message) {
 			p.hardEvictionTimer = nil
 		}
 	}
+	room.bumpEpoch()
 
 	room.mu.Unlock() // Unlock before sending
 
@@ -848,7 +1207,7 @@ func (h *Hub) handleEndRoom(c *Client, msg Message) {
 	// Broadcast room_ended
 	endPayload, _ := json.Marshal(map[string]string{
 		"by":     c.cid,
-		"reason": "host_ended",
+		"reason": tombstoneReasonEndedByHost,
 	})
 	endMsg := Message{
 		V:       1,
@@ -861,6 +1220,11 @@ func (h *Hub) handleEndRoom(c *Client, msg Message) {
 		client.sendMessage(endMsg)
 	}
 
+	// Record a tombstone so suspended participants that reconnect within the
+	// TTL receive a structured ROOM_ENDED instead of being silently turned
+	// into a fresh participant in a recreated room.
+	h.recordTombstone(rid, tombstoneReasonEndedByHost)
+
 	// Remove room from hub
 	h.mu.Lock()
 	delete(h.rooms, rid)
@@ -871,6 +1235,8 @@ func (h *Hub) handleEndRoom(c *Client, msg Message) {
 	room.byCID = make(map[string]*roomParticipant)
 	room.byClient = make(map[*Client]string)
 	room.HostCID = ""
+	room.negotiationDirty = nil
+	room.mediaLiveness = nil
 	room.mu.Unlock()
 
 	// Notify watchers
@@ -896,7 +1262,8 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 	defer room.mu.Unlock()
 
 	// Sender must be an active (attached) participant in this room.
-	if room.cidForClient(c) == "" {
+	senderCID := room.cidForClient(c)
+	if senderCID == "" {
 		log.Printf("[RELAY] Client %s (CID: %s) tried to relay in room %s but is not a participant", c.sid, c.cid, c.rid)
 		return
 	}
@@ -906,7 +1273,15 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 		rawPayload = make(map[string]interface{})
 		log.Printf("[RELAY] Client %s (CID: %s) sent invalid payload for type %s: %v", c.sid, c.cid, msg.Type, err)
 	}
-	rawPayload["from"] = c.cid
+	rawPayload["from"] = senderCID
+
+	// content_state is latest-state UI metadata, not negotiation traffic.
+	// Persist it on the participant record so a peer reconnecting after a
+	// suspension still receives the current value via room_state, instead of
+	// only learning about new transitions.
+	if msg.Type == "content_state" {
+		applyContentStateUpdate(room, senderCID, rawPayload)
+	}
 
 	newPayload, _ := json.Marshal(rawPayload)
 
@@ -917,21 +1292,75 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 		Payload: newPayload,
 	}
 
-	// Iterate active participants only. Suspended participants have no
-	// transport attached — offer/answer/ice sent to them would be dropped
-	// anyway. The sender will re-send on reconnect via ICE restart.
+	// Walk the full participant list (including suspended). Active peers get
+	// the message; for offer/answer/ice we additionally mark the sender's
+	// dirty pair with each suspended target and respond `relay_failed` so the
+	// sender doesn't sit waiting forever for an answer that will never come.
+	negotiationType := msg.Type == "offer" || msg.Type == "answer" || msg.Type == "ice"
 	relayedCount := 0
-	for client, cid := range room.byClient {
-		if cid == c.cid {
+	suspendedTargets := make([]string, 0)
+	for cid, p := range room.byCID {
+		if cid == senderCID {
 			continue
 		}
 		if msg.To != "" && msg.To != cid {
 			continue
 		}
-		client.sendMessage(relayMsg)
-		relayedCount++
+		if p.Client != nil {
+			p.Client.sendMessage(relayMsg)
+			relayedCount++
+			continue
+		}
+		if negotiationType {
+			room.markNegotiationDirty(senderCID, cid)
+			suspendedTargets = append(suspendedTargets, cid)
+		}
 	}
-	log.Printf("[RELAY] Client %s (CID: %s) relayed %s message to %d participants in room %s", c.sid, c.cid, msg.Type, relayedCount, c.rid)
+
+	if len(suspendedTargets) > 0 && negotiationType {
+		// Tell the sender we couldn't deliver. The SDK should suppress further
+		// negotiation to that CID and wait for `negotiation_dirty` after the
+		// peer reattaches.
+		failPayload, _ := json.Marshal(map[string]interface{}{
+			"reason":  "target_suspended",
+			"targets": suspendedTargets,
+			"of":      msg.Type,
+		})
+		c.sendMessage(Message{
+			V:       1,
+			Type:    "relay_failed",
+			RID:     msg.RID,
+			Payload: failPayload,
+		})
+	}
+
+	log.Printf("[RELAY] Client %s (CID: %s) relayed %s message to %d participants in room %s (suspended-targets=%d)", c.sid, senderCID, msg.Type, relayedCount, c.rid, len(suspendedTargets))
+}
+
+// applyContentStateUpdate merges the latest content metadata into the
+// sender's participant record so it can be replayed via room_state after a
+// suspension. Caller must hold room.mu.
+func applyContentStateUpdate(room *Room, senderCID string, payload map[string]interface{}) {
+	p := room.participantByCID(senderCID)
+	if p == nil {
+		return
+	}
+	state := &ParticipantContentState{
+		Epoch:       room.Epoch,
+		UpdatedAtMs: time.Now().UnixMilli(),
+	}
+	if active, ok := payload["active"].(bool); ok {
+		state.Active = active
+	}
+	if contentType, ok := payload["contentType"].(string); ok {
+		state.ContentType = contentType
+	}
+	// `active=false` collapses to a cleared state so suspended peers don't see
+	// a stale "screen sharing" indicator after the share stops.
+	if !state.Active {
+		state.ContentType = ""
+	}
+	p.ContentState = state
 }
 
 func (h *Hub) handleMediaState(c *Client, msg Message) {
@@ -989,6 +1418,55 @@ func (h *Hub) handleMediaState(c *Client, msg Message) {
 		if cid != c.cid {
 			client.sendMessage(relayMsg)
 		}
+	}
+}
+
+// handleMediaLiveness records peer-reported inbound-media observations for
+// suspended CIDs. Used as a cleanup hint in hardEvictSuspended so a
+// suspended participant whose signaling transport is late to recover but
+// whose peer media is still flowing is not removed solely because the
+// directory clock fired. The hint is NEVER used for authorization or
+// authority — only to defer eviction.
+//
+// Wire payload:
+//
+//	{ "v":1, "type":"media_liveness", "payload":{ "cids":["C-..","C-.."] } }
+//
+// Reports apply to the sender's room. Unknown CIDs are ignored.
+func (h *Hub) handleMediaLiveness(c *Client, msg Message) {
+	if c.rid == "" || c.cid == "" {
+		return
+	}
+	h.mu.RLock()
+	room, exists := h.rooms[c.rid]
+	h.mu.RUnlock()
+	if !exists {
+		return
+	}
+
+	var payload struct {
+		CIDs []string `json:"cids"`
+	}
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		return
+	}
+
+	now := time.Now().UnixMilli()
+	room.mu.Lock()
+	defer room.mu.Unlock()
+	// Sender must be an attached participant in this room. Stale-socket
+	// reports get dropped — same authorization rule as relay.
+	if room.cidForClient(c) == "" {
+		return
+	}
+	for _, reportedCID := range payload.CIDs {
+		if reportedCID == "" || reportedCID == c.cid {
+			continue
+		}
+		if room.participantByCID(reportedCID) == nil {
+			continue
+		}
+		room.recordMediaLiveness(reportedCID, now)
 	}
 }
 
@@ -1062,6 +1540,7 @@ func (h *Hub) suspendClientInRoom(c *Client) {
 	}
 
 	room.detachClient(p)
+	room.bumpEpoch()
 	log.Printf("[SUSPEND] Client %s (CID: %s) suspended in room %s. Hard eviction in %s", c.sid, cid, rid, suspendHardEvictionTimeout)
 
 	// Close over this specific *Room so a timer firing after the room has been
@@ -1091,6 +1570,12 @@ func (h *Hub) suspendClientInRoom(c *Client) {
 // final room_state so remaining peers tear down the stale peer connection.
 // Takes *Room (not rid) so a late-firing timer against a replaced-since room
 // is dropped cleanly.
+//
+// If active peers have recently reported inbound media from this CID, eviction
+// is deferred for a short window and re-evaluated. media_liveness is a
+// cleanup hint only — it never extends the slot indefinitely, but a peer
+// whose signaling transport is late to recover should not be removed solely
+// because the directory clock fired.
 func (h *Hub) hardEvictSuspended(room *Room, cid string) {
 	h.mu.RLock()
 	current, exists := h.rooms[room.RID]
@@ -1107,9 +1592,24 @@ func (h *Hub) hardEvictSuspended(room *Room, cid string) {
 		room.mu.Unlock()
 		return
 	}
+
+	if room.hasRecentMediaLiveness(cid, mediaLivenessFreshnessWindow) {
+		log.Printf("[HARD_EVICT] Deferring eviction of CID %s in room %s — recent media-liveness hint", cid, rid)
+		// Re-arm; we'll re-check once peers either go quiet or the participant
+		// reattaches.
+		p.hardEvictionTimer = time.AfterFunc(hardEvictMediaActiveDeferral, func() {
+			h.hardEvictSuspended(room, cid)
+		})
+		room.mu.Unlock()
+		return
+	}
+
 	log.Printf("[HARD_EVICT] Suspend window expired for CID %s in room %s. Removing participant.", cid, rid)
 	room.removeParticipant(cid)
+	room.dropCIDFromDirty(cid)
+	room.dropMediaLivenessFor(cid)
 	room.transferHostIfNeeded(cid)
+	room.bumpEpoch()
 
 	isEmpty := room.participantCount() == 0
 	room.mu.Unlock()
@@ -1157,6 +1657,9 @@ func (h *Hub) removeClientFromRoom(c *Client) {
 		return
 	}
 	room.removeParticipant(cid)
+	room.dropCIDFromDirty(cid)
+	room.dropMediaLivenessFor(cid)
+	room.bumpEpoch()
 	log.Printf("[REMOVE_FROM_ROOM] Client %s (CID: %s) removed from room %s. Remaining participants: %d", c.sid, cid, rid, room.participantCount())
 	room.transferHostIfNeeded(cid)
 
@@ -1182,6 +1685,7 @@ func (h *Hub) broadcastRoomState(room *Room) {
 	hostCid := room.HostCID
 	rid := room.RID
 	roomMaxParticipants := room.MaxParticipants
+	epoch := room.Epoch
 	// Only broadcast to actively-attached clients; suspended participants
 	// have no transport to receive messages.
 	clients := room.activeClients()
@@ -1191,10 +1695,11 @@ func (h *Hub) broadcastRoomState(room *Room) {
 		"hostCid":         hostCid,
 		"participants":    participants,
 		"maxParticipants": roomMaxParticipants,
+		"epoch":           epoch,
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
-	log.Printf("[BROADCAST] Room State for %s: %d participants", rid, len(participants))
+	log.Printf("[BROADCAST] Room State for %s: %d participants epoch=%d", rid, len(participants), epoch)
 
 	msg := Message{
 		V:       1,
@@ -1204,6 +1709,87 @@ func (h *Hub) broadcastRoomState(room *Room) {
 	}
 
 	for _, client := range clients {
+		client.sendMessage(msg)
+	}
+}
+
+// sendRoomStateSnapshot delivers an authoritative room_state to a single
+// client. Used after a successful reconnect so SDKs have a confirmed sync
+// point on the new transport before scheduling renegotiation, regardless of
+// whether the epoch advanced during the outage.
+func (h *Hub) sendRoomStateSnapshot(c *Client, room *Room) {
+	room.mu.Lock()
+	participants := room.snapshotParticipants()
+	hostCid := room.HostCID
+	rid := room.RID
+	roomMaxParticipants := room.MaxParticipants
+	epoch := room.Epoch
+	room.mu.Unlock()
+
+	payload := map[string]interface{}{
+		"hostCid":         hostCid,
+		"participants":    participants,
+		"maxParticipants": roomMaxParticipants,
+		"epoch":           epoch,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	c.sendMessage(Message{
+		V:       1,
+		Type:    "room_state",
+		RID:     rid,
+		Payload: payloadBytes,
+	})
+}
+
+// sendRoomEnded surfaces a structured terminal error to a client whose
+// reconnect attempt landed on a tombstoned room. SDKs map ROOM_ENDED to a
+// final "call ended" UI and clear persisted reconnect state.
+func (h *Hub) sendRoomEnded(c *Client, rid, reason string) {
+	if reason == "" {
+		reason = tombstoneReasonEndedByHost
+	}
+	payload, _ := json.Marshal(map[string]interface{}{
+		"code":    "ROOM_ENDED",
+		"message": "Room has ended",
+		"reason":  reason,
+	})
+	c.sendMessage(Message{
+		V:       1,
+		Type:    "error",
+		RID:     rid,
+		Payload: payload,
+	})
+}
+
+// notifyDirtyNegotiation informs each active peer that they had pending
+// signaling traffic to the given CID while it was suspended. SDKs use this to
+// schedule a fresh glare-safe negotiation/ICE-restart after the authoritative
+// post-reconnect snapshot, instead of waiting for an answer that will never
+// arrive.
+func (h *Hub) notifyDirtyNegotiation(room *Room, recoveredCID string, partners []string) {
+	if len(partners) == 0 {
+		return
+	}
+	payload, _ := json.Marshal(map[string]interface{}{
+		"with": recoveredCID,
+	})
+	msg := Message{
+		V:       1,
+		Type:    "negotiation_dirty",
+		RID:     room.RID,
+		Payload: payload,
+	}
+	room.mu.Lock()
+	targets := make([]*Client, 0, len(partners))
+	for _, partnerCID := range partners {
+		p := room.participantByCID(partnerCID)
+		if p == nil || p.Client == nil {
+			continue
+		}
+		targets = append(targets, p.Client)
+	}
+	room.mu.Unlock()
+	for _, client := range targets {
 		client.sendMessage(msg)
 	}
 }

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -816,8 +816,12 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 	// caller in a recreated room.
 	if reconnectCID != "" && tokenValid {
 		if t := h.lookupTombstone(rid); t != nil {
-			log.Printf("[JOIN] Rejecting reconnect to tombstoned room %s (reason=%s)", rid, t.Reason)
-			h.sendRoomEnded(c, rid, t.Reason)
+			reason := t.Reason
+			if reason == "" {
+				reason = tombstoneReasonEndedByHost
+			}
+			log.Printf("[JOIN] Rejecting reconnect to tombstoned room %s (reason=%s)", rid, reason)
+			c.sendErrorWithReason(rid, "ROOM_ENDED", "Room has ended", reason)
 			return
 		}
 	}
@@ -1299,7 +1303,7 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 	// sender doesn't sit waiting forever for an answer that will never come.
 	negotiationType := msg.Type == "offer" || msg.Type == "answer" || msg.Type == "ice"
 	relayedCount := 0
-	suspendedTargets := make([]string, 0)
+	var suspendedTargets []string
 	for cid, p := range room.byCID {
 		if cid == senderCID {
 			continue
@@ -1318,7 +1322,7 @@ func (h *Hub) handleRelay(c *Client, msg Message) {
 		}
 	}
 
-	if len(suspendedTargets) > 0 && negotiationType {
+	if len(suspendedTargets) > 0 {
 		// Tell the sender we couldn't deliver. The SDK should suppress further
 		// negotiation to that CID and wait for `negotiation_dirty` after the
 		// peer reattaches.
@@ -1752,26 +1756,6 @@ func (h *Hub) sendRoomStateSnapshot(c *Client, room *Room) {
 	})
 }
 
-// sendRoomEnded surfaces a structured terminal error to a client whose
-// reconnect attempt landed on a tombstoned room. SDKs map ROOM_ENDED to a
-// final "call ended" UI and clear persisted reconnect state.
-func (h *Hub) sendRoomEnded(c *Client, rid, reason string) {
-	if reason == "" {
-		reason = tombstoneReasonEndedByHost
-	}
-	payload, _ := json.Marshal(map[string]interface{}{
-		"code":    "ROOM_ENDED",
-		"message": "Room has ended",
-		"reason":  reason,
-	})
-	c.sendMessage(Message{
-		V:       1,
-		Type:    "error",
-		RID:     rid,
-		Payload: payload,
-	})
-}
-
 // notifyDirtyNegotiation informs each active peer that they had pending
 // signaling traffic to the given CID while it was suspended. SDKs use this to
 // schedule a fresh glare-safe negotiation/ICE-restart after the authoritative
@@ -1806,15 +1790,26 @@ func (h *Hub) notifyDirtyNegotiation(room *Room, recoveredCID string, partners [
 }
 
 func (c *Client) sendError(rid, code, message string) {
-	payload, _ := json.Marshal(map[string]interface{}{
+	c.sendErrorWithReason(rid, code, message, "")
+}
+
+// sendErrorWithReason mirrors sendError but emits an additional `reason`
+// field on the error payload. Used for terminal codes (e.g. ROOM_ENDED)
+// where the SDK wants the trigger surfaced for UX or telemetry.
+func (c *Client) sendErrorWithReason(rid, code, message, reason string) {
+	payload := map[string]interface{}{
 		"code":    code,
 		"message": message,
-	})
+	}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	body, _ := json.Marshal(payload)
 	c.sendMessage(Message{
 		V:       1,
 		Type:    "error",
 		RID:     rid,
-		Payload: payload,
+		Payload: body,
 	})
 }
 

--- a/server/sse.go
+++ b/server/sse.go
@@ -65,6 +65,13 @@ func serveSSE(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	client := &Client{hub: hub, send: make(chan []byte, 256), sid: sid, ip: ip, transport: TransportSSE}
 	existing := hub.getClientBySID(sid)
 	if existing != nil {
+		// TODO(#7): SID-based replaceClient is currently a participant
+		// takeover risk for in-room sessions — anyone who learns the SID can
+		// inherit the participant's identity. The proper fix is the pending
+		// unauthenticated SSE + `resumeSse` protocol described in
+		// docs/resilience-failure-modes.md. Hardening here is gated on the
+		// SDKs gaining the `resumeSse` envelope first to avoid breaking
+		// legitimate SSE reconnects in transit. Tracked for Phase 2.
 		hub.replaceClient(existing, client)
 	} else {
 		hub.registerClient(client)


### PR DESCRIPTION
## Summary

Implements **Phase 1** of [`docs/resilience-failure-modes.md`](docs/resilience-failure-modes.md) end-to-end: server-side protocol additions plus typed SDK parsing/error handling on Web, Android, and iOS for issues **#1, #2, #3, #4, #11, #15, #16**. SDK behavioral consumption (MediaEngine ICE-restart gate, periodic `media_liveness` emission, suspended UI timer, stale enqueue tagging) and Phase 2/3 issues (#5/#7/#8/#10/#12/#14) stay queued for follow-up slices.

The proposal doc itself is updated with a per-section Status line and a Status column on the priority table so the remaining work is unambiguous.

### Server (Go)
- Tombstones + structured `ROOM_ENDED` for ended rooms (#11).
- `joined.payload.reconnect: "fresh" | "reattached" | "recovered"` and identity-recovered CID path when a valid token's room/participant is gone (#2).
- Expiring reconnect tokens — HMAC over `(cid, rid, expiresAt)` with TTL = `suspendHardEvictionTimeout` (#15 part 1).
- `Room.Epoch` (monotonic) included in `joined`/`room_state`; authoritative `room_state` snapshot on the new transport immediately after every successful `joined` (#4).
- Dirty-pair tracking — `relay_failed{target_suspended,...}` to the sender on offer/answer/ice to a suspended target, and `negotiation_dirty{with}` to the affected peers right after the reattach snapshot (#1).
- `media_liveness{cids:[...]}` cleanup hint; `hardEvictSuspended` defers eviction while a recent observation exists (#3 server side).
- Latest `contentState` persisted on the participant record and included in every `joined`/`room_state` (#16).
- SSE `replaceClient` hardening (#7) deferred behind a `TODO(#7)` next to the call site — needs the SDK `resumeSse` envelope first to avoid breaking legitimate transport flaps.

### SDKs (Web · Android · iOS)
- Typed parsing for every new field and message: `epoch`, `reconnect`, `reconnectTokenTTLMs`, `participants[].contentState`, `error.reason`, `relay_failed`, `negotiation_dirty`.
- New `sessionExpired` terminal error mapped from `INVALID_RECONNECT_TOKEN`; `ROOM_ENDED` and `INVALID_RECONNECT_TOKEN` both clear persisted reconnect storage.
- Web `SignalingEngine` exposes `lastReconnectOutcome`, `lastEpoch`, `epochAtDisconnect`, `awaitingPostReconnectSnapshot` so `MediaEngine` can gate ICE restart on a confirmed post-reconnect snapshot (wiring is the follow-up).

### Tests / CI
- New `server/resilience_phase1_test.go` covers reconnect outcomes, recovered CID, ROOM_ENDED tombstone, expired-token rejection, epoch advancement, post-reconnect snapshot, dirty-pair + `relay_failed`, `negotiation_dirty` on reattach, content-state replay, and media-liveness deferral.
- Web payload tests extended for the new fields/parsers (`payloads.test.ts`).
- All suites green: server (Go), Web (vitest, 301), Android (gradle), iOS (xcodebuild, 246).
- `scripts/check-resilience-constants.mjs` and `scripts/check-version-parity.mjs` green.

### Docs
- [`docs/serenada_protocol_v1.md`](docs/serenada_protocol_v1.md) — new `joined`/`room_state` fields, new error codes (`ROOM_ENDED`, `INVALID_RECONNECT_TOKEN`), and three new message types (`relay_failed`, `negotiation_dirty`, `media_liveness`).
- [`docs/resilience-failure-modes.md`](docs/resilience-failure-modes.md) — priority table now carries a Status column; every issue's section has a `**Status:**` line summarizing what landed and what remains; full Phase 1 entry added to the change log.

## Test plan

- [x] `cd server && go test ./...` (server + Phase 1 suite + loadconduit)
- [x] `cd client && npm run test` (Web SDK — 301 tests, 17 files)
- [x] `cd client && npm run build` (TypeScript + Vite)
- [x] `cd client-android && ./gradlew :serenada-core:testDebugUnitTest`
- [x] `cd client-android && ./gradlew :serenada-core:assembleDebug :serenada-call-ui:assembleDebug :app:assembleDebug`
- [x] `cd client-ios && xcodegen generate && xcodebuild ... test` (246 unit tests)
- [x] `node scripts/check-resilience-constants.mjs`
- [x] `node scripts/check-version-parity.mjs`
- [ ] Smoke test against a live deployment once this lands on `agatx/resilience-audit`

## Out of scope (Phase 2 / 3)

- SDK MediaEngine consumption of `negotiation_dirty` / `relay_failed` / post-reconnect snapshot gate (#1, #4, #13 SDK side).
- Periodic `media_liveness` emission from SDKs (#3 SDK side) and per-participant suspended UI presentation timer (#3 / #6 surface).
- Stale buffered offer/ICE discard in the SDK enqueue/flush path (#13).
- SSE pending-session + `resumeSse` (#7) coupled with transport-resume (#12) and active-replacement guard (#15 part 2).
- Process-death recovery (#5), iOS background-foreground forced ping (#8), push-to-rejoin lifecycle serialization (#10), Android foreground-service drift (#14), TURN expiry queueing (#9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)