### PR TITLE
Phase 2 partial: process-death recovery (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ client-ios/Resources/GoogleService-Info.plist
 /client/packages/core/docs/
 /client/packages/react-ui/docs/
 /client-android/serenada-webrtc/build
+/.autoplanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.5.1] — 2026-04-27
+
+### Changed
+- Version bump across all SDK platforms (web `@serenada/core` + `@serenada/react-ui`, Android `core` + `call-ui` + `libwebrtc`, iOS `SerenadaCore`) and integration docs.
+
 ## [0.5.0] — 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.1] — 2026-04-27
+
+### Fixed
+- Android: in-call layout now uses `localCameraMode` (instead of `isFrontCamera`) to decide which video is large vs PIP, so configs that start in `WORLD` or `COMPOSITE` mode correctly show the local camera as the main surface from the first frame.
+- Web, Android, iOS: when the local camera is off, the remote video is always the main surface (the user's swap preference is preserved and reapplied when video resumes) — no more giant "Camera off" placeholder when the call starts in `WORLD`/`COMPOSITE` with video disabled.
+- Web, Android, iOS: hide the participant name from the bottom-left pill when the remote video-off placeholder is already showing the name; the mic-muted icon still appears when applicable.
+- Android: `inviteControlsEnabled = false` now also hides the QR code and Share button in the waiting overlay (previously only the "Invite to room" button was gated), so invite controls no longer flash during phase transitions.
+
 ## [0.6.0] — 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.5.1] — 2026-04-27
+## [0.6.0] — 2026-04-27
 
 ### Changed
 - Version bump across all SDK platforms (web `@serenada/core` + `@serenada/react-ui`, Android `core` + `call-ui` + `libwebrtc`, iOS `SerenadaCore`) and integration docs.

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7559_173-universal:0.5.0`
-- `app.serenada:core:0.5.0`
-- `app.serenada:call-ui:0.5.0`
+- `app.serenada:libwebrtc-7559_173-universal:0.5.1`
+- `app.serenada:core:0.5.1`
+- `app.serenada:call-ui:0.5.1`
 
 Release APK (signed):
 ```bash

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7559_173-universal:0.6.0`
-- `app.serenada:core:0.6.0`
-- `app.serenada:call-ui:0.6.0`
+- `app.serenada:libwebrtc-7559_173-universal:0.6.1`
+- `app.serenada:core:0.6.1`
+- `app.serenada:call-ui:0.6.1`
 
 Release APK (signed):
 ```bash

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7559_173-universal:0.5.1`
-- `app.serenada:core:0.5.1`
-- `app.serenada:call-ui:0.5.1`
+- `app.serenada:libwebrtc-7559_173-universal:0.6.0`
+- `app.serenada:core:0.6.0`
+- `app.serenada:call-ui:0.6.0`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.5.0"
+                version = "0.5.1"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.5.1"
+                version = "0.6.0"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.0"
+                version = "0.6.1"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -157,9 +157,14 @@ internal fun CallScreen(
         mutableStateOf(config.autoHideControls)
     }
     var wereControlsLastHiddenByAutoHide by remember { mutableStateOf(false) }
-    var isLocalLarge by rememberSaveable { mutableStateOf(false) }
+    var isLocalLarge by rememberSaveable {
+        mutableStateOf(
+            uiState.localCameraMode == LocalCameraMode.WORLD ||
+                uiState.localCameraMode == LocalCameraMode.COMPOSITE
+        )
+    }
     var remoteVideoFitCover by rememberSaveable { mutableStateOf(initialRemoteVideoFitCover) }
-    var lastFrontCameraState by remember { mutableStateOf(uiState.isFrontCamera) }
+    var lastCameraMode by remember { mutableStateOf(uiState.localCameraMode) }
     var localAspectRatio by remember { mutableStateOf<Float?>(null) }
     var remoteAspectRatio by remember { mutableStateOf<Float?>(null) }
     val remoteTileAspectRatios = remember { mutableStateMapOf<String, Float>() }
@@ -276,13 +281,12 @@ internal fun CallScreen(
         }
     }
 
-    // Auto-swap based on camera facing
-    LaunchedEffect(uiState.isFrontCamera) {
-        if (uiState.isFrontCamera != lastFrontCameraState) {
-            // Front -> Back: Swapping to main view for better preview of what we capture
-            // Back -> Front: Swapping to PIP to see remote person clearly
-            isLocalLarge = !uiState.isFrontCamera
-            lastFrontCameraState = uiState.isFrontCamera
+    // Auto-swap when camera mode changes: WORLD/COMPOSITE → local large, SELFIE → local PIP.
+    LaunchedEffect(uiState.localCameraMode) {
+        if (uiState.localCameraMode != lastCameraMode) {
+            isLocalLarge = uiState.localCameraMode == LocalCameraMode.WORLD ||
+                uiState.localCameraMode == LocalCameraMode.COMPOSITE
+            lastCameraMode = uiState.localCameraMode
         }
     }
 
@@ -560,7 +564,8 @@ internal fun CallScreen(
                 ParticipantBadge(
                     modifier = Modifier.align(Alignment.BottomStart),
                     muted = remoteP?.audioEnabled == false,
-                    displayName = remoteP?.displayName,
+                    // Avoid duplicating the name when the remote video-off placeholder already shows it.
+                    displayName = if (uiState.remoteVideoEnabled) remoteP?.displayName else null,
                 )
             }
         }
@@ -1260,43 +1265,45 @@ private fun WaitingOverlay(
             textAlign = TextAlign.Center
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Surface(
-            modifier = Modifier.size(200.dp).clip(RoundedCornerShape(16.dp)),
-            color = Color.White
-        ) {
-            qrBitmap?.let {
-                Image(
-                    bitmap = it.asImageBitmap(),
-                    contentDescription = resolveString(SerenadaString.CallQrCode, strings),
-                    modifier = Modifier.fillMaxSize().padding(16.dp)
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Button(
-            onClick = {
-                if (onShareLink != null) {
-                    onShareLink()
-                } else {
-                    shareLink(context, link, chooserTitle)
-                }
-            },
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = Color.White.copy(alpha = 0.2f)
-                ),
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(resolveString(SerenadaString.CallShareInvitation, strings))
-        }
-
+        // QR / Share / Invite are all "invite controls" — keep them off the screen
+        // entirely when disabled so they don't flash during phase transitions.
         if (config.inviteControlsEnabled) {
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Surface(
+                modifier = Modifier.size(200.dp).clip(RoundedCornerShape(16.dp)),
+                color = Color.White
+            ) {
+                qrBitmap?.let {
+                    Image(
+                        bitmap = it.asImageBitmap(),
+                        contentDescription = resolveString(SerenadaString.CallQrCode, strings),
+                        modifier = Modifier.fillMaxSize().padding(16.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Button(
+                onClick = {
+                    if (onShareLink != null) {
+                        onShareLink()
+                    } else {
+                        shareLink(context, link, chooserTitle)
+                    }
+                },
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color.White.copy(alpha = 0.2f)
+                    ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(resolveString(SerenadaString.CallShareInvitation, strings))
+            }
+
             Spacer(modifier = Modifier.height(12.dp))
 
             Button(

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -290,6 +290,12 @@ internal fun CallScreen(
         }
     }
 
+    // When the local camera is off there's nothing meaningful to enlarge — force
+    // remote-as-large so the user doesn't see a giant "Camera off" placeholder.
+    // The user's swap preference (`isLocalLarge`) is preserved and reapplied
+    // automatically when video comes back on.
+    val effectiveLocalLarge = isLocalLarge && uiState.localVideoEnabled
+
     SerenadaTheme(theme) {
         BoxWithConstraints(
             modifier =
@@ -365,8 +371,8 @@ internal fun CallScreen(
         val pipVideoModifier =
             pipBaseModifier.padding(pipContentPadding).clip(RoundedCornerShape(pipInnerCornerRadius))
 
-        val localModifier = if (isLocalLarge) mainModifier else pipVideoModifier
-        val remoteModifier = if (isLocalLarge) pipVideoModifier else mainModifier
+        val localModifier = if (effectiveLocalLarge) mainModifier else pipVideoModifier
+        val remoteModifier = if (effectiveLocalLarge) pipVideoModifier else mainModifier
         if (showPip) {
             Box(modifier = pipBackgroundModifier)
         }
@@ -405,7 +411,7 @@ internal fun CallScreen(
                 onLocalPinchZoom = onLocalPinchZoom,
                 strings = strings,
             )
-        } else if (isLocalLarge) {
+        } else if (effectiveLocalLarge) {
             val ratio = localAspectRatio ?: 0f
             val containerRatio = if (maxHeight == 0.dp) 1f else maxWidth / maxHeight
             val safeContainerRatio = if (containerRatio > 0f) containerRatio else 1f
@@ -524,9 +530,9 @@ internal fun CallScreen(
             Box(modifier = localModifier) {
                 VideoPlaceholder(
                     text =
-                        if (isLocalLarge) resolveString(SerenadaString.CallLocalCameraOff, strings)
+                        if (effectiveLocalLarge) resolveString(SerenadaString.CallLocalCameraOff, strings)
                         else resolveString(SerenadaString.CallCameraOff, strings),
-                    fontSize = if (isLocalLarge) 16.sp else 10.sp
+                    fontSize = if (effectiveLocalLarge) 16.sp else 10.sp
                 )
             }
         }
@@ -535,7 +541,7 @@ internal fun CallScreen(
             !isMultiParty &&
                     !uiState.remoteVideoEnabled &&
                     (uiState.phase == CallPhase.InCall ||
-                            (uiState.phase == CallPhase.Waiting && isLocalLarge))
+                            (uiState.phase == CallPhase.Waiting && effectiveLocalLarge))
         if (showRemotePlaceholder) {
             val remoteP = uiState.remoteParticipants.firstOrNull()
             val text =
@@ -545,7 +551,7 @@ internal fun CallScreen(
             Box(modifier = remoteModifier) {
                 VideoPlaceholder(
                     text = text,
-                    fontSize = if (isLocalLarge) 10.sp else 16.sp,
+                    fontSize = if (effectiveLocalLarge) 10.sp else 16.sp,
                     displayName = nameToShow,
                 )
             }
@@ -608,7 +614,7 @@ internal fun CallScreen(
         }
 
         // Waiting State Overlay
-        if (uiState.phase == CallPhase.Waiting && !isLocalLarge) {
+        if (uiState.phase == CallPhase.Waiting && !effectiveLocalLarge) {
             WaitingOverlay(
                 roomId = roomId,
                 serverHost = serverHost,
@@ -653,7 +659,7 @@ internal fun CallScreen(
             uiState.phase == CallPhase.InCall &&
                     isWorldOrCompositeMode &&
                     uiState.isFlashAvailable
-        val showRemoteFitButton = uiState.remoteVideoEnabled && !isLocalLarge && !isMultiParty
+        val showRemoteFitButton = uiState.remoteVideoEnabled && !effectiveLocalLarge && !isMultiParty
         if (showFlashButton || showRemoteFitButton) {
             Column(
                 modifier =

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.5.1"
+val sdkVersion = "0.6.0"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.5.0"
+val sdkVersion = "0.5.1"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.0"
+val sdkVersion = "0.6.1"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/RecoveryStorage.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/RecoveryStorage.kt
@@ -1,0 +1,83 @@
+package app.serenada.core
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Persisted call-recovery state — surfaced to host apps so a relaunched
+ * process can prompt the user to rejoin an in-flight call instead of
+ * silently dropping them on the home screen.
+ *
+ * Backed by app-private [SharedPreferences]; cleared on clean leave,
+ * `room_ended`, or `INVALID_RECONNECT_TOKEN`.
+ */
+data class RecoveryRecord(
+    val roomId: String,
+    val cid: String,
+    val reconnectToken: String,
+    val lastEpoch: Long?,
+    val sessionStartTs: Long,
+    /**
+     * Unix-ms after which the host app should NOT offer the rejoin prompt.
+     * Computed as `now + reconnectTokenTTLMs` at write time so the SDK
+     * does not need to know server clocks.
+     */
+    val expiresAtMs: Long,
+)
+
+/**
+ * Lightweight, app-private SharedPreferences-backed store for recovery
+ * records. The Android SDK keeps one `RecoveryStorage` instance per
+ * `SerenadaCore`; the active session reads/writes via that instance.
+ */
+internal class RecoveryStorage(context: Context) {
+    private val prefs: SharedPreferences = context.applicationContext
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): RecoveryRecord? {
+        val raw = prefs.getString(KEY_RECORD, null) ?: return null
+        return try {
+            val json = JSONObject(raw)
+            val record = RecoveryRecord(
+                roomId = json.getString("roomId"),
+                cid = json.getString("cid"),
+                reconnectToken = json.getString("reconnectToken"),
+                lastEpoch = if (json.has("lastEpoch") && !json.isNull("lastEpoch"))
+                    json.getLong("lastEpoch") else null,
+                sessionStartTs = json.getLong("sessionStartTs"),
+                expiresAtMs = json.getLong("expiresAtMs"),
+            )
+            if (System.currentTimeMillis() > record.expiresAtMs) {
+                clear()
+                return null
+            }
+            record
+        } catch (_: JSONException) {
+            clear()
+            null
+        }
+    }
+
+    fun save(record: RecoveryRecord) {
+        val json = JSONObject().apply {
+            put("roomId", record.roomId)
+            put("cid", record.cid)
+            put("reconnectToken", record.reconnectToken)
+            if (record.lastEpoch != null) put("lastEpoch", record.lastEpoch)
+            put("sessionStartTs", record.sessionStartTs)
+            put("expiresAtMs", record.expiresAtMs)
+        }
+        prefs.edit().putString(KEY_RECORD, json.toString()).apply()
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_RECORD).apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "serenada_recovery"
+        private const val KEY_RECORD = "record_v1"
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -29,6 +29,31 @@ class SerenadaCore(
     private val okHttpClient = OkHttpClient.Builder().build()
     private val apiClient = CoreApiClient(okHttpClient)
     private val resolvedConfig = resolveSerenadaConfig(config)
+    internal val recoveryStorage = RecoveryStorage(context)
+
+    /**
+     * Returns a recoverable session if the previous process ended abruptly
+     * (kill, OS LMK, crash) while a call was active and the persisted
+     * reconnect token is still within its TTL. Host apps should call this on
+     * launch and surface a "Rejoin call?" prompt — calling [join] with the
+     * returned `roomId` reattaches under the same CID.
+     *
+     * Returns `null` when there is nothing to recover.
+     */
+    fun getRecoverableSession(): RecoveryRecord? {
+        assertMainThread()
+        return recoveryStorage.load()
+    }
+
+    /**
+     * Drops any persisted recovery record. Call this when the user
+     * explicitly declines the rejoin prompt so subsequent launches do not
+     * keep offering the same dead session.
+     */
+    fun discardRecoverableSession() {
+        assertMainThread()
+        recoveryStorage.clear()
+    }
 
     private fun assertMainThread() {
         check(Looper.myLooper() == Looper.getMainLooper()) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -190,7 +190,7 @@ class SerenadaSession internal constructor(
         },
         onError = { callError ->
             joinFlowCoordinator.clearJoinTimeout()
-            resetResources()
+            resetResources(clearRecovery = shouldClearRecovery(callError))
             updateState(CallState(phase = CallPhase.Error, error = callError))
             delegate?.invoke()?.onSessionEnded(this, EndReason.Error(callError))
         },
@@ -1088,12 +1088,12 @@ class SerenadaSession internal constructor(
     private fun cleanupCall(reason: EndReason) {
         updateState(_state.value.copy(phase = CallPhase.Ending))
         if (_diagnostics.value.isScreenSharing) webRtcEngine.stopScreenShare()
-        resetResources()
+        resetResources(clearRecovery = true)
         updateState(CallState(phase = CallPhase.Idle))
         delegate?.invoke()?.onSessionEnded(this, reason)
     }
 
-    private fun resetResources() {
+    private fun resetResources(clearRecovery: Boolean = false) {
         joinFlowCoordinator.reset()
         peerNegotiationEngine.resetAll()
         iceFetchGeneration += 1
@@ -1113,9 +1113,17 @@ class SerenadaSession internal constructor(
         userPreferredVideoEnabled = config.defaultVideoEnabled; isVideoPausedByProximity = false
         reconnectToken = null; reconnectRecoveryPending = false; hasInitialIceServers = false
         sessionStartTs = null
-        recoveryStorage.clear()
+        if (clearRecovery) recoveryStorage.clear()
         providerScope.coroutineContext.cancelChildren()
         updateDiagnostics(CallDiagnostics())
+    }
+
+    private fun shouldClearRecovery(callError: CallError): Boolean {
+        return when (callError) {
+            CallError.RoomEnded,
+            CallError.SessionExpired -> true
+            else -> false
+        }
     }
 
     /**

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -128,6 +128,8 @@ class SerenadaSession internal constructor(
     private val remoteMediaStates = mutableMapOf<String, RemoteMediaState>()
     private var callStartTimeMs: Long? = null
     private var pendingJoinRoom: String? = null
+    private val recoveryStorage = RecoveryStorage(appContext)
+    private var sessionStartTs: Long? = null
     private val connectionStatusTracker = ConnectionStatusTracker(
         handler = handler,
         getPhase = { _state.value.phase },
@@ -177,6 +179,7 @@ class SerenadaSession internal constructor(
                 hostCid = roomState.hostCid
                 updateParticipants(roomState)
             }
+            persistRecoveryRecord()
             broadcastLocalMediaState()
             loadInitialIceServers()
         },
@@ -1109,8 +1112,31 @@ class SerenadaSession internal constructor(
         connectionStatusTracker.cancelTimer()
         userPreferredVideoEnabled = config.defaultVideoEnabled; isVideoPausedByProximity = false
         reconnectToken = null; reconnectRecoveryPending = false; hasInitialIceServers = false
+        sessionStartTs = null
+        recoveryStorage.clear()
         providerScope.coroutineContext.cancelChildren()
         updateDiagnostics(CallDiagnostics())
+    }
+
+    /**
+     * Snapshots the in-memory reconnect state into the cross-launch
+     * recovery store so a relaunched process can offer a "Rejoin call?"
+     * prompt. No-op until the join handshake has produced a CID + token.
+     */
+    private fun persistRecoveryRecord() {
+        val cid = clientId ?: return
+        val token = reconnectToken ?: return
+        if (sessionStartTs == null) sessionStartTs = clock.nowMs()
+        val ttlMs = RecoveryTokenTTLMs
+        val record = RecoveryRecord(
+            roomId = roomId,
+            cid = cid,
+            reconnectToken = token,
+            lastEpoch = currentRoomState?.epoch,
+            sessionStartTs = sessionStartTs ?: clock.nowMs(),
+            expiresAtMs = clock.nowMs() + ttlMs,
+        )
+        recoveryStorage.save(record)
     }
 
     private fun applyLocalVideoPreference() {
@@ -1156,6 +1182,10 @@ class SerenadaSession internal constructor(
     private companion object {
         const val TAG = "SerenadaSession"
         const val CPU_WAKE_LOCK_TAG = "serenada:call-cpu"
+        // Matches the server's reconnectTokenTTL (= suspendHardEvictionTimeout).
+        // The recovery record stops offering rejoin past this window because
+        // the persisted token would no longer be honored anyway.
+        const val RecoveryTokenTTLMs = 10L * 60L * 1000L
         val REQUIRED_ANDROID_PERMISSIONS = arrayOf(
             android.Manifest.permission.CAMERA,
             android.Manifest.permission.RECORD_AUDIO,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
@@ -308,24 +308,6 @@ internal class CameraCaptureController(
         currentCameraSource = cameraSourceFromMode(availableCameraModes.firstOrNull() ?: LocalCameraMode.SELFIE)
     }
 
-    fun restartVideoCapturerFromAvailableModes(videoSource: VideoSource?): Boolean {
-        val attempted = mutableSetOf<LocalCameraSource>()
-        for (mode in availableCameraModes) {
-            val source = cameraSourceFromMode(mode)
-            if (!attempted.add(source)) continue
-            if (restartVideoCapturer(source, videoSource)) {
-                return true
-            }
-            logger?.log(SerenadaLogLevel.WARNING, "Camera", "Failed to start camera source $source")
-            if (source == LocalCameraSource.COMPOSITE) {
-                compositeDisabledAfterFailure = true
-                reportCompositeCameraUnavailable("Composite camera startup failed")
-            }
-        }
-        notifyCameraModeAndFlash()
-        return false
-    }
-
     // ── Camera capture profile selection ────────────────────────────────
 
     internal fun cameraCapturePolicyFor(source: LocalCameraSource): CapturePolicy {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -212,7 +212,7 @@ internal class WebRtcEngine(
 
         videoSource = peerConnectionFactory.createVideoSource(false)
         cameraController.resetCameraSourceToInitial()
-        val startedVideo = cameraController.restartVideoCapturerFromAvailableModes(videoSource)
+        val startedVideo = cameraController.restartVideoCapturer(cameraController.currentCameraSource, videoSource)
         if (!startedVideo) {
             logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "No camera capturer available; continuing audio-only")
         }
@@ -288,7 +288,7 @@ internal class WebRtcEngine(
             return false
         }
         if (enabled && !screenShareController.isScreenSharing && cameraController.videoCapturer == null) {
-            if (!cameraController.restartVideoCapturerFromAvailableModes(videoSource)) {
+            if (!cameraController.restartVideoCapturer(cameraController.currentCameraSource, videoSource)) {
                 localVideoTrack?.setEnabled(false)
                 return false
             }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -390,7 +390,11 @@ internal class WebRtcEngine(
             return
         }
         renderer.init(eglBase.eglBaseContext, rendererEvents)
-        renderer.setEnableHardwareScaler(true)
+        // Hardware scaler issues setFixedSize(...) with a buffer smaller than the view.
+        // On Android 9 / older SurfaceFlinger this leaves the surface anchored at top-left
+        // after a remote resolution change, producing a black bar on the right until the
+        // next forced layout pass. Sizing the buffer from layout avoids the race.
+        renderer.setEnableHardwareScaler(false)
     }
 
     private fun applyAudioTrackHints() {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -212,7 +212,7 @@ internal class WebRtcEngine(
 
         videoSource = peerConnectionFactory.createVideoSource(false)
         cameraController.resetCameraSourceToInitial()
-        val startedVideo = cameraController.restartVideoCapturer(cameraController.currentCameraSource, videoSource)
+        val startedVideo = restartVideoCapturerWithFallback(cameraController.currentCameraSource)
         if (!startedVideo) {
             logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "No camera capturer available; continuing audio-only")
         }
@@ -288,7 +288,7 @@ internal class WebRtcEngine(
             return false
         }
         if (enabled && !screenShareController.isScreenSharing && cameraController.videoCapturer == null) {
-            if (!cameraController.restartVideoCapturer(cameraController.currentCameraSource, videoSource)) {
+            if (!restartVideoCapturerWithFallback(cameraController.currentCameraSource)) {
                 localVideoTrack?.setEnabled(false)
                 return false
             }
@@ -299,6 +299,39 @@ internal class WebRtcEngine(
         val effectiveEnabled = enabled && (cameraController.videoCapturer != null || screenShareController.isScreenSharing)
         localVideoTrack?.setEnabled(effectiveEnabled)
         return effectiveEnabled
+    }
+
+    private fun restartVideoCapturerWithFallback(preferredSource: CameraCaptureController.LocalCameraSource): Boolean {
+        for (candidate in cameraSourceCandidates(preferredSource)) {
+            if (cameraController.restartVideoCapturer(candidate, videoSource)) {
+                if (candidate != preferredSource) {
+                    logger?.log(SerenadaLogLevel.WARNING, "Camera", "Camera source fallback applied: $candidate")
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun cameraSourceCandidates(
+        preferredSource: CameraCaptureController.LocalCameraSource
+    ): List<CameraCaptureController.LocalCameraSource> {
+        val candidates = mutableListOf(preferredSource)
+        cameraController.availableCameraModes
+            .map { cameraSourceFromMode(it) }
+            .forEach { source ->
+                if (source !in candidates) candidates.add(source)
+            }
+        return candidates
+    }
+
+    private fun cameraSourceFromMode(mode: LocalCameraMode): CameraCaptureController.LocalCameraSource {
+        return when (mode) {
+            LocalCameraMode.SELFIE -> CameraCaptureController.LocalCameraSource.SELFIE
+            LocalCameraMode.WORLD -> CameraCaptureController.LocalCameraSource.WORLD
+            LocalCameraMode.COMPOSITE -> CameraCaptureController.LocalCameraSource.COMPOSITE
+            LocalCameraMode.SCREEN_SHARE -> CameraCaptureController.LocalCameraSource.SELFIE
+        }
     }
 
     fun setHdVideoExperimentalEnabled(enabled: Boolean) {

--- a/client-android/serenada-core/src/test/java/app/serenada/core/RecoveryStorageTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/RecoveryStorageTest.kt
@@ -1,0 +1,87 @@
+package app.serenada.core
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RecoveryStorageTest {
+    private val storage = RecoveryStorage(RuntimeEnvironment.getApplication())
+
+    @After
+    fun tearDown() {
+        storage.clear()
+    }
+
+    @Test
+    fun `load returns null when nothing stored`() {
+        assertNull(storage.load())
+    }
+
+    @Test
+    fun `round-trips a valid record`() {
+        val record = RecoveryRecord(
+            roomId = "room-1",
+            cid = "C-abc",
+            reconnectToken = "tok",
+            lastEpoch = 7L,
+            sessionStartTs = System.currentTimeMillis() - 10_000,
+            expiresAtMs = System.currentTimeMillis() + 60_000,
+        )
+        storage.save(record)
+        assertEquals(record, storage.load())
+    }
+
+    @Test
+    fun `lastEpoch may be null`() {
+        val record = RecoveryRecord(
+            roomId = "room-1",
+            cid = "C-abc",
+            reconnectToken = "tok",
+            lastEpoch = null,
+            sessionStartTs = System.currentTimeMillis(),
+            expiresAtMs = System.currentTimeMillis() + 60_000,
+        )
+        storage.save(record)
+        assertNull(storage.load()?.lastEpoch)
+    }
+
+    @Test
+    fun `expired records are dropped on load`() {
+        val record = RecoveryRecord(
+            roomId = "room-1",
+            cid = "C-abc",
+            reconnectToken = "tok",
+            lastEpoch = null,
+            sessionStartTs = System.currentTimeMillis() - 100_000,
+            expiresAtMs = System.currentTimeMillis() - 1,
+        )
+        storage.save(record)
+        assertNull(storage.load())
+        // The slot should be empty after the expired-record drop.
+        assertNull(storage.load())
+    }
+
+    @Test
+    fun `clear removes any stored value`() {
+        storage.save(
+            RecoveryRecord(
+                roomId = "room-1",
+                cid = "C-abc",
+                reconnectToken = "tok",
+                lastEpoch = 1L,
+                sessionStartTs = System.currentTimeMillis(),
+                expiresAtMs = System.currentTimeMillis() + 60_000,
+            )
+        )
+        storage.clear()
+        assertTrue(storage.load() == null)
+    }
+}

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.5.0"
+val sdkVersion = "0.5.1"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.5.1"
+val sdkVersion = "0.6.0"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.0"
+val sdkVersion = "0.6.1"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -23,12 +23,16 @@ func shouldShowRemoteVideoPlaceholder(phase: CallPhase, remoteVideoEnabled: Bool
     !remoteVideoEnabled && phase == .inCall
 }
 
-func shouldShowRemoteFitButton(phase: CallPhase, remoteVideoEnabled: Bool, isLocalLarge: Bool) -> Bool {
-    phase == .inCall && remoteVideoEnabled && !isLocalLarge
+func shouldShowRemoteFitButton(phase: CallPhase, remoteVideoEnabled: Bool, isLocalLarge: Bool, localVideoEnabled: Bool) -> Bool {
+    phase == .inCall && remoteVideoEnabled && !(isLocalLarge && localVideoEnabled)
 }
 
-func shouldRenderLocalAsPrimarySurface(phase: CallPhase, isLocalLarge: Bool) -> Bool {
-    phase == .inCall && isLocalLarge
+// When the local camera is off there's nothing meaningful to enlarge — force
+// remote-as-primary so the user doesn't see a giant "Camera off" placeholder.
+// The user's swap preference (`isLocalLarge`) is preserved and reapplied
+// automatically when video comes back on.
+func shouldRenderLocalAsPrimarySurface(phase: CallPhase, isLocalLarge: Bool, localVideoEnabled: Bool) -> Bool {
+    phase == .inCall && isLocalLarge && localVideoEnabled
 }
 
 func shouldUseBroadcastPicker(isScreenSharing: Bool, screenShareExtensionBundleId: String?) -> Bool {
@@ -317,7 +321,8 @@ struct CallScreenView: View {
     var body: some View {
         let showLocalAsPrimarySurface = shouldRenderLocalAsPrimarySurface(
             phase: uiState.phase,
-            isLocalLarge: isLocalLarge
+            isLocalLarge: isLocalLarge,
+            localVideoEnabled: uiState.localVideoEnabled
         )
         let isPinchZoomEnabled = shouldEnablePinchZoom(showLocalAsPrimarySurface: showLocalAsPrimarySurface)
         let shouldRunAutoHideTask = areControlsVisible && uiState.phase == .inCall && isControlsAutoHideEnabled
@@ -655,7 +660,8 @@ struct CallScreenView: View {
                 if shouldShowRemoteFitButton(
                     phase: uiState.phase,
                     remoteVideoEnabled: uiState.remoteVideoEnabled,
-                    isLocalLarge: isLocalLarge
+                    isLocalLarge: isLocalLarge,
+                    localVideoEnabled: uiState.localVideoEnabled
                 ) && !isMultiParty {
                     iconButton(system: remoteVideoFitCover ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right", accessibilityLabel: remoteVideoFitCover ? str(.callA11yVideoFit) : str(.callA11yVideoFill)) {
                         withAnimation(.easeInOut(duration: 0.2)) {

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -386,7 +386,11 @@ struct CallScreenView: View {
                         placeholderText: uiState.phase == .inCall ? str(.callVideoOff) : nil,
                         placeholderDisplayName: uiState.phase == .inCall ? uiState.remoteParticipants.first?.displayName : nil
                     )
-                    ParticipantBadge(muted: uiState.remoteParticipants.first?.audioEnabled == false, displayName: uiState.remoteParticipants.first?.displayName)
+                    // Avoid duplicating the name when the remote video-off placeholder already shows it.
+                    ParticipantBadge(
+                        muted: uiState.remoteParticipants.first?.audioEnabled == false,
+                        displayName: uiState.remoteVideoEnabled ? uiState.remoteParticipants.first?.displayName : nil
+                    )
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
                 smallLocalView

--- a/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
+++ b/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
@@ -58,17 +58,21 @@ final class CallScreenStateTests: XCTestCase {
     }
 
     func testRemoteFitButtonShownOnlyWhenRemoteIsMainSurface() {
-        XCTAssertTrue(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: true, isLocalLarge: false))
-        XCTAssertFalse(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: false, isLocalLarge: false))
-        XCTAssertFalse(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: true, isLocalLarge: true))
-        XCTAssertFalse(shouldShowRemoteFitButton(phase: .waiting, remoteVideoEnabled: true, isLocalLarge: false))
+        XCTAssertTrue(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: true, isLocalLarge: false, localVideoEnabled: true))
+        XCTAssertFalse(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: false, isLocalLarge: false, localVideoEnabled: true))
+        XCTAssertFalse(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: true, isLocalLarge: true, localVideoEnabled: true))
+        XCTAssertFalse(shouldShowRemoteFitButton(phase: .waiting, remoteVideoEnabled: true, isLocalLarge: false, localVideoEnabled: true))
+        // Local camera off forces remote-as-primary, so the fit button should appear even if isLocalLarge is true.
+        XCTAssertTrue(shouldShowRemoteFitButton(phase: .inCall, remoteVideoEnabled: true, isLocalLarge: true, localVideoEnabled: false))
     }
 
     func testOnlyInCallRendersLocalAsPrimarySurfaceWhenExpanded() {
-        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .waiting, isLocalLarge: false))
-        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .waiting, isLocalLarge: true))
-        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .inCall, isLocalLarge: false))
-        XCTAssertTrue(shouldRenderLocalAsPrimarySurface(phase: .inCall, isLocalLarge: true))
+        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .waiting, isLocalLarge: false, localVideoEnabled: true))
+        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .waiting, isLocalLarge: true, localVideoEnabled: true))
+        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .inCall, isLocalLarge: false, localVideoEnabled: true))
+        XCTAssertTrue(shouldRenderLocalAsPrimarySurface(phase: .inCall, isLocalLarge: true, localVideoEnabled: true))
+        // Local camera off should never render local as primary regardless of swap preference.
+        XCTAssertFalse(shouldRenderLocalAsPrimarySurface(phase: .inCall, isLocalLarge: true, localVideoEnabled: false))
     }
 
     func testPipBottomPaddingUsesLowerOffsetsInLandscape() {

--- a/client-ios/SerenadaCore/Sources/RecoveryStorage.swift
+++ b/client-ios/SerenadaCore/Sources/RecoveryStorage.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Persisted call-recovery state — surfaced to host apps so a relaunched
+/// process can prompt the user to rejoin an in-flight call instead of
+/// silently dropping them on the home screen.
+///
+/// Backed by `UserDefaults` (the active app group when the host app
+/// configures one, else `.standard`); cleared on clean leave,
+/// `room_ended`, or `INVALID_RECONNECT_TOKEN`.
+public struct RecoveryRecord: Equatable, Codable, Sendable {
+    public let roomId: String
+    public let cid: String
+    public let reconnectToken: String
+    public let lastEpoch: Int64?
+    public let sessionStartTs: Int64
+    /// Unix-ms after which the host app should NOT offer the rejoin
+    /// prompt. Computed as `now + reconnectTokenTTLMs` at write time so the
+    /// SDK does not need to know server clocks.
+    public let expiresAtMs: Int64
+
+    public init(
+        roomId: String,
+        cid: String,
+        reconnectToken: String,
+        lastEpoch: Int64?,
+        sessionStartTs: Int64,
+        expiresAtMs: Int64
+    ) {
+        self.roomId = roomId
+        self.cid = cid
+        self.reconnectToken = reconnectToken
+        self.lastEpoch = lastEpoch
+        self.sessionStartTs = sessionStartTs
+        self.expiresAtMs = expiresAtMs
+    }
+}
+
+/// Lightweight, pluggable store for recovery records. The SDK keeps one
+/// per `SerenadaCore`; the active session reads/writes via that instance.
+public final class RecoveryStorage: @unchecked Sendable {
+    private static let recordKey = "serenada.recovery.record_v1"
+
+    private let defaults: UserDefaults
+    private let now: () -> Int64
+
+    public convenience init() {
+        self.init(defaults: .standard)
+    }
+
+    public init(defaults: UserDefaults, now: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    public func load() -> RecoveryRecord? {
+        guard let data = defaults.data(forKey: Self.recordKey) else { return nil }
+        guard let record = try? JSONDecoder().decode(RecoveryRecord.self, from: data) else {
+            defaults.removeObject(forKey: Self.recordKey)
+            return nil
+        }
+        if now() > record.expiresAtMs {
+            defaults.removeObject(forKey: Self.recordKey)
+            return nil
+        }
+        return record
+    }
+
+    public func save(_ record: RecoveryRecord) {
+        guard let data = try? JSONEncoder().encode(record) else { return }
+        defaults.set(data, forKey: Self.recordKey)
+    }
+
+    public func clear() {
+        defaults.removeObject(forKey: Self.recordKey)
+    }
+}

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.5.0"
+    public static let version = "0.5.1"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.5.1"
+    public static let version = "0.6.0"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -48,13 +48,36 @@ public final class SerenadaCore {
     /// Optional logger for SDK diagnostics.
     public var logger: SerenadaLogger?
 
-    public init(config: SerenadaConfig) {
+    /// Cross-launch recovery store for in-flight call state. Default
+    /// `UserDefaults.standard`; the host app can replace it with an
+    /// app-group-scoped store before opening any session.
+    public let recoveryStorage: RecoveryStorage
+
+    public init(config: SerenadaConfig, recoveryStorage: RecoveryStorage = RecoveryStorage()) {
         self.config = config
+        self.recoveryStorage = recoveryStorage
         do {
             self.resolvedConfig = try resolveSerenadaConfig(config)
         } catch {
             preconditionFailure(error.localizedDescription)
         }
+    }
+
+    /// Returns a recoverable session if the previous process ended abruptly
+    /// (force-quit, jetsam, OS kill) while a call was active and the
+    /// persisted reconnect token is still within its TTL. Host apps should
+    /// call this on launch and surface a "Rejoin call?" prompt — calling
+    /// `join(roomId:)` with the returned `roomId` reattaches under the same
+    /// CID. Returns `nil` when there is nothing to recover.
+    public func getRecoverableSession() -> RecoveryRecord? {
+        recoveryStorage.load()
+    }
+
+    /// Drops any persisted recovery record. Call this when the user
+    /// explicitly declines the rejoin prompt so subsequent launches do not
+    /// keep offering the same dead session.
+    public func discardRecoverableSession() {
+        recoveryStorage.clear()
     }
 
     /// Join an existing call by URL. Returns a session that begins connecting immediately.
@@ -84,7 +107,8 @@ public final class SerenadaCore {
             delegateProvider: { [weak self] in self?.delegate },
             logger: logger,
             initialSignalingProvider: createSignalingProvider(for: sessionConfig),
-            displayName: displayName
+            displayName: displayName,
+            recoveryStorage: recoveryStorage
         )
         return session
     }
@@ -100,7 +124,8 @@ public final class SerenadaCore {
             delegateProvider: { [weak self] in self?.delegate },
             logger: logger,
             initialSignalingProvider: createSignalingProvider(for: config),
-            displayName: displayName
+            displayName: displayName,
+            recoveryStorage: recoveryStorage
         )
         return session
     }

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.0"
+    public static let version = "0.6.1"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -257,7 +257,9 @@ private extension SerenadaServerProvider {
                 hostPeerId: payload.hostCid,
                 maxParticipants: payload.maxParticipants,
                 epoch: payload.epoch,
-                reconnectOutcome: payload.reconnect
+                reconnectOutcome: payload.reconnect,
+                reconnectToken: reconnectToken,
+                reconnectTokenTTLMs: payload.reconnectTokenTTLMs.map(Int64.init)
             )
         )
     }

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -171,6 +171,9 @@ public final class SerenadaSession: ObservableObject {
     private var iceFetchGeneration = 0
     private var reconnectTask: Task<Void, Never>?
 
+    private let recoveryStorage: RecoveryStorage
+    private var sessionStartTs: Int64?
+
     public convenience init(
         roomId: String,
         roomUrl: URL? = nil,
@@ -178,7 +181,8 @@ public final class SerenadaSession: ObservableObject {
         config: SerenadaConfig,
         delegateProvider: (() -> SerenadaCoreDelegate?)? = nil,
         logger: SerenadaLogger? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        recoveryStorage: RecoveryStorage = RecoveryStorage()
     ) {
         let sessionConfig = config.signalingProvider == nil
             ? SerenadaConfig(
@@ -195,7 +199,8 @@ public final class SerenadaSession: ObservableObject {
             roomId: roomId, roomUrl: roomUrl, config: sessionConfig,
             delegateProvider: delegateProvider, logger: logger,
             initialSignalingProvider: nil, signaling: nil, apiClient: nil, audioController: nil, mediaEngine: nil, clock: nil,
-            displayName: displayName
+            displayName: displayName,
+            recoveryStorage: recoveryStorage
         )
     }
 
@@ -211,8 +216,10 @@ public final class SerenadaSession: ObservableObject {
         audioController: SessionAudioController? = nil,
         mediaEngine: SessionMediaEngine? = nil,
         clock: SessionClock? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        recoveryStorage: RecoveryStorage = RecoveryStorage()
     ) {
+        self.recoveryStorage = recoveryStorage
         self.roomId = roomId
         self.roomUrl = roomUrl
         self.config = config
@@ -638,6 +645,7 @@ public final class SerenadaSession: ObservableObject {
     fileprivate func handleProviderJoined(_ event: JoinedEvent) {
         currentError = nil
         signalingMessageRouter?.processJoinedEvent(event)
+        persistRecoveryRecord(token: event.reconnectToken, ttlMs: event.reconnectTokenTTLMs)
     }
 
     fileprivate func handleProviderRoomStateUpdated(_ event: RoomStateEvent) {
@@ -900,6 +908,8 @@ public final class SerenadaSession: ObservableObject {
         joinFlowCoordinator?.clearAllTimers()
         connectionStatusTracker?.cancelTimer()
         iceFetchGeneration += 1
+        sessionStartTs = nil
+        recoveryStorage.clear()
 
         let videoCaptureSupported = !availableCameraModes.isEmpty
         userPreferredVideoEnabled = videoCaptureSupported && config.defaultVideoEnabled
@@ -1141,4 +1151,30 @@ public final class SerenadaSession: ObservableObject {
         }
         pathMonitor.start(queue: pathMonitorQueue)
     }
+
+    /// Snapshots the in-memory reconnect state into the cross-launch
+    /// recovery store so a relaunched process can offer a "Rejoin call?"
+    /// prompt. No-op until the join handshake has produced a CID + token.
+    private func persistRecoveryRecord(token: String?, ttlMs: Int64?) {
+        guard let cid = clientId, let token = token else { return }
+        if sessionStartTs == nil { sessionStartTs = Self.nowMs() }
+        let ttl = ttlMs.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultRecoveryTokenTTLMs
+        let record = RecoveryRecord(
+            roomId: roomId,
+            cid: cid,
+            reconnectToken: token,
+            lastEpoch: currentRoomState?.epoch,
+            sessionStartTs: sessionStartTs ?? Self.nowMs(),
+            expiresAtMs: Self.nowMs() + ttl
+        )
+        recoveryStorage.save(record)
+    }
+
+    private static func nowMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    /// Matches the server's `reconnectTokenTTL` (= `suspendHardEvictionTimeout`).
+    /// Used when the server did not surface `reconnectTokenTTLMs`.
+    private static let defaultRecoveryTokenTTLMs: Int64 = 10 * 60 * 1000
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -599,7 +599,7 @@ public final class SerenadaSession: ObservableObject {
     private func handleError(_ error: CallError) {
         currentError = error
         joinFlowCoordinator?.clearAllTimers()
-        resetResources()
+        resetResources(clearRecovery: shouldClearRecovery(for: error))
         internalPhase = .error
         commitSnapshot()
     }
@@ -749,7 +749,7 @@ public final class SerenadaSession: ObservableObject {
     private func failJoinWithError(_ error: CallError) {
         joinFlowCoordinator?.clearAllTimers()
         currentError = error
-        resetResources()
+        resetResources(clearRecovery: shouldClearRecovery(for: error))
         internalPhase = .error
         commitSnapshot()
     }
@@ -877,7 +877,7 @@ public final class SerenadaSession: ObservableObject {
             internalPhase = .ending
             commitSnapshot { s, _ in s.localParticipant.videoEnabled = false; s.remoteParticipants = [] }
         }
-        resetResources()
+        resetResources(clearRecovery: true)
         if transitionToEnding {
             delegateProvider?()?.sessionDidEnd(self, reason: reason)
             Task { @MainActor [weak self] in
@@ -892,7 +892,7 @@ public final class SerenadaSession: ObservableObject {
         }
     }
 
-    private func resetResources() {
+    private func resetResources(clearRecovery: Bool = false) {
         statsPoller?.stop()
         peerNegotiationEngine?.resetAll()
         signalingProvider.disconnect()
@@ -909,7 +909,7 @@ public final class SerenadaSession: ObservableObject {
         connectionStatusTracker?.cancelTimer()
         iceFetchGeneration += 1
         sessionStartTs = nil
-        recoveryStorage.clear()
+        if clearRecovery { recoveryStorage.clear() }
 
         let videoCaptureSupported = !availableCameraModes.isEmpty
         userPreferredVideoEnabled = videoCaptureSupported && config.defaultVideoEnabled
@@ -933,6 +933,15 @@ public final class SerenadaSession: ObservableObject {
             d.isFlashAvailable = false; d.isFlashEnabled = false
             d.remoteContentParticipantId = nil; d.remoteContentType = nil
             d.realtimeStats = .empty; d.featureDegradations = []
+        }
+    }
+
+    private func shouldClearRecovery(for error: CallError) -> Bool {
+        switch error {
+        case .roomEnded, .sessionExpired:
+            return true
+        default:
+            return false
         }
     }
 

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -86,6 +86,12 @@ public struct JoinedEvent: Equatable, Sendable {
     public let epoch: Int64?
     /// How the server treated this join. nil for older providers.
     public let reconnectOutcome: ReconnectOutcome?
+    /// Server-issued reconnect token from `joined.reconnectToken`. The
+    /// session uses this to populate the cross-launch recovery record;
+    /// the provider also keeps an internal copy for transport reconnects.
+    public let reconnectToken: String?
+    /// How long (ms) the server is willing to honor `reconnectToken`.
+    public let reconnectTokenTTLMs: Int64?
 
     public init(
         peerId: String,
@@ -93,7 +99,9 @@ public struct JoinedEvent: Equatable, Sendable {
         hostPeerId: String? = nil,
         maxParticipants: Int? = nil,
         epoch: Int64? = nil,
-        reconnectOutcome: ReconnectOutcome? = nil
+        reconnectOutcome: ReconnectOutcome? = nil,
+        reconnectToken: String? = nil,
+        reconnectTokenTTLMs: Int64? = nil
     ) {
         self.peerId = peerId
         self.participants = participants
@@ -101,6 +109,8 @@ public struct JoinedEvent: Equatable, Sendable {
         self.maxParticipants = maxParticipants
         self.epoch = epoch
         self.reconnectOutcome = reconnectOutcome
+        self.reconnectToken = reconnectToken
+        self.reconnectTokenTTLMs = reconnectTokenTTLMs
     }
 }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RecoveryStorageTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RecoveryStorageTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import SerenadaCore
+
+final class RecoveryStorageTests: XCTestCase {
+    private let suiteName = "serenada.recovery.tests"
+    private var defaults: UserDefaults!
+    private var storage: RecoveryStorage!
+    private var nowMs: Int64 = 1_000_000
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = UserDefaults(suiteName: suiteName)!
+        storage = RecoveryStorage(defaults: defaults, now: { [weak self] in self?.nowMs ?? 0 })
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testLoadReturnsNilWhenNothingStored() {
+        XCTAssertNil(storage.load())
+    }
+
+    func testRoundTripsValidRecord() {
+        let record = RecoveryRecord(
+            roomId: "room-1",
+            cid: "C-abc",
+            reconnectToken: "tok",
+            lastEpoch: 7,
+            sessionStartTs: nowMs - 10_000,
+            expiresAtMs: nowMs + 60_000
+        )
+        storage.save(record)
+        XCTAssertEqual(storage.load(), record)
+    }
+
+    func testLastEpochMayBeNil() {
+        let record = RecoveryRecord(
+            roomId: "room-1",
+            cid: "C-abc",
+            reconnectToken: "tok",
+            lastEpoch: nil,
+            sessionStartTs: nowMs,
+            expiresAtMs: nowMs + 60_000
+        )
+        storage.save(record)
+        XCTAssertNil(storage.load()?.lastEpoch)
+    }
+
+    func testExpiredRecordsAreDroppedOnLoad() {
+        let record = RecoveryRecord(
+            roomId: "room-1",
+            cid: "C-abc",
+            reconnectToken: "tok",
+            lastEpoch: nil,
+            sessionStartTs: nowMs - 100_000,
+            expiresAtMs: nowMs - 1
+        )
+        storage.save(record)
+        XCTAssertNil(storage.load())
+        XCTAssertNil(storage.load())
+    }
+
+    func testClearRemovesAnyStoredValue() {
+        let record = RecoveryRecord(
+            roomId: "room-1",
+            cid: "C-abc",
+            reconnectToken: "tok",
+            lastEpoch: 1,
+            sessionStartTs: nowMs,
+            expiresAtMs: nowMs + 60_000
+        )
+        storage.save(record)
+        storage.clear()
+        XCTAssertNil(storage.load())
+    }
+
+    func testCorruptedDataIsDropped() {
+        defaults.set(Data("not json".utf8), forKey: "serenada.recovery.record_v1")
+        XCTAssertNil(storage.load())
+    }
+}

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		252529C96E5D4B8966096E25 /* JoinWithCodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6625E5E013BB38E369F98188 /* JoinWithCodeScreen.swift */; };
 		25AD5A8310F31233C76D87DB /* LiveRoomOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367DCC8F4EDC812C9FBA3F02 /* LiveRoomOverride.swift */; };
 		2689E7B3ED25607A90E268B7 /* FakeMediaEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461DCF4D9C695C2B6051BF91 /* FakeMediaEngine.swift */; };
+		2A96BF63C126AFE8CE2976D4 /* RecoveryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77004950192C89C56E76A8F /* RecoveryStorageTests.swift */; };
 		2B3986D47A857C11365A6D68 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5B216BB8A302914AB1CA5B /* NotificationService.swift */; };
 		2DC84097620992B43C52D59E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = ECFBB844D3428C53592F5F7B /* FirebaseMessaging */; };
 		3153C0E407E8DD601B43B97E /* RootViewRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD7296B4488661AE49A34BA /* RootViewRoutingTests.swift */; };
@@ -212,6 +213,7 @@
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E77004950192C89C56E76A8F /* RecoveryStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryStorageTests.swift; sourceTree = "<group>"; };
 		E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SerenadaiOS.entitlements; sourceTree = "<group>"; };
 		E9CFF87F710AB38BB7519AFB /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ECF59DDD3EB32D08B6F0B913 /* SerenadaCoreProviderModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaCoreProviderModeTests.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */,
 				E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */,
 				801D5040B2102E7DFFFDC2B2 /* LoopbackSignalingProviderTests.swift */,
+				E77004950192C89C56E76A8F /* RecoveryStorageTests.swift */,
 				79D3BC3109B79353E8157F76 /* RoomWatcherTests.swift */,
 				ECF59DDD3EB32D08B6F0B913 /* SerenadaCoreProviderModeTests.swift */,
 				4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */,
@@ -809,6 +812,7 @@
 				366BA266D1F08550723BA77D /* LayoutConformanceTests.swift in Sources */,
 				C0500F3658A11A038780B5FD /* LoopbackSignalingProviderTests.swift in Sources */,
 				C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */,
+				2A96BF63C126AFE8CE2976D4 /* RecoveryStorageTests.swift in Sources */,
 				71320D322F59D2244B5A2027 /* RoomStatusesTests.swift in Sources */,
 				9C333A1799F89B5A4A9080BB /* RoomWatcherTests.swift in Sources */,
 				3153C0E407E8DD601B43B97E /* RootViewRoutingTests.swift in Sources */,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.5.0",
-        "@serenada/react-ui": "0.5.0",
+        "@serenada/core": "0.5.1",
+        "@serenada/react-ui": "0.5.1",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -4315,21 +4315,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.5.0"
+        "@serenada/core": "0.5.1"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.5.0",
+        "@serenada/core": "^0.5.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.5.1",
-        "@serenada/react-ui": "0.5.1",
+        "@serenada/core": "0.6.0",
+        "@serenada/react-ui": "0.6.0",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -4315,21 +4315,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.5.1"
+        "@serenada/core": "0.6.0"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.5.1",
+        "@serenada/core": "^0.6.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.6.0",
-        "@serenada/react-ui": "0.6.0",
+        "@serenada/core": "0.6.1",
+        "@serenada/react-ui": "0.6.1",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -4315,21 +4315,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.0"
+        "@serenada/core": "0.6.1"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.0",
+        "@serenada/core": "^0.6.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.5.0",
-    "@serenada/react-ui": "0.5.0",
+    "@serenada/core": "0.5.1",
+    "@serenada/react-ui": "0.5.1",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.5.1",
-    "@serenada/react-ui": "0.5.1",
+    "@serenada/core": "0.6.0",
+    "@serenada/react-ui": "0.6.0",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.6.0",
-    "@serenada/react-ui": "0.6.0",
+    "@serenada/core": "0.6.1",
+    "@serenada/react-ui": "0.6.1",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/SerenadaCore.ts
+++ b/client/packages/core/src/SerenadaCore.ts
@@ -6,6 +6,11 @@ import type { ResolvedSerenadaConfig } from './configValidation.js';
 import { requireServerHost, resolveSerenadaConfig } from './configValidation.js';
 import { SerenadaServerProvider } from './SerenadaServerProvider.js';
 import type { PeerMessage, SignalingProvider } from './SignalingProvider.js';
+import {
+    clearRecoveryRecord,
+    loadRecoveryRecord,
+    type RecoveryRecord,
+} from './recoveryStorage.js';
 
 /**
  * Main entry point for the Serenada SDK.
@@ -24,6 +29,28 @@ export class SerenadaCore {
     /** Check if the current browser supports WebRTC calling. */
     static isSupported(): boolean {
         return typeof RTCPeerConnection !== 'undefined';
+    }
+
+    /**
+     * Returns a recoverable session if the previous tab/page session ended
+     * abruptly (reload, OS-level crash) while a call was active and the
+     * persisted reconnect token is still within its TTL. Host apps should
+     * call this on launch and surface a "Rejoin call?" prompt — calling
+     * {@link join} with the returned `roomId` reattaches under the same CID.
+     *
+     * Returns `null` when there is nothing to recover.
+     */
+    static getRecoverableSession(): RecoveryRecord | null {
+        return loadRecoveryRecord();
+    }
+
+    /**
+     * Drops any persisted recovery record. Host apps call this when the
+     * user explicitly declines to rejoin, so subsequent launches do not
+     * keep prompting for the same dead session.
+     */
+    static discardRecoverableSession(): void {
+        clearRecoveryRecord();
     }
 
     /** Join an existing call by URL. Returns a session handle. */

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.5.0';
+export const SERENADA_CORE_VERSION = '0.5.1';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.5.1';
+export const SERENADA_CORE_VERSION = '0.6.0';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.0';
+export const SERENADA_CORE_VERSION = '0.6.1';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export type {
     SerenadaLogLevel,
     SerenadaLogger,
 } from './types.js';
+export type { RecoveryRecord } from './recoveryStorage.js';
 export type {
     ProviderCapabilities,
     ConnectionInfo,

--- a/client/packages/core/src/recoveryStorage.ts
+++ b/client/packages/core/src/recoveryStorage.ts
@@ -1,0 +1,96 @@
+/**
+ * Persistent recovery state — surfaced to host apps so a relaunched tab can
+ * prompt the user to rejoin an in-flight call instead of silently dropping
+ * them on the home screen.
+ *
+ * Per the Phase 2 spec (`docs/resilience-failure-modes.md`, #5), the web
+ * scope is `sessionStorage`: per-tab, survives reload, lost on tab close —
+ * the right scope for "you reloaded the page mid-call".
+ *
+ * The record carries the same `reconnectToken` that `SignalingEngine`
+ * persists for in-tab reconnects. The two stores are kept in lockstep:
+ * a fresh `joined` writes both, a clean leave / `room_ended` /
+ * `INVALID_RECONNECT_TOKEN` clears both.
+ */
+
+export interface RecoveryRecord {
+    roomId: string;
+    cid: string;
+    reconnectToken: string;
+    /** Server room state epoch at the moment the record was last refreshed. */
+    lastEpoch: number | null;
+    /** Unix-ms timestamp of the original join (NOT the latest reconnect). */
+    sessionStartTs: number;
+    /**
+     * Unix-ms after which the host app should NOT offer the rejoin prompt.
+     * Computed as `now + reconnectTokenTTLMs` at write time so the SDK does
+     * not need to know server clocks.
+     */
+    expiresAtMs: number;
+}
+
+const STORAGE_KEY = 'serenada.recovery';
+
+function getStorage(): Storage | null {
+    try {
+        return typeof window !== 'undefined' ? window.sessionStorage : null;
+    } catch {
+        return null;
+    }
+}
+
+export function loadRecoveryRecord(): RecoveryRecord | null {
+    const store = getStorage();
+    if (!store) return null;
+    try {
+        const raw = store.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            typeof parsed.roomId !== 'string' ||
+            typeof parsed.cid !== 'string' ||
+            typeof parsed.reconnectToken !== 'string' ||
+            typeof parsed.sessionStartTs !== 'number' ||
+            typeof parsed.expiresAtMs !== 'number'
+        ) {
+            store.removeItem(STORAGE_KEY);
+            return null;
+        }
+        if (Date.now() > parsed.expiresAtMs) {
+            store.removeItem(STORAGE_KEY);
+            return null;
+        }
+        return {
+            roomId: parsed.roomId,
+            cid: parsed.cid,
+            reconnectToken: parsed.reconnectToken,
+            lastEpoch: typeof parsed.lastEpoch === 'number' ? parsed.lastEpoch : null,
+            sessionStartTs: parsed.sessionStartTs,
+            expiresAtMs: parsed.expiresAtMs,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function saveRecoveryRecord(record: RecoveryRecord): void {
+    const store = getStorage();
+    if (!store) return;
+    try {
+        store.setItem(STORAGE_KEY, JSON.stringify(record));
+    } catch {
+        // Quota / private mode — best-effort persistence.
+    }
+}
+
+export function clearRecoveryRecord(): void {
+    const store = getStorage();
+    if (!store) return;
+    try {
+        store.removeItem(STORAGE_KEY);
+    } catch {
+        // Ignore.
+    }
+}

--- a/client/packages/core/src/recoveryStorage.ts
+++ b/client/packages/core/src/recoveryStorage.ts
@@ -71,6 +71,11 @@ export function loadRecoveryRecord(): RecoveryRecord | null {
             expiresAtMs: parsed.expiresAtMs,
         };
     } catch {
+        try {
+            store.removeItem(STORAGE_KEY);
+        } catch {
+            // Ignore cleanup failures and preserve best-effort behavior.
+        }
         return null;
     }
 }

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -13,6 +13,7 @@ import {
     parseNegotiationDirtyPayload,
 } from './payloads.js';
 import { formatError } from '../formatError.js';
+import { saveRecoveryRecord, clearRecoveryRecord } from '../recoveryStorage.js';
 import {
     RECONNECT_BACKOFF_BASE_MS,
     RECONNECT_BACKOFF_CAP_MS,
@@ -55,6 +56,12 @@ export class SignalingEngine {
     lastEpoch: number | null = null;
     /** Epoch at the moment the transport was last observed disconnected. */
     epochAtDisconnect: number | null = null;
+    /**
+     * Unix-ms timestamp of the first successful `joined` for the current
+     * session. Stable across reconnects so the persisted recovery record
+     * carries the original join time, not the latest reattach time.
+     */
+    private sessionStartTs: number | null = null;
     /**
      * True from disconnect until we've seen a fresh authoritative snapshot
      * for the current room on the new transport. Consumers should suppress
@@ -307,6 +314,10 @@ export class SignalingEngine {
                     this.persistReconnectStorage();
                 }
                 this.persistClientId();
+                if (this.sessionStartTs === null) {
+                    this.sessionStartTs = Date.now();
+                }
+                this.persistRecoveryRecord(joined.reconnectTokenTTLMs);
                 this.logger?.log(
                     'debug',
                     'Signaling',
@@ -709,5 +720,28 @@ export class SignalingEngine {
         }
         this.reconnectToken = null;
         this.reconnectTokenRoomId = null;
+        this.sessionStartTs = null;
+        clearRecoveryRecord();
+    }
+
+    // Snapshots the in-memory reconnect state into the cross-launch
+    // recovery store so a relaunched tab can offer a "Rejoin call?" prompt.
+    // No-op when we don't have full credentials yet (e.g. first transport
+    // open before the server has answered with `joined`).
+    private persistRecoveryRecord(reconnectTokenTTLMs: number | undefined): void {
+        if (!this.currentRoomId || !this.clientId || !this.reconnectToken || !this.sessionStartTs) {
+            return;
+        }
+        const ttl = reconnectTokenTTLMs && reconnectTokenTTLMs > 0
+            ? reconnectTokenTTLMs
+            : 10 * 60 * 1000;
+        saveRecoveryRecord({
+            roomId: this.currentRoomId,
+            cid: this.clientId,
+            reconnectToken: this.reconnectToken,
+            lastEpoch: this.lastEpoch,
+            sessionStartTs: this.sessionStartTs,
+            expiresAtMs: Date.now() + ttl,
+        });
     }
 }

--- a/client/packages/core/test/recoveryStorage.test.ts
+++ b/client/packages/core/test/recoveryStorage.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+// Provide a minimal window + sessionStorage shim for the Node test env,
+// matching the pattern used by SignalingEngine.test.ts.
+const store: Record<string, string> = {};
+if (typeof globalThis.window === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).window = globalThis;
+}
+if (typeof (globalThis as { sessionStorage?: unknown }).sessionStorage === 'undefined') {
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        value: {
+            getItem: (k: string) => store[k] ?? null,
+            setItem: (k: string, v: string) => { store[k] = v; },
+            removeItem: (k: string) => { delete store[k]; },
+            clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+        },
+        configurable: true,
+    });
+}
+
+import {
+    loadRecoveryRecord,
+    saveRecoveryRecord,
+    clearRecoveryRecord,
+} from '../src/recoveryStorage';
+
+const STORAGE_KEY = 'serenada.recovery';
+
+function freshRecord(overrides: Partial<Parameters<typeof saveRecoveryRecord>[0]> = {}) {
+    return {
+        roomId: 'room-1',
+        cid: 'C-abc',
+        reconnectToken: 'tok',
+        lastEpoch: 7,
+        sessionStartTs: Date.now() - 10_000,
+        expiresAtMs: Date.now() + 60_000,
+        ...overrides,
+    };
+}
+
+describe('recoveryStorage', () => {
+    beforeEach(() => {
+        for (const k of Object.keys(store)) delete store[k];
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns null when nothing stored', () => {
+        expect(loadRecoveryRecord()).toBeNull();
+    });
+
+    it('round-trips a valid record', () => {
+        const rec = freshRecord();
+        saveRecoveryRecord(rec);
+        expect(loadRecoveryRecord()).toEqual(rec);
+    });
+
+    it('drops malformed JSON entries on read', () => {
+        window.sessionStorage.setItem(STORAGE_KEY, '{not valid');
+        expect(loadRecoveryRecord()).toBeNull();
+    });
+
+    it('drops records that are missing required fields', () => {
+        window.sessionStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ roomId: 'r', cid: 'c' })
+        );
+        expect(loadRecoveryRecord()).toBeNull();
+        // Read should also have removed the bad record.
+        expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('drops expired records and clears the slot', () => {
+        const rec = freshRecord({ expiresAtMs: Date.now() - 1 });
+        saveRecoveryRecord(rec);
+        expect(loadRecoveryRecord()).toBeNull();
+        expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('clearRecoveryRecord removes any stored value', () => {
+        saveRecoveryRecord(freshRecord());
+        clearRecoveryRecord();
+        expect(loadRecoveryRecord()).toBeNull();
+    });
+
+    it('lastEpoch may be null', () => {
+        const rec = freshRecord({ lastEpoch: null });
+        saveRecoveryRecord(rec);
+        expect(loadRecoveryRecord()?.lastEpoch).toBeNull();
+    });
+});

--- a/client/packages/core/test/recoveryStorage.test.ts
+++ b/client/packages/core/test/recoveryStorage.test.ts
@@ -61,6 +61,7 @@ describe('recoveryStorage', () => {
     it('drops malformed JSON entries on read', () => {
         window.sessionStorage.setItem(STORAGE_KEY, '{not valid');
         expect(loadRecoveryRecord()).toBeNull();
+        expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
     it('drops records that are missing required fields', () => {

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.5.1",
+    "@serenada/core": "^0.6.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.5.1"
+    "@serenada/core": "0.6.0"
   },
   "repository": {
     "type": "git",

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.5.0",
+    "@serenada/core": "^0.5.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.5.0"
+    "@serenada/core": "0.5.1"
   },
   "repository": {
     "type": "git",

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.0",
+    "@serenada/core": "^0.6.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.6.0"
+    "@serenada/core": "0.6.1"
   },
   "repository": {
     "type": "git",

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -249,6 +249,11 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     const [permissionDenied, setPermissionDenied] = useState(false);
     const [copied, setCopied] = useState(false);
     const [isLocalLarge, setIsLocalLarge] = useState(false);
+    // When the local camera is off there's nothing meaningful to enlarge — force
+    // remote-as-primary so the user doesn't see a giant "Camera off" placeholder.
+    // The user's swap preference (`isLocalLarge`) is preserved and reapplied
+    // automatically when video comes back on.
+    const effectiveLocalLarge = isLocalLarge && !isCameraOff;
     const [areControlsVisible, setAreControlsVisible] = useState(true);
     const [showRecoveringBadge, setShowRecoveringBadge] = useState(false);
     const [showWaiting, setShowWaiting] = useState(true);
@@ -1035,10 +1040,10 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
         <div data-serenada-callflow="" className={rootClassName} style={rootStyle} onPointerUp={handleScreenTap}>
             {callProbe}
             {overlayContent}
-            <div className={`call-container ${isLocalLarge ? 'local-large' : ''}`}>
+            <div className={`call-container ${effectiveLocalLarge ? 'local-large' : ''}`}>
                 <div
-                    className={`video-remote-container ${isLocalLarge ? 'pip' : 'primary'}`}
-                    onPointerUp={isLocalLarge ? (event) => {
+                    className={`video-remote-container ${effectiveLocalLarge ? 'pip' : 'primary'}`}
+                    onPointerUp={effectiveLocalLarge ? (event) => {
                         event.stopPropagation();
                         handleControlsInteraction();
                         setIsLocalLarge(false);
@@ -1087,8 +1092,8 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                 </div>
 
                 <div
-                    className={`video-local-container ${isLocalLarge ? 'primary' : 'pip'}`}
-                    onPointerUp={!isLocalLarge ? (event) => {
+                    className={`video-local-container ${effectiveLocalLarge ? 'primary' : 'pip'}`}
+                    onPointerUp={!effectiveLocalLarge ? (event) => {
                         event.stopPropagation();
                         handleControlsInteraction();
                         setIsLocalLarge(true);

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -1077,7 +1077,11 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                         </button>
                     )}
 
-                    <ParticipantBadge muted={remoteParticipant0?.audioEnabled === false} displayName={remoteParticipant0?.displayName} />
+                    <ParticipantBadge
+                        muted={remoteParticipant0?.audioEnabled === false}
+                        // Avoid duplicating the name when the remote video-off placeholder already shows it.
+                        displayName={remoteParticipant0?.videoEnabled === false ? undefined : remoteParticipant0?.displayName}
+                    />
 
                     {waitingOverlay}
                 </div>

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -66,9 +66,9 @@ self.addEventListener('activate', (event) => {
     event.waitUntil(clients.claim());
 });
 
-self.addEventListener('fetch', (event) => {
-    // Basic pass-through fetch handler
-    event.respondWith(fetch(event.request));
+self.addEventListener('fetch', () => {
+    // No-op — let the browser handle requests normally.
+    // Listener is kept to satisfy PWA installability heuristics.
 });
 
 self.addEventListener('push', (event) => {

--- a/docs/android-sdk-improvements-plan-v2.md
+++ b/docs/android-sdk-improvements-plan-v2.md
@@ -1,0 +1,902 @@
+# Serenada Android SDK — Code-Level Implementation Plan
+
+## Overview
+
+Executable, code-level plan for landing the SDK improvements in [`serenada-sdk-proposal.md`](../zello-android-client/docs/plans/serenada-sdk-proposal.md). Designed for hand-off to a team of coding agents.
+
+**Iteration 10 — final convergence.** Targeted fixes on top of iteration 9. Plan shape unchanged.
+
+- **Reuse the existing `JoinReconnectOutcome` enum** ([SignalingProvider.kt:50](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)) for `CallEvent.Recovered`, instead of declaring a new `ReconnectOutcome`. The existing enum already has the same `FRESH | REATTACHED | RECOVERED` shape; introducing a parallel type is needless drift. API-Lock therefore *does not* introduce a new outcome enum — it simply references `JoinReconnectOutcome`.
+- **Recovery API surface additions move to API-Lock.** The defaulted constructor parameters on `JoinedEvent` (`reconnectToken: String? = null`, `reconnectTokenTTLMs: Long? = null`) and `JoinOptions` (`reconnectToken: String? = null`) are part of the locked public surface, so they land in API-Lock. L0 keeps the *parser* and *plumbing* edits (`SerenadaServerProvider.processJoinedPayload`, `SignalingMessageRouter.processJoinedEvent`, TTL persistence). This restores "all public API additions land in API-Lock" without splitting hairs.
+- **`ConnectionDegraded` and `ThermalThrottle` get explicit producer tests.** L1-Integrate adds `ConnectionDegradedEventTest`; L2-Integrate's `ThermalIntegrationTest` asserts a `CallEvent.ThermalThrottle` is emitted on each transition.
+- **`StatsPoller` construction example uses the injected `mainDispatcher`** for `snapshotSlots`, so dispatcher-boundary tests exercise the same dispatcher the production code uses.
+
+**Iteration 9 carryover.** Two follow-ups on top of iteration 8.
+
+- **Drop unproduced `CallEvent` cases.** `CodecSwitched` and `BitrateAdapted` were declared in API-Lock but no later track produces or tests them. Per "empty knobs are API noise" (A8), removed from the locked sealed interface for 0.6.0; re-introduce in the release that adds a producer.
+- **L1-Integrate checklist expanded** to enumerate dispatcher wiring, failure isolation, null-merge skip, thermal collector lifecycle, and main-thread publish boundaries.
+
+**Iteration 8 carryover.** Five blocker fixes on top of iteration 7. The plan shape is unchanged.
+
+- **`StatsPoller` threading model is now explicit.** Slot-list snapshot runs on the **session/main thread** (the only safe reader of `peerSlots`); the off-main worker pulls each tick's snapshot via `snapshotSlots: suspend () -> List<PeerConnectionSlotProtocol>` which internally hops to the **injected `mainDispatcher`** (`Dispatchers.Main.immediate` in production, the test dispatcher in tests) and copies the map. Stats *collection* and `mergeRealtimeStats` stay on the worker dispatcher (`Dispatchers.Default`). The three `publish*` callbacks hop back to the same injected `mainDispatcher` before touching `MutableStateFlow.value`. Resolves review block #1.
+- **`StatsPoller` per-slot collection is now isolation-failure tolerant.** Each `slot.collectAwait()` is wrapped in `runCatching` so one stuck or throwing slot cannot kill the loop, and `mergeRealtimeStats(...)` returning `null` (no samples) skips the slow tick instead of NPE'ing into `publishRealtime`/`QualityScorer.score`. Resolves review block #2.
+- **`JoinedEvent` is now listed as a binary-breaking change** alongside `RecoveryRecord`, `JoinOptions`, and `SerenadaConfig`. The two new constructor parameters are defaulted (`null`), so source compat holds; the binary signature does not. Resolves review block #3.
+- **Reduced-motion testing uses an explicit component parameter**, not the non-existent `LocalAccessibilityManager.isReduceMotionEnabled`. L3 components accept `reduceMotion: Boolean = LocalReduceMotion.current` (a `ProvidableCompositionLocal<Boolean>` defined in `serenada-call-ui` defaulting to `false`). Production reads `Settings.Global.TRANSITION_ANIMATION_SCALE == 0f` once at the host and provides the value; tests pass `reduceMotion = true` directly to the component. Resolves review block #4.
+- **`ThermalSensor` uses a `ThermalStatusSource` seam**, not a "fake PowerManager". The interface is API-level-aware; production binds it to `PowerManager.OnThermalStatusChangedListener` (API ≥ 29) or to a constant `NONE` source (API < 29). Tests provide a `FakeThermalStatusSource` directly. Resolves review block #5.
+
+**Iteration 7 carryover.** Final pass converges six P0/P1 handoff inconsistencies the prior iteration missed. What moved is **ownership** (so each track compiles in isolation), **lifecycle detail** (so agents don't have to invent it), and a small number of **factual corrections** against the actual WebRTC AAR.
+
+- **API-Lock now owns the additive `RecoveryRecord` fields** (`roomUrl: String = ""`, `displayName: String? = null`) **and the public config model types** (`VideoQualityConfig`, `AudioQualityConfig`, `AudioProcessingConfig`, `BluetoothPolicy`, `ThermalConfig`). L0/L2 keep the *behavior* edits but no longer carry the constructor/field declarations the earlier base-commit code already references. Resolves review P0-1, P0-3.
+- **`JoinedEvent` is widened in L0 to carry `reconnectToken: String?` and `reconnectTokenTTLMs: Long?`** ([SignalingProvider.kt:52](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)). `SerenadaServerProvider.processJoinedPayload` already parses both — L0 just forwards them. `SignalingMessageRouter.processJoinedEvent` ([SignalingMessageRouter.kt:99](client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt)) plumbs both through `onJoined`. Resolves review P0-2.
+- **`QualityScorer` is a pure reducer over an explicit `QualityScoreState`** — `score(state, sample) -> (state', CallQuality)`. EWMA and hysteresis live in the state record. The stateful holder is `StatsPoller`. Resolves review P1-4.
+- **`StatsPoller` lifecycle is specified**: owning `CoroutineScope`, `Dispatchers.Default` worker, `start()`/`stop()`, per-slot 1 s timeout via `withTimeoutOrNull`, guarded continuation resume. Cadence text corrected: **2 s = 10 fast publishes + 1 slow publish** (every 10th 200 ms tick). Resolves review P1-5.
+- **`PeerAudioLevels` and `AudioLevelSmoother` are owned by L1-2a**, not L1-Integrate, so the policy file compiles standalone. Resolves review P1-6.
+- **L0+ ownership widened**: damp body lives in `WebRtcEngine.dampLocalAudio()` near `toggleAudio` ([WebRtcEngine.kt:281](client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt)); `SessionMediaEngine` interface gets the method; `FakeMediaEngine` ([FakeMediaEngine.kt](client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt)) records calls for tests. Resolves review P1-7.
+- **L2-Integrate also owns `SessionAudioController.kt`** to widen the route surface ([SessionAudioController.kt](client-android/serenada-core/src/main/java/app/serenada/core/call/SessionAudioController.kt)). Resolves review P1-8.
+- **VP9 `scalabilityMode` is dropped** from `SimulcastTransceiverBuilder`. The current `libwebrtc-7559_173` AAR's `RtpParameters.Encoding` doesn't expose that field; we ship 3-layer simulcast on the existing encoding params and leave SVC for a later AAR bump. Resolves review P1-9.
+- **Test deps add `kotlinx-coroutines-test`** in API-Lock (`testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")`). Resolves review P2-10.
+- **`AudioQualityAutoPolicy` is named explicitly** as the holder of FEC AUTO thresholds + dwell, alongside `SdpAudioPolicy`. Resolves review P2-11.
+- **`assertNoEngineRefs` is wired into `:serenada-call-ui:check`** so V1 actually runs the guard. Resolves review P2-12.
+
+Carryover from earlier iterations stays as decided: P1-2 (`AudioRouteDevice` exposed), P1-3 (`dampLocalAudio` seam), P1-5 (`onIceRestarted` callback), P1-6 (`Recovered` only on server-confirmed outcome), P2-7 (no-op stubs), P2-8 (`cd client-android &&` prefix), P2-9 (semantic-state tests), and the iteration-6 stats seam (`WebRtcStatsSnapshot`).
+
+**Scope.** Android-only. Items 11–14 land in `serenada-call-ui`; items 1–10 in `serenada-core`. Items 15–19 (Zello-side glue) are out of scope.
+
+**Repository anchors.** Paths are relative to `/Users/alexeygavrilov/Developer/src/connected/`.
+
+## Goals
+
+1. Ship every Core SDK item (1–10) and every Call-UI SDK item (11–14) per the proposal.
+2. Each track lands with deterministic automated tests. Real BT radio (L2-5) and on-device thermal sensors (L1-3) are documented manual escapes; their selector logic is fully unit-tested.
+3. Preserve **source** compatibility for existing consumers. ABI changes are acknowledged and signalled by a 0.5.x → 0.6.0 minor bump.
+4. L0 + L1-Integrate are the unlock layer for L2 / L3.
+
+## Non-Goals
+
+- Pre-call UI, envelope push-wake, PTT arbitration, account/contact glue (proposal items 15–18).
+- iOS/Web parity for the new types.
+- Multi-party (>2 participants).
+- Wire-protocol changes. Server already emits `reconnectToken`/`reconnectTokenTTLMs` and per-candidate `ice` messages.
+
+## Requirements
+
+### Functional
+
+- **R1.** All public API additions are non-breaking at the **source** level: every new constructor parameter has a default value, every new method is additive, no existing methods change signature. Binary compatibility is **not** promised — see N4.
+- **R2.** Every new config knob defaults to **today's behavior**. Default-flip PRs are separate, one-line, post-Zello-rollout.
+- **R3.** New event/state surfaces are cold-safe; replay buffers are bounded.
+- **R4.** Recovery survives process death. `RecoveryRecord` v2 carries `roomUrl: String = ""` (defaulted for source compat; runtime-validated) and `displayName: String? = null`; `reconnectTokenTTLMs` is plumbed end-to-end.
+- **R5.** Quality score is deterministic given a fixed `RealtimeCallStats` sequence.
+
+### Non-Functional
+
+- **N1.** **No new runtime dependencies.** Recovery JSON keeps using `org.json.JSONObject`; no `kotlinx-serialization`.
+- **N2.** No reflection in production code or tests. SDP rewriting is a tested helper with golden inputs/outputs.
+- **N3.** Hot flows on `SerenadaSession` follow the existing pattern (`MutableStateFlow.asStateFlow()` / `MutableSharedFlow.asSharedFlow()`); they are bound to the session lifetime.
+- **N4.** **ABI is allowed to break** in this release because the SDK is pre-1.0 (0.5.x → 0.6.0). Four public data classes change primary-constructor shape: `RecoveryRecord`, `JoinOptions`, `SerenadaConfig`, and `JoinedEvent` (the last is part of the public `SignalingProvider` surface — gains `reconnectToken` and `reconnectTokenTTLMs`, both `null`-defaulted). **Every new parameter has a default value**, so source-form callers continue compiling. The 0.6.0 release notes call this out for any external SDK consumer. `CallDiagnostics` is **not** modified — design grounds, not ABI grounds.
+
+### Verification (run on every track)
+
+- **V1.** `cd client-android && ./gradlew :serenada-core:test :serenada-call-ui:test`
+- **V2.** `cd client-android && ./gradlew :serenada-core:lint :serenada-call-ui:lint` — no new warnings beyond baseline.
+- **V3.** `node scripts/check-resilience-constants.mjs && node scripts/check-version-parity.mjs`
+- **V4.** `tools/worktree-validate.sh` (`SKIP_IOS=1` acceptable on Linux CI).
+
+## API Model
+
+API additions land as the first commit on the feature branch (T API-Lock). It is a base commit, not a standalone PR. The consolidated PR ships at T Finalize.
+
+```kotlin
+// SerenadaSession — new top-level surfaces, side-by-side with existing state/diagnostics.
+val events: SharedFlow<CallEvent>                                   // hot, replay=0, buffer=32, DROP_OLDEST
+val qualityScore: StateFlow<CallQuality>                            // populated by L1-Integrate
+val localAudioLevel: StateFlow<Float>                               // 0.0..1.0, populated by L1-Integrate
+val remoteAudioLevels: StateFlow<Map<String, Float>>                // peerCid -> level
+val thermalState: StateFlow<ThermalState>                           // populated by L1-Integrate
+val audioRoute: StateFlow<AudioRouteDevice?>                        // currently active route (null if unknown)
+val availableAudioRoutes: StateFlow<List<AudioRouteDevice>>         // resolves review P1-2
+
+fun setPreferredAudioRoute(routeId: Int)                            // selects by stable AudioRouteDevice.id
+fun setPreferredAudioRoute(route: AudioRoute)                       // convenience for "any device of this type"
+
+// SerenadaCore — recovery API. Synchronous; uses existing `var delegate`.
+fun SerenadaCore.getRecoverableSession(): RecoveryRecord?
+fun SerenadaCore.resume(record: RecoveryRecord, displayName: String? = null): SerenadaSession
+
+// SessionRecoveryToken — cross-process envelope. org.json-backed.
+class SessionRecoveryToken {
+    fun encode(): String
+    fun toRecord(): RecoveryRecord                                  // returns the v2 RecoveryRecord
+    companion object {
+        fun decode(s: String): SessionRecoveryToken?                // null on unknown version
+        fun fromRecord(r: RecoveryRecord): SessionRecoveryToken
+    }
+}
+
+// AudioRouteDevice — exposed publicly for the picker (resolves review P1-2).
+data class AudioRouteDevice(
+    val id: Int,                  // stable id from AudioDeviceInfo.getId()
+    val type: AudioRoute,         // SPEAKER, EARPIECE, BLUETOOTH_SCO, BLUETOOTH_LE, WIRED_HEADSET, ...
+    val label: String,            // human-readable name from AudioDeviceInfo.productName
+)
+```
+
+The two `setPreferredAudioRoute` overloads cover both "user picked a specific device from the list" (id-based) and "switch to speaker / earpiece" (type-based). Picking by id is exact; picking by type chooses the highest-priority device of that type, falling back to current route if none.
+
+### Why telemetry stays off `CallDiagnostics`
+
+Even with ABI relaxed (N4), telemetry as separate flows is the better **design**: each flow has its own change-detection granularity, callers compose with `combine`/`distinctUntilChanged` per-field, and we avoid emitting a fat snapshot every time any one value changes. `CallDiagnostics` and `SerenadaDiagnostics.kt` (the pre-flight utility) are both untouched.
+
+## Execution DAG
+
+```
+T API-Lock (base commit; includes WebRTC test-harness probe)
+  │
+  ├─► L0 Recovery schema + resume()
+  │     └─► L0+ Reconnect audio damp
+  │
+  ├─► L1 (independent policies in parallel)
+  │     ├─ L1-1a QualityScorer.kt
+  │     ├─ L1-2a AudioLevelSampler.kt
+  │     ├─ L1-3a ThermalSensor.kt
+  │     └─► L1-Integrate (single agent: wires all three into StatsPoller + SerenadaSession + PeerNegotiationEngine)
+  │
+  ├─► L2 (independent policies in parallel)
+  │     ├─ L2-1a SimulcastTransceiverBuilder
+  │     ├─ L2-2a SdpAudioPolicy + AudioQualityAutoPolicy
+  │     ├─ L2-3a SdpRedPolicy (RED)
+  │     ├─ L2-4a AudioDeviceModuleBuilder (seam)
+  │     ├─ L2-5a CallAudioRoutePolicy
+  │     ├─ L2-6  Trickle ICE verification (tests only)
+  │     ├─ L2-7a ThermalGovernorPolicy (pure)
+  │     └─► L2-Integrate (single agent)
+  │
+  └─► L3 (parallel, after L1-Integrate + L2-Integrate)
+        ├─ L3-1 QualityChip
+        ├─ L3-2 ReconnectingChip
+        ├─ L3-3 AudioDevicePicker
+        └─ L3-4 AudioLevelDot
+
+T Finalize: docs, version bump, parity, single PR.
+```
+
+The "policy `*a` + integrator" pattern: each L1/L2 track first lands a self-contained policy class in its own file. A single follow-up integrator agent owns the only edits to the shared big files (`StatsPoller.kt`, `SerenadaSession.kt`, `WebRtcEngine.kt`, `CallAudioSessionController.kt`, `SerenadaConfig.kt`, plus `PeerConnectionSlotProtocol.kt`/`PeerConnectionSlot.kt`/`FakePeerConnectionSlot.kt` and `PeerNegotiationEngine.kt` for L1-Integrate, and `SessionAudioController.kt` for L2-Integrate).
+
+### File ownership table
+
+| Track | Writes |
+|---|---|
+| API-Lock | `CallEvent.kt` *new* (uses existing `JoinReconnectOutcome`), `SessionRecoveryToken.kt` *new*, `AudioRoute.kt` + `AudioRouteDevice.kt` *new*, `RecoveryStorage.kt` (additive `roomUrl` + `displayName` fields with defaults — schema/migration body still in L0), `VideoQualityConfig.kt` *new* (data class only), `AudioQualityConfig.kt` *new* (data class only), `AudioProcessingConfig.kt` *new* (data class only), `BluetoothPolicy.kt` *new* (data class only), `ThermalConfig.kt` *new* (data class only), `SerenadaConfig.kt` (sub-field defaults plumbed; bodies don't read them yet), `SignalingProvider.kt` (`JoinedEvent` gains `reconnectToken: String? = null` + `reconnectTokenTTLMs: Long? = null`; `JoinOptions.reconnectToken: String? = null` — both signature-only, parser bodies still in L0), `SerenadaSession.kt` (new flows + `setPreferredAudioRoute` no-op stubs), `SerenadaCore.kt` (`resume` no-op stub), `SessionMediaEngine.kt` (`dampLocalAudio` no-op stub), `serenada-call-ui/build.gradle.kts` (Compose test deps + `assertNoEngineRefs` wired into `check`), `serenada-core/build.gradle.kts` (`kotlinx-coroutines-test` test dep), `WebRtcHarnessProbeTest.kt` *new* |
+| L0 | `RecoveryStorage.kt` (v2 schema + migration body), `SerenadaServerProvider.processJoinedPayload` forwards `reconnectToken` + `reconnectTokenTTLMs` (signatures landed in API-Lock), `SignalingMessageRouter.processJoinedEvent` ([SignalingMessageRouter.kt:99](client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt)) plumbs them through `onJoined`, `SerenadaServerProvider.kt` (`JoinOptions.reconnectToken` seeded on first connect), `SerenadaCore.kt` (`resume` body), `SerenadaSession.kt` (TTL persistence, internal join-with-token path, `Recovered` emission on server-confirmed outcome) |
+| L0+ | `SerenadaSession.kt` (state observer), `SessionMediaEngine.kt` (`dampLocalAudio` body on the interface — delegates to engine), `WebRtcEngine.kt` (concrete `dampLocalAudio` near `toggleAudio` at [WebRtcEngine.kt:281](client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt)), `FakeMediaEngine.kt` (records `dampLocalAudio` calls for tests at [FakeMediaEngine.kt](client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt)) |
+| L1-1a | `QualityScorer.kt` *new* (pure reducer + `QualityScoreState` data class) |
+| L1-2a | `AudioLevelSampler.kt` *new* (pure extractor over raw `RTCStatsReport`), `PeerAudioLevels.kt` *new* (data class), `AudioLevelSmoother.kt` *new* (per-slot smoother) |
+| L1-3a | `ThermalSensor.kt` *new* |
+| L1-Integrate | `StatsPoller.kt`, `SerenadaSession.kt`, `PeerConnectionSlotProtocol.kt` (callback shape → `WebRtcStatsSnapshot`), `PeerConnectionSlot.kt` (call `AudioLevelSampler` in-place; emit snapshot), `FakePeerConnectionSlot.kt` (test double matches new shape), `PeerNegotiationEngine.kt` (add ICE-restart callback — resolves review P1-5) |
+| L2-1a | `SimulcastTransceiverBuilder.kt` *new* (consumes API-Lock `VideoQualityConfig`; no `scalabilityMode` — see review P1-9) |
+| L2-2a | `SdpAudioPolicy.kt` *new*, `AudioQualityAutoPolicy.kt` *new* (FEC AUTO thresholds + 30 s dwell — resolves review P2-11) |
+| L2-3a | `SdpRedPolicy.kt` *new* |
+| L2-4a | `AudioDeviceModuleBuilder.kt` *new* (seam over `JavaAudioDeviceModule.builder()`) |
+| L2-5a | `CallAudioRoutePolicy.kt` *new* (consumes the public `AudioRouteDevice` from API-Lock) |
+| L2-6 | `TrickleIceVerificationTest.kt` only |
+| L2-7a | `ThermalGovernorPolicy.kt` *new* (consumes API-Lock `VideoQualityConfig` + `ThermalConfig`) |
+| L2-Integrate | `WebRtcEngine.kt`, `CallAudioSessionController.kt`, `SessionAudioController.kt` (widen interface with route flows — resolves review P1-8), `SerenadaConfig.kt` (sub-field bodies are now read), `SerenadaSession.kt` (`setPreferredAudioRoute` bodies, `availableAudioRoutes`/`audioRoute` emitter wiring) |
+| L3-1..4 | one Compose file each under `serenada-call-ui/.../components/` |
+
+## StatsPoller concurrency design
+
+`PeerConnectionSlot` is the only owner of the raw `RTCStatsReport` — it parses the report into a `RealtimeCallStats` summary and currently discards the rest. The cleanest seam is to widen what the slot returns: parse audio levels in the same pass and hand the scheduler a single snapshot. The scheduler stays slot-agnostic.
+
+```kotlin
+// PeerConnectionSlotProtocol.kt — widened callback shape (L1-Integrate change)
+internal data class WebRtcStatsSnapshot(
+    val summary: String,                                  // existing diagnostic string
+    val realtime: RealtimeCallStats?,                     // existing parsed summary
+    val audioLevels: PeerAudioLevels,                     // NEW — parsed in-slot from the same report
+)
+
+internal data class PeerAudioLevels(
+    val remoteByTrackId: Map<String, Float>,              // smoothed inbound levels per remote audio track
+    val localOutbound: Float,                             // smoothed outbound level for this peer's local sender
+)
+
+interface PeerConnectionSlotProtocol {
+    /* …existing surface… */
+    fun collectWebRtcStats(onComplete: (WebRtcStatsSnapshot) -> Unit)   // signature change
+}
+```
+
+`AudioLevelSampler` is a pure helper called inside `PeerConnectionSlot.onStatsDelivered` against the raw `RTCStatsReport`; smoothing state is held per-slot. `StatsPoller` then sees only snapshots and owns its own lifecycle:
+
+```kotlin
+internal class StatsPoller(
+    // Snapshot must be taken on the session/main thread because peerSlots is
+    // session-owned and not thread-safe. The lambda hops to Main.immediate
+    // internally and returns a defensive copy; the worker stays off-main.
+    private val snapshotSlots: suspend () -> List<PeerConnectionSlotProtocol>,
+    private val resolvePeerCid: (PeerConnectionSlotProtocol) -> PeerCid,
+    // Publish callbacks hop to Main.immediate before touching MutableStateFlow.value.
+    private val publishAudio: suspend (Map<PeerCid, Float>, Float /*localOutbound*/) -> Unit,
+    private val publishRealtime: suspend (RealtimeCallStats) -> Unit,
+    private val publishQuality: suspend (CallQuality) -> Unit,
+    private val workerDispatcher: CoroutineDispatcher = Dispatchers.Default,   // injectable for tests
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
+    /* …existing deps… */
+) {
+    private var scope: CoroutineScope? = null
+    private val mutex = Mutex()                       // single global in-flight guard
+    private var qualityState = QualityScoreState.initial()
+
+    fun start() {
+        if (scope != null) return
+        scope = CoroutineScope(SupervisorJob() + workerDispatcher).also { it.launch { runLoop() } }
+    }
+
+    fun stop() {
+        scope?.cancel()
+        scope = null
+    }
+
+    private suspend fun PeerConnectionSlotProtocol.collectAwait(): WebRtcStatsSnapshot? =
+        withTimeoutOrNull(SLOT_STATS_TIMEOUT_MS) {     // 1 s per-slot ceiling
+            suspendCancellableCoroutine { cont ->
+                try { collectWebRtcStats { snap -> if (cont.isActive) cont.resume(snap) } }
+                catch (t: Throwable) { if (cont.isActive) cont.resumeWithException(t) }
+            }
+        }
+
+    private suspend fun runLoop() {
+        var slowTickCounter = 0
+        while (coroutineContext.isActive) {
+            delay(FAST_LANE_INTERVAL_MS)               // 200 ms
+            if (!mutex.tryLock()) continue             // skip if previous tick still draining
+            try {
+                val isSlowTick = (++slowTickCounter % SLOW_LANE_RATIO == 0)  // every 10th tick (2 s)
+                val slots = snapshotSlots()             // hops to Main.immediate, copies, returns
+                val snapshots = coroutineScope {
+                    slots.map { slot ->
+                        async {
+                            // runCatching isolates a single failing slot from the rest of the tick.
+                            slot to runCatching { slot.collectAwait() }.getOrNull()
+                        }
+                    }.awaitAll()
+                }.mapNotNull { (s, snap) -> snap?.let { s to it } }
+
+                val audioByPeer = mutableMapOf<PeerCid, Float>()
+                var localOutbound = 0f
+                for ((slot, snap) in snapshots) {
+                    audioByPeer[resolvePeerCid(slot)] = snap.audioLevels.remoteByTrackId.values.maxOrNull() ?: 0f
+                    localOutbound = maxOf(localOutbound, snap.audioLevels.localOutbound)
+                }
+                withContext(mainDispatcher) { publishAudio(audioByPeer, localOutbound) }
+
+                if (isSlowTick) {
+                    val merged = mergeRealtimeStats(snapshots.mapNotNull { it.second.realtime })
+                        ?: continue                     // no samples this tick — skip slow publish
+                    val (next, quality) = QualityScorer.score(qualityState, merged)
+                    qualityState = next
+                    withContext(mainDispatcher) {
+                        publishRealtime(merged)
+                        publishQuality(quality)
+                    }
+                }
+            } finally { mutex.unlock() }
+        }
+    }
+}
+```
+
+Threading model:
+- **Slot-list snapshot** runs on `Dispatchers.Main.immediate` (the only safe reader of `peerSlots`); the lambda copies the map and returns the list to the worker.
+- **Stats collection + merge** run on `Dispatchers.Default` (or `StandardTestDispatcher` in tests).
+- **Publish** hops back to `Main.immediate` before mutating `MutableStateFlow.value`.
+
+Failure isolation: each `slot.collectAwait()` is `runCatching`-wrapped, so one stuck/throwing slot cannot tear down the loop or sibling slots. `mergeRealtimeStats(...)` returning `null` (zero samples) skips the slow publish via `continue`, avoiding the NPE path the prior pseudocode allowed. Per-slot `withTimeoutOrNull(1_000)` keeps a stuck slot from blocking the whole tick. `QualityScorer.score` is a pure reducer over `QualityScoreState`; `StatsPoller` is the stateful holder.
+
+**Cadence.** Fast lane fires every 200 ms (5 Hz). Slow lane rides every 10th fast tick — i.e. **2 s = 10 fast publishes + 1 slow publish**. Tested in `StatsPollerSchedulerTest.kt` (virtual time via `kotlinx-coroutines-test` + a `FakePeerConnectionSlot` returning canned `WebRtcStatsSnapshot`s) and in `PeerConnectionSlotAudioLevelTest.kt` (raw `RTCStatsReport` → `PeerAudioLevels`).
+
+## Rollout policy
+
+SDK ships every new knob with **today's behavior** as default. Zello opts in:
+
+| Knob | SDK default | Zello opts in |
+|---|---|---|
+| `VideoQualityConfig.simulcastEnabled` | `false` | `true` |
+| `AudioQualityConfig.fec` | `OFF` | `AUTO` |
+| `AudioQualityConfig.dtx` | `OFF` | `AUTO` |
+| `AudioQualityConfig.redundancy` (RED) | `false` | stays `false` until cross-platform reciprocal |
+| `AudioProcessingConfig.*` | matches today's hard-coded path | (no change) |
+| `BluetoothPolicy.preferLeAudio` | `false` | `true` |
+| `ThermalConfig.policyEnabled` | `false` | `true` |
+| `events`, telemetry flows | always on (purely additive) | — |
+
+DTX default is `OFF` because today's WebRTC SDP doesn't set `usedtx=1`. AUTO would change media behavior, so `OFF` is the true preserve-current setting. Zello flips to `AUTO` after one production cycle.
+
+---
+
+## Track Details
+
+### T API-Lock
+
+**Scope.**
+
+1. New types: `CallEvent` (sealed interface), `CallQuality`, `ThermalState`, `AudioRoute`, `AudioRouteDevice`, `SessionRecoveryToken`. `MediaKind` and `Direction` are deferred to the release that introduces a producer (see iteration-9 note).
+2. **Public config model types as data classes (no behavior, defaults preserve today's behavior)** — `VideoQualityConfig`, `AudioQualityConfig`, `AudioProcessingConfig`, `BluetoothPolicy`, `ThermalConfig`. `SerenadaConfig` gains the corresponding sub-fields with defaults, but L2 still owns the bodies that *read* them. This keeps API-Lock the single locking commit for public surface.
+3. **`RecoveryRecord` gains `roomUrl: String = ""` and `displayName: String? = null`** with defaults. L0 fills the storage migration body; the constructor change must land in API-Lock so `SessionRecoveryToken.toRecord()` and the `SerenadaCore.resume` stub compile.
+3a. **`JoinedEvent` gains `reconnectToken: String? = null` and `reconnectTokenTTLMs: Long? = null`** ([SignalingProvider.kt:52](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)). Defaults preserve source compat. L0 fills the parser body that populates them; API-Lock owns the constructor signature so all downstream callers compile.
+3b. **`JoinOptions.reconnectToken: String? = null`** is added in API-Lock for the same reason — it is part of the public `SignalingProvider` surface. L0 fills the seed-on-first-connect logic.
+3c. **`CallEvent.Recovered.outcome` reuses `JoinReconnectOutcome`** ([SignalingProvider.kt:50](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)) — no new outcome enum is introduced.
+4. New flows + methods on `SerenadaSession`: `events`, `qualityScore`, `localAudioLevel`, `remoteAudioLevels`, `thermalState`, `audioRoute`, `availableAudioRoutes`, `setPreferredAudioRoute(routeId)`, `setPreferredAudioRoute(route)`.
+   - **Stubs are safe no-ops** (resolves review P2-7): `setPreferredAudioRoute` logs at DEBUG and returns; `events` is a real `MutableSharedFlow` that simply has no producers yet; `qualityScore` defaults to `CallQuality.UNKNOWN`; flows that are list-typed default to `emptyList()`.
+5. `SerenadaCore.resume(record, displayName)` — synchronous stub that calls `assertMainThread()` and **delegates to `join(record.roomUrl, displayName ?: record.displayName)`** as a placeholder. L0 replaces the body with the real reconnect path. Stubs that throw are avoided so the base branch can run end-to-end tests during stacked work.
+6. New seam on `SessionMediaEngine`: `fun dampLocalAudio(durationMs: Long, restoreIfEnabled: () -> Boolean)`. API-Lock body is a no-op; L0+ fills it in (and adds the concrete implementation in `WebRtcEngine`).
+7. **Test deps wired** (resolves review P2-10, P2-12):
+   ```kotlin
+   // serenada-core/build.gradle.kts
+   dependencies {
+       /* …existing… */
+       testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+   }
+
+   // serenada-call-ui/build.gradle.kts
+   dependencies {
+       /* …existing… */
+       testImplementation("androidx.compose.ui:ui-test-junit4:1.6.8")
+       debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.8")
+       testImplementation("org.robolectric:robolectric:4.12.2")
+       testImplementation("junit:junit:4.13.2")
+   }
+   android.testOptions.unitTests.isIncludeAndroidResources = true
+   tasks.named("check") { dependsOn("assertNoEngineRefs") }   // wire CI guard into V1
+   ```
+8. **WebRTC test-harness probe.** `WebRtcHarnessProbeTest.kt` runs Robolectric, calls `PeerConnectionFactory.initialize` + creates a no-op `PeerConnection`. The probe's outcome is recorded in `client-android/serenada-core/TESTING.md`. L2 agents do not branch on viability.
+
+**Tests.**
+
+- `ApiSurfaceCompileTest.kt` — plain compile-time usage, no reflection:
+  ```kotlin
+  @Suppress("UNUSED_VARIABLE", "unused")
+  class ApiSurfaceCompileTest {
+      fun usesEvents(s: SerenadaSession) { val f: SharedFlow<CallEvent> = s.events }
+      fun usesQuality(s: SerenadaSession) { val f: StateFlow<CallQuality> = s.qualityScore }
+      fun usesRoutes(s: SerenadaSession) {
+          val f: StateFlow<List<AudioRouteDevice>> = s.availableAudioRoutes
+          s.setPreferredAudioRoute(0); s.setPreferredAudioRoute(AudioRoute.SPEAKER)
+      }
+      // …one fun per new public surface
+  }
+  ```
+- `EventsBufferOverflowTest.kt` — uses an **active slow subscriber**. Subscriber consumes one event then `delay(10_000)`s; producer emits 100 events; on resume, subscriber sees the most-recent 32 (DROP_OLDEST semantics). With `replay = 0`, the test never asserts that a late subscriber sees prior events.
+- One trivial Compose test under `:serenada-call-ui:test` to confirm test deps resolve.
+
+**`CallEvent` shape (locked here, emitted later).**
+
+```kotlin
+sealed interface CallEvent {
+    val timestampMs: Long
+    data class IceRestarted(val reason: String, override val timestampMs: Long) : CallEvent
+    data class AudioRouteChanged(val from: AudioRouteDevice?, val to: AudioRouteDevice?, override val timestampMs: Long) : CallEvent
+    data class ConnectionDegraded(val from: CallQuality, val to: CallQuality, override val timestampMs: Long) : CallEvent
+    data class FecEngaged(val lossPercent: Double, override val timestampMs: Long) : CallEvent
+    data class ThermalThrottle(val from: ThermalState, val to: ThermalState, override val timestampMs: Long) : CallEvent
+    data class Recovered(val tokenVersion: Int, val outcome: JoinReconnectOutcome, override val timestampMs: Long) : CallEvent
+    // CodecSwitched and BitrateAdapted intentionally omitted in 0.6.0 — no producer track in this plan.
+    // They will be introduced (along with their MediaKind / Direction enums) in the release that
+    // adds the producer (codec-switching track / per-encoding bitrate adaptor).
+}
+// outcome reuses the existing app.serenada.core.JoinReconnectOutcome enum; no new enum is declared here.
+```
+
+**Checklist.**
+
+- [ ] New types and flows compiled; stubs are safe no-ops, not throwing.
+- [ ] `setPreferredAudioRoute` (id and type overloads) and `availableAudioRoutes` declared.
+- [ ] `SessionMediaEngine.dampLocalAudio` seam declared.
+- [ ] Compose test scopes added; trivial test runs; `kotlinx-coroutines-test` resolves on `:serenada-core:test`.
+- [ ] `WebRtcHarnessProbeTest` runs and `TESTING.md` documents the chosen harness.
+- [ ] `assertNoEngineRefs` runs as part of `:serenada-call-ui:check`.
+- [ ] No new runtime deps; no reflection in tests.
+- [ ] `CallDiagnostics` source untouched.
+
+---
+
+### T L0 — Recovery schema + `resume()`
+
+**Schema (constructor in API-Lock; storage body here).** API-Lock landed:
+
+```kotlin
+data class RecoveryRecord(
+    val roomId: String,
+    val cid: String,
+    val reconnectToken: String,
+    val lastEpoch: Long?,
+    val sessionStartTs: Long,
+    val expiresAtMs: Long,
+    val roomUrl: String = "",                // defaulted for source compat (review P0-1)
+    val displayName: String? = null,
+)
+
+class RecoveryRecordIncompleteException(msg: String) : IllegalStateException(msg)
+class RecoveryExpiredException : IllegalStateException("Recovery record expired")
+```
+
+A blank `roomUrl` cannot drive a reconnect, so `resume()` validates it and rejects with `RecoveryRecordIncompleteException`. The default satisfies R1 without weakening runtime behavior.
+
+**Migration semantics.** `RecoveryStorage.load()` reads the JSON `version` field. If `version != 2` (or missing — i.e., v1 records written by 0.5.x), `load()` calls `clear()` and returns `null`. There is no in-memory v1 record with a blank `roomUrl`. `RecoveryRecordSchemaTest.kt` asserts: (a) v2 records round-trip; (b) v1 records are cleared and `load()` returns `null` on next call.
+
+**TTL + token plumbing (resolves review P0-2).** Three coordinated edits (the constructor changes themselves landed in API-Lock — L0 only fills bodies):
+
+1. `JoinedEvent` ([SignalingProvider.kt:52](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)) already carries `reconnectToken: String?` and `reconnectTokenTTLMs: Long?` (added in API-Lock as defaulted fields). L0 owns no signature change here.
+2. `SerenadaServerProvider.processJoinedPayload` ([SerenadaServerProvider.kt:226](client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt)) parses both values from the wire payload (it already does — they were just discarded) and forwards them on the `JoinedEvent`.
+3. `SignalingMessageRouter.processJoinedEvent` ([SignalingMessageRouter.kt:99](client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt)) replaces the current `onJoined(..., null, null, null)` with the real values from the event, and `onJoined`'s callback signature gains `reconnectToken: String?, reconnectTokenTTLMs: Long?`. `SerenadaSession` writes `expiresAtMs = now + ttl` from the server-issued value rather than a hard-coded constant, and persists `reconnectToken` into the v2 record.
+
+**Reconnect-outcome plumbing (resolves review P1-6).** The server's `joined` payload already carries a `reconnect` field with values `fresh | reattached | recovered` (see `server/signaling.go:60–80`). `SignalingMessageRouter` now plumbs that field through `onJoined` to `SerenadaSession`. `SerenadaSession.persistRecoveryRecord` already runs on every `joined`; in addition, when this session was started via `core.resume(...)` AND the server outcome is `reattached` or `recovered`, `SerenadaSession` emits exactly one `CallEvent.Recovered(tokenVersion, outcome)`. `fresh` outcomes do not emit `Recovered`. Sessions started via plain `core.join(...)` never emit `Recovered`.
+
+**Files.** `RecoveryStorage.kt`, `SignalingMessageRouter.kt`, `SignalingPayloads.kt` (parse the existing `reconnect` field if not already), `SerenadaSession.kt`, `SerenadaServerProvider.kt` (parser body for token + TTL; seeds `JoinOptions.reconnectToken` on first connect — both signatures landed in API-Lock), `SerenadaCore.kt`, `SessionRecoveryToken.kt` (org.json envelope, `version = 2`).
+
+`SerenadaCore.resume`:
+
+```kotlin
+fun resume(record: RecoveryRecord, displayName: String? = null): SerenadaSession {
+    assertMainThread()
+    if (record.roomUrl.isBlank()) throw RecoveryRecordIncompleteException("roomUrl missing")
+    if (System.currentTimeMillis() > record.expiresAtMs) throw RecoveryExpiredException()
+    return joinInternal(
+        url = record.roomUrl,
+        displayName = displayName ?: record.displayName,
+        reconnectPeerId = record.cid,
+        reconnectToken = record.reconnectToken,
+        markAsResume = true,                       // gates the Recovered event emission
+    )
+}
+```
+
+**Tests.**
+
+- `RecoveryRecordSchemaTest.kt` — v2 round-trip; v1 cleared, second `load()` returns `null`.
+- `RecoveryRecordIncompleteTest.kt` — blank-`roomUrl` record: `getRecoverableSession()` returns it (it's still in storage), but `core.resume(record)` throws `RecoveryRecordIncompleteException`.
+- `RecoveryTtlPlumbingTest.kt` — `FakeSignalingProvider` emits `joined` with `reconnectTokenTTLMs = 30_000`; assert `expiresAtMs ≈ now + 30_000`.
+- `RecoveryResumeTest.kt` — persist v2 record; `core.resume(record)` produces a session whose first join envelope contains both `reconnectPeerId` and `reconnectToken`.
+- `RecoveredEventTest.kt` — three cases: `fresh` outcome → no `Recovered` event; `reattached` outcome → one `Recovered` event with `outcome = REATTACHED`; `recovered` outcome → one `Recovered` event with `outcome = RECOVERED`. Plain `join()` (no resume) → no `Recovered` event regardless of outcome.
+- `RecoveryExpiredTest.kt` — past `expiresAtMs` → `getRecoverableSession()` returns `null`; `resume(stale)` throws `RecoveryExpiredException`.
+- `SessionRecoveryTokenTest.kt` — `JSONObject` round-trip; reject unknown `version`.
+
+**Checklist.**
+
+- [ ] v2 schema + migration (v1 → cleared); `RecoveryRecordIncompleteException` defined (constructor change shipped in API-Lock).
+- [ ] `SerenadaServerProvider.processJoinedPayload` forwards `reconnectToken` + `reconnectTokenTTLMs` on `JoinedEvent` (signature already added in API-Lock); `SignalingMessageRouter.onJoined` plumbs both.
+- [ ] `JoinOptions.reconnectToken` plumbed; `SerenadaServerProvider` seeds it on first connect.
+- [ ] `core.resume(record, displayName)` synchronous; uses existing `delegate`.
+- [ ] `SessionRecoveryToken.toRecord()` returns v2 `RecoveryRecord`.
+- [ ] `Recovered` event emitted only on server-confirmed `reattached`/`recovered` outcomes after `resume()`.
+- [ ] No regression in `SerenadaSessionContractTest`.
+
+---
+
+### T L0+ — Reconnect audio damp
+
+**Scope.** On `ConnectionStatus` transition into `Connected` from either `Recovering` or `Retrying`, suppress local audio for 200 ms to avoid the WebRTC squelch on reattach. Damp only when the user has not muted themselves; restore the prior effective state.
+
+**Seam (resolves review P1-3, P1-7).** `SessionMediaEngine` is an interface ([SessionMediaEngine.kt](client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt)). API-Lock declares the method; L0+ adds the body in two places:
+
+```kotlin
+// WebRtcEngine.kt — concrete implementation near toggleAudio() at line 281
+override fun dampLocalAudio(durationMs: Long, restoreIfEnabled: () -> Boolean) {
+    // Routes to the existing audio-track enable toggle, schedules a re-enable
+    // that re-reads restoreIfEnabled() at the deadline. Does NOT mutate
+    // CallState or broadcast media-state events.
+    setLocalAudioEnabledInternal(false)              // private peer of toggleAudio that skips state broadcast
+    mainHandler.postDelayed({
+        if (restoreIfEnabled()) setLocalAudioEnabledInternal(true)
+    }, durationMs)
+}
+
+// FakeMediaEngine.kt — records calls so ReconnectAudioDampTest can assert
+override fun dampLocalAudio(durationMs: Long, restoreIfEnabled: () -> Boolean) {
+    dampCalls += DampCall(durationMs, restoreIfEnabled)
+}
+```
+
+`SerenadaSession` then observes its own state and triggers the seam:
+
+```kotlin
+private fun observeReconnectForDamp() = launch {
+    state.map { it.connectionStatus }.distinctUntilChanged()
+         .scan(null as ConnectionStatus? to null as ConnectionStatus?) { acc, cur -> acc.second to cur }
+         .collect { (prev, cur) ->
+             val transitioning = (prev == ConnectionStatus.Recovering || prev == ConnectionStatus.Retrying)
+                              && cur == ConnectionStatus.Connected
+             if (!transitioning) return@collect
+             if (!state.value.localAudioEnabled) return@collect          // honor user mute
+             mediaEngine.dampLocalAudio(200) { state.value.localAudioEnabled }
+         }
+}
+```
+
+The damp does not emit any `state` change, does not broadcast media-state, and reads `localAudioEnabled` again at the deadline so a mute issued during the 200 ms window is honored.
+
+**Tests.** `ReconnectAudioDampTest.kt`:
+
+- Damps when `Recovering → Connected` and `localAudioEnabled = true`.
+- Damps when `Retrying → Connected` and `localAudioEnabled = true`.
+- Does not damp when user is muted (`localAudioEnabled = false`).
+- If the user mutes during the 200 ms damp window, the post-delay restore checks the new mute state and does not re-enable.
+- Damp does not emit any `state.localAudioEnabled = false` snapshot through `SerenadaSession.state`.
+
+**Checklist.**
+
+- [ ] `WebRtcEngine.dampLocalAudio` body implemented; `FakeMediaEngine` records calls.
+- [ ] `SerenadaSession.observeReconnectForDamp` wired.
+- [ ] Mute-state respected; no spurious `state` emissions.
+- [ ] All five test cases green.
+
+---
+
+### T L1-1a — `QualityScorer.kt`
+
+Pure reducer over an explicit state record (resolves review P1-4):
+
+```kotlin
+internal data class QualityScoreState(
+    val ewmaR: Double,             // smoothed R-factor (audio)
+    val ewmaVideo: Double,
+    val sustainedAtCurrent: Int,   // ticks the candidate has held — drives hysteresis
+    val current: CallQuality,
+) {
+    companion object { fun initial() = QualityScoreState(0.0, 0.0, 0, CallQuality.UNKNOWN) }
+}
+
+internal object QualityScorer {
+    fun score(state: QualityScoreState, sample: RealtimeCallStats): Pair<QualityScoreState, CallQuality>
+}
+```
+
+G.107 simplified for audio (R-factor from rtt, jitter, loss); video from freeze rate, decode fps, decoded height; combine = `min`. EWMA over 5 s lives inside the state. Hysteresis: downgrade after 1 sample, upgrade after 3 (`sustainedAtCurrent` counter). `StatsPoller` owns the state cell — there is no global mutable state in the scorer.
+
+**Tests.** `QualityScorerTest.kt` — 30-row golden table; oscillation around boundaries doesn't flap (driving the same sequence twice yields the same trace).
+
+### T L1-2a — `AudioLevelSampler.kt`
+
+Pure extractor over a single raw `RTCStatsReport`. Owns the data classes it returns (resolves review P1-6):
+
+```kotlin
+// PeerAudioLevels.kt — owned by L1-2a so the policy file compiles standalone
+internal data class PeerAudioLevels(
+    val remoteByTrackId: Map<String, Float>,
+    val localOutbound: Float,
+)
+
+// AudioLevelSmoother.kt — per-slot IIR state, owned by L1-2a
+internal class AudioLevelSmoother { /* IIR coefficients per track-id */ }
+
+// AudioLevelSampler.kt
+internal object AudioLevelSampler {
+    fun sample(report: RTCStatsReport, smoother: AudioLevelSmoother): PeerAudioLevels
+}
+```
+
+Called from inside `PeerConnectionSlot.onStatsDelivered` (L1-Integrate wires that call site; the `*a` track only adds the three files). Smoothing state is per-slot and lives in the smoother instance.
+
+**Tests.** `AudioLevelSamplerTest.kt` — synthetic `RTCStatsReport`s exercise inbound and outbound paths; silence ≤ 0.05; smoothing bounded; track-id keying preserved across calls.
+
+### T L1-3a — `ThermalSensor.kt`
+
+Two files (resolves review block #5):
+
+```kotlin
+// ThermalStatusSource.kt — internal seam, the only thing ThermalSensor reads
+internal interface ThermalStatusSource {
+    /** Hot flow of platform thermal status integers (PowerManager.THERMAL_STATUS_*). */
+    fun statuses(): Flow<Int>
+    companion object {
+        fun fromPlatform(context: Context): ThermalStatusSource =
+            if (Build.VERSION.SDK_INT >= 29) PowerManagerThermalStatusSource(context.getSystemService(PowerManager::class.java))
+            else ConstantThermalStatusSource(PowerManager.THERMAL_STATUS_NONE)
+    }
+}
+
+// ThermalSensor.kt — pure mapping over the seam
+internal class ThermalSensor(private val source: ThermalStatusSource) {
+    fun states(): Flow<ThermalState> =
+        source.statuses().map { mapPlatformStatusToThermalState(it) }.distinctUntilChanged()
+}
+```
+
+Production binds the seam to `PowerManager.OnThermalStatusChangedListener` (API ≥ 29) or to a constant `THERMAL_STATUS_NONE` source (API < 29). The pre-API-29 branch is selected at construction time, not at every emit.
+
+**Tests.** `ThermalSensorTest.kt` — `FakeThermalStatusSource` exposes a `MutableSharedFlow<Int>`; the test pushes status codes and asserts mapped `ThermalState` emissions, including duplicate-suppression. No Robolectric, no fake `PowerManager`.
+
+### T L1-Integrate
+
+**Sole owner of `StatsPoller.kt`, `SerenadaSession.kt`, `PeerConnectionSlotProtocol.kt`, `PeerConnectionSlot.kt`, `FakePeerConnectionSlot.kt`, and `PeerNegotiationEngine.kt` edits in L1.**
+
+1. Widen `PeerConnectionSlotProtocol.collectWebRtcStats` to deliver `WebRtcStatsSnapshot` (definition above). `summary` and `realtime` are populated by the existing parsing path; the new `audioLevels` field is populated by `AudioLevelSampler.sample(rawReport, smoother)` against the same raw `RTCStatsReport` the slot already has in hand at `PeerConnectionSlot.kt:408`. `WebRtcStatsSnapshot` is owned by L1-Integrate (it composes types from L1-2a).
+2. `PeerConnectionSlot` holds an `AudioLevelSmoother` per slot lifetime; clears it on close.
+3. `FakePeerConnectionSlot` returns canned `WebRtcStatsSnapshot`s to match.
+4. Implement the slot-iterating scheduler above with explicit `start()`/`stop()`, owning supervised scope, injectable worker dispatcher (`Dispatchers.Default` → `StandardTestDispatcher` in tests), separately-injectable main dispatcher (`Dispatchers.Main.immediate` → the same `StandardTestDispatcher` in tests), `runCatching` per slot, `withTimeoutOrNull(1_000)` per slot, and null-merged-slow-tick skipping. `SerenadaSession` constructs the poller with `mainDispatcher = sessionMainDispatcher` (the same dispatcher used elsewhere in the session — `Dispatchers.Main.immediate` in production, the test dispatcher in tests) and passes `snapshotSlots = { withContext(sessionMainDispatcher) { peerSlots.values.toList() } }`. The injected dispatcher is used for both the snapshot hop and the publish hop, so dispatcher-boundary tests exercise the same shape as production. `StatsPoller` holds the `QualityScoreState` cell. `ThermalSensor` is a separate session-scoped collector built over the L1-3a `ThermalStatusSource` seam.
+5. `PeerNegotiationEngine` exposes a new optional callback (resolves review P1-5):
+
+```kotlin
+// PeerNegotiationEngine
+var onIceRestarted: ((reason: String) -> Unit)? = null
+// fired from the existing scheduleIceRestart()/triggerIceRestart() paths
+```
+
+`SerenadaSession` registers a callback that forwards into the `events` SharedFlow as `CallEvent.IceRestarted`. Quality downgrades emit `ConnectionDegraded`; thermal transitions emit `ThermalThrottle`.
+
+**Tests.**
+
+- `StatsPollerSchedulerTest.kt` — virtual time (`StandardTestDispatcher` from `kotlinx-coroutines-test`). Required cases:
+  - 2 s window = exactly 10 fast publishes + 1 slow publish.
+  - Concurrent ticks do not stack (mutex test): a long collect that exceeds 200 ms causes the next tick to be skipped, not queued.
+  - **Thrown slot collect**: one slot's callback throws; `runCatching` swallows it; sibling slots still publish on the same tick; loop continues to the next tick.
+  - **Timed-out slot**: one slot never invokes its callback; `withTimeoutOrNull(1_000)` returns `null` for that slot; the tick still publishes whatever sibling slots produced.
+  - **Null `realtime` per snapshot**: snapshots have non-null `audioLevels` but null `realtime`; slow tick's `mergeRealtimeStats` returns `null`; slow tick `continue`s without `publishRealtime`/`publishQuality`.
+  - **All-null slow tick**: zero slots returned snapshots this tick; slow tick `continue`s without panic.
+  - **Dispatcher boundaries**: `publishAudio` / `publishRealtime` / `publishQuality` invocations land on the `mainDispatcher`, not the worker dispatcher (test asserts via dispatcher tagging in the publish lambdas).
+  - `start()`/`stop()` lifecycle round-trips: `start()` is idempotent; `stop()` cancels the scope; calling `start()` again creates a fresh scope and resumes ticking.
+  - Uses `FakePeerConnectionSlot` returning canned `WebRtcStatsSnapshot`s.
+- `PeerConnectionSlotAudioLevelTest.kt` — drive `PeerConnectionSlot.onStatsDelivered` with synthetic `RTCStatsReport`s; assert the emitted `WebRtcStatsSnapshot.audioLevels` matches expected smoothed values for inbound and outbound tracks.
+- `SessionTelemetryWiringTest.kt` — end-to-end through `TestSessionFactory`; `localAudioLevel` and `remoteAudioLevels` flows update from snapshots.
+- `IceRestartedEventTest.kt` — driving `FakePeerNegotiationEngine.onIceRestarted("manual")` produces exactly one `CallEvent.IceRestarted` on `session.events`.
+- `ConnectionDegradedEventTest.kt` — feed canned `RealtimeCallStats` sequences through the slow-lane pipeline so the `QualityScorer` reports a downgrade (`GOOD → POOR`) and an upgrade (`POOR → GOOD`); assert a single `CallEvent.ConnectionDegraded(from=GOOD, to=POOR)` on the downgrade and **no** event on the upgrade (the contract is degradation-only, not symmetric — upgrades are surfaced via `qualityScore` but not as events).
+
+**Checklist.**
+
+- [ ] `WebRtcStatsSnapshot` defined; `PeerConnectionSlotProtocol` callback signature updated; `PeerConnectionSlot` and `FakePeerConnectionSlot` adapted.
+- [ ] `AudioLevelSampler` invoked inside `PeerConnectionSlot` on the raw report; per-slot smoother lifecycle correct (cleared on slot close).
+- [ ] `StatsPoller` has `start()`/`stop()`, owning supervised scope, **separate injectable worker (`Dispatchers.Default`) and main (`Dispatchers.Main.immediate`) dispatchers**, per-slot 1 s `withTimeoutOrNull`; consumes snapshots only.
+- [ ] **Slot-list snapshot hops to `Main.immediate`** via `snapshotSlots: suspend () -> List<...>` constructed by `SerenadaSession`; worker never touches `peerSlots` directly.
+- [ ] **Per-slot failure isolation**: each `slot.collectAwait()` wrapped in `runCatching`; a single thrown or timed-out slot does not cancel sibling collects or the loop.
+- [ ] **Null-merge slow tick**: when `mergeRealtimeStats(...)` returns `null`, the slow tick `continue`s without invoking `publishRealtime` or `QualityScorer.score`.
+- [ ] **Main-thread publish boundary**: `publishAudio`, `publishRealtime`, `publishQuality` invoked under `withContext(mainDispatcher)`; `MutableStateFlow.value` writes happen on main only.
+- [ ] **Thermal collector lifecycle**: `ThermalSensor.states()` collected under the same session scope as `StatsPoller`; cancelled on session close; emits via the `thermalState: StateFlow<ThermalState>` flow on main.
+- [ ] All three telemetry flows (`localAudioLevel`, `remoteAudioLevels`, `qualityScore`) populated end-to-end through `TestSessionFactory`.
+- [ ] `PeerNegotiationEngine.onIceRestarted` callback added; events wired through to `session.events` as `CallEvent.IceRestarted`, on main.
+
+---
+
+### T L2 — pure policy tracks (parallel)
+
+All `*a` tracks land **only new files** with **no edits to shared big files**.
+
+- **L2-1a Simulcast.** `SimulcastTransceiverBuilder.kt` returns `RtpTransceiver.RtpTransceiverInit` for a given `VideoQualityConfig` (from API-Lock) — three encoding params with `maxBitrateBps` / `scaleResolutionDownBy` / `active`. **No `scalabilityMode`** (resolves review P1-9): the current `libwebrtc-7559_173` AAR's `RtpParameters.Encoding` does not expose that field, and AAR bumps are out of scope for this plan. VP9 SVC is deferred. Tested with `SimulcastTransceiverBuilderTest.kt`.
+- **L2-2a Opus FEC + DTX.** `SdpAudioPolicy.kt` — pure SDP munger, fmtp-only, idempotent (consumes API-Lock `AudioQualityConfig`, default `dtx = OFF`). `AudioQualityAutoPolicy.kt` — pure stats→action policy with the FEC AUTO thresholds (5 s loss > 0.5% engages; 30 s sustained < 0.2% disengages); L2-Integrate calls it from the slow-lane stats hook to drive renegotiation (resolves review P2-11). Tests: `SdpAudioPolicyTest.kt` (golden SDPs in `src/test/resources/sdp/`), `AudioQualityAutoPolicyTest.kt` (hysteresis + dwell), `OpusInteropHarnessTest.kt` (API-Lock harness round-trip).
+- **L2-3a Opus RED.** `SdpRedPolicy.kt` — PT allocator (96–127, avoid existing PTs), m-line PT-list rewrite, `red/48000/2` rtpmap, `<red-pt> <opus-pt>/<opus-pt>` fmtp. Tests: `SdpRedPolicyTest.kt` (golden + PT-collision matrix) + `RedRoundTripHarnessTest.kt`. Default off; stays off this plan's lifetime.
+- **L2-4a AEC/NS/AGC.** `AudioDeviceModuleBuilder.kt` — interface seam wrapping `JavaAudioDeviceModule.builder()` (consumes API-Lock `AudioProcessingConfig`). Tests: `AudioDeviceModuleBuilderTest.kt`.
+- **L2-5a LE Audio routing.** `CallAudioRoutePolicy.kt` consumes the public `AudioRouteDevice` and `BluetoothPolicy` declared in API-Lock:
+  ```kotlin
+  fun select(devices: List<AudioRouteDevice>, policy: BluetoothPolicy, current: AudioRouteDevice?): AudioRouteDevice?
+  ```
+  Pure, trivially unit-testable. Adaptation from `AudioDeviceInfo` to `AudioRouteDevice` happens in `CallAudioSessionController` (L2-Integrate). Tests: `CallAudioRoutePolicyTest.kt` (BLE-only, SCO-only, both, none, `preferLeAudio` on/off).
+- **L2-6 Trickle ICE — tests-only verification.** No new code, no `IceConfig` knob. `TrickleIceVerificationTest.kt` asserts `PeerNegotiationEngine.kt:155` sends `ice` synchronously per `onIceCandidate`; receiver-side buffer drains correctly.
+- **L2-7a Thermal policy.** `ThermalGovernorPolicy.kt` — pure `(ThermalState, VideoQualityConfig) -> Policy(maxFps, disableHighestLayer, audioOnly)`. Tests: `ThermalGovernorPolicyTest.kt`.
+
+### T L2-Integrate
+
+**Sole owner** of edits to `WebRtcEngine.kt`, `CallAudioSessionController.kt`, `SessionAudioController.kt` (interface widening — resolves review P1-8), `SerenadaConfig.kt` (sub-field bodies), and `SerenadaSession.kt` in L2. The `SessionAudioController` interface ([SessionAudioController.kt](client-android/serenada-core/src/main/java/app/serenada/core/call/SessionAudioController.kt)) currently only exposes `activate/deactivate/shouldPauseVideoForProximity`; L2-Integrate adds `audioRoute: StateFlow<AudioRouteDevice?>`, `availableAudioRoutes: StateFlow<List<AudioRouteDevice>>`, `setPreferredAudioRoute(routeId: Int)`, `setPreferredAudioRoute(route: AudioRoute)` to the interface and implements them in `CallAudioSessionController`. Wires:
+
+- `SimulcastTransceiverBuilder` into `WebRtcEngine` video sender (`addTransceiver`).
+- `SdpAudioPolicy` (and optionally `SdpRedPolicy`) between `createOffer/Answer` and `setLocalDescription`. `AudioQualityAutoPolicy` is invoked from the slow-lane stats hook to flip FEC and trigger renegotiation.
+- `AudioDeviceModuleBuilder` seam into `configureAudioDeviceModule` (lines 135–193).
+- `CallAudioRoutePolicy` into `CallAudioSessionController.applyCallAudioRouting`. Adapts `AudioDeviceInfo` → `AudioRouteDevice` (id, type, label). Updates `audioRoute: StateFlow<AudioRouteDevice?>` and `availableAudioRoutes: StateFlow<List<AudioRouteDevice>>` flows on `SerenadaSession`. Implements both `setPreferredAudioRoute(routeId)` and `setPreferredAudioRoute(route)` bodies — the id-based form looks up the device in the cached available list; the type-based form picks the first matching device. Emits `CallEvent.AudioRouteChanged(from, to)`.
+- `ThermalGovernorPolicy` consumer subscribes to `SerenadaSession.thermalState` and applies via `RtpSender.setParameters` mutations.
+
+**Integration tests.**
+
+- `WebRtcEngineSimulcastIntegrationTest.kt` — 3 `a=rid` lines on offer; offer/answer round-trips through the API-Lock harness.
+- `OpusFecIntegrationTest.kt` — AUTO threshold + 30 s dwell drives renegotiation; `FecEngaged` emitted; harness round-trips.
+- `WebRtcEngineAudioProcessingTest.kt` — each `AecMode` triggers the right ADM-builder calls.
+- `LeAudioRoutingTest.kt` — `audioRoute` and `availableAudioRoutes` update; events emitted; both `setPreferredAudioRoute` overloads round-trip; selection by stale id falls back to current route.
+- `ThermalIntegrationTest.kt` — SEVERE disables video track; MODERATE disables top simulcast layer; **each transition emits exactly one `CallEvent.ThermalThrottle(from, to)` with the correct `from`/`to` states**, and the no-op transition (e.g., `LIGHT → LIGHT`) emits nothing.
+
+**Checklist.**
+
+- [ ] All policies wired through one integrator agent.
+- [ ] `SessionAudioController` interface widened; route flows + setter overloads land here.
+- [ ] All new `SerenadaConfig` sub-field bodies wired in one PR.
+- [ ] Both `setPreferredAudioRoute` overloads implemented.
+- [ ] Integration tests green.
+
+---
+
+### T L3 — Compose components (parallel; depends on L2-Integrate for `setPreferredAudioRoute`)
+
+Four files under `serenada-call-ui/.../components/`. Consume **only public flows / methods on `SerenadaSession`**.
+
+- `QualityChip.kt` ← `session.qualityScore`
+- `ReconnectingChip.kt` ← `session.state.connectionStatus`
+- `AudioDevicePicker.kt` — binds to `session.audioRoute: AudioRouteDevice?` and `session.availableAudioRoutes: List<AudioRouteDevice>`; on selection calls `session.setPreferredAudioRoute(device.id)`. The picker shows `device.label` per row, so two paired Bluetooth devices are distinguishable (resolves review P1-2). Persistence is the host's responsibility.
+- `AudioLevelDot.kt` ← `session.localAudioLevel` / `session.remoteAudioLevels[peerCid]`
+
+**Reduced-motion seam.** L3 introduces a small composition local in `serenada-call-ui` so the components themselves stay declarative:
+
+```kotlin
+// ReduceMotion.kt — owned by L3
+val LocalReduceMotion: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }
+```
+
+Each L3 component exposes `reduceMotion: Boolean = LocalReduceMotion.current` as its first non-data parameter; when `true`, the component renders the same final visual state but skips `animate*AsState`/`Crossfade` wrappers. The host app provides the value once at the call screen root by reading `Settings.Global.TRANSITION_ANIMATION_SCALE == 0f` (the platform-correct signal); L3 itself does not touch system settings.
+
+**Tests.** Each: `createComposeRule()` + `onNodeWithContentDescription(...)` per state. **Reduced-motion variants are tested via the explicit parameter** (resolves review P2-9, iteration-8 review block #4): the test composes the component with `reduceMotion = true` (or wraps it in `CompositionLocalProvider(LocalReduceMotion provides true)`) and asserts the *observable* state — content description, semantics — without measuring animation calls. No reliance on `LocalAccessibilityManager.isReduceMotionEnabled` (which is not a Compose UI 1.6 API).
+
+**CI guard.** API-Lock wires `:serenada-call-ui:assertNoEngineRefs` into `:serenada-call-ui:check`. The task fails the build if any `serenada-call-ui` source imports any of the **specific engine internals**:
+- `app.serenada.core.call.WebRtcEngine`
+- `app.serenada.core.call.PeerConnectionSlot` (and `.PeerConnectionSlotProtocol`)
+- `app.serenada.core.call.PeerNegotiationEngine`
+- `app.serenada.core.call.StatsPoller`
+- `app.serenada.core.call.CallAudioSessionController`
+- `android.media.AudioManager`
+
+Public model types in `app.serenada.core.call.*` (e.g., `CallPhase`, `ConnectionStatus`, `LocalCameraMode`) remain allowed.
+
+**Checklist.**
+
+- [ ] Four components added.
+- [ ] `assertNoEngineRefs` task in place with the narrow allowlist above and attached to `check`.
+- [ ] Compose semantic-state tests green (no animation-call counts).
+
+---
+
+### T Finalize
+
+1. CHANGELOGs in `client-android/serenada-core/` and `client-android/serenada-call-ui/`. **Call out the ABI break** (`RecoveryRecord`, `JoinOptions`, `SerenadaConfig`, `JoinedEvent`) explicitly under "Breaking changes (binary)".
+2. Bump SDK version 0.5.x → **0.6.0** across all 8 sources tracked by `check-version-parity.mjs`. The minor bump is the public signal of the ABI break.
+3. README example: `events`, `resume`, configs, `setPreferredAudioRoute`, `AudioRouteDevice`.
+4. Open the consolidated PR. **API-Lock is not merged separately** — Finalize is the merge unit.
+
+**Checklist.**
+
+- [ ] CHANGELOGs note breaking ABI changes.
+- [ ] Version bumped to 0.6.0; parity script green.
+- [ ] README examples up to date.
+- [ ] `tools/worktree-validate.sh` green on a clean clone.
+
+---
+
+## What the loss harness is and isn't
+
+A `LossyNetwork` wrapper around `FakeSignalingTransport` exists for **control-plane** tests (recovery handoff, candidate ordering). It does not validate media features.
+
+Media features are covered by:
+
+- **Pure stats-policy tests** — `QualityScorerTest`, `AudioQualityAutoPolicyTest`, `ThermalGovernorPolicyTest`, `AudioLevelSamplerTest`, `CallAudioRoutePolicyTest`, `SimulcastTransceiverBuilderTest`. Deterministic, no harness.
+- **WebRTC harness chosen at API-Lock** (recorded in `TESTING.md`). Used by `OpusInteropHarnessTest`, `RedRoundTripHarnessTest`, `WebRtcEngineSimulcastIntegrationTest`. Runs in `:serenada-core:test`, no device.
+- **No `tc netem`** harness.
+
+## Alternatives Considered
+
+### A1. Modify `CallDiagnostics` in place
+
+**Rejected on design grounds (not ABI grounds).** Even with N4 allowing ABI breaks, separate flows compose better and yield narrower change-detection.
+
+### A2. Sidecar types instead of extending `RecoveryRecord` / `JoinOptions` / `SerenadaConfig`
+
+**Considered, rejected.** Cost: doubled type surface, two `JoinOptions` flowing through `SignalingProvider`, idiom-breaking config split. Benefit: avoids a 0.x SDK ABI bump that consumers in this monorepo (Zello, sample app) won't notice because they're rebuilt in lockstep. The honest call is the version bump; sidecar types would carry compat baggage we don't need.
+
+### A3. Single big-bang track
+
+**Rejected.** The `*a` policy + integrator pattern is the smallest model that lets independent agents work in parallel without merge conflicts.
+
+### A4. Generic SDP rewriter library
+
+**Rejected.** Per-feature pure functions with golden tests are simpler.
+
+### A5. Bundle Opus RED with FEC/DTX
+
+**Rejected.** RED needs PT allocation + m-line surgery; FEC/DTX is an fmtp-only edit.
+
+### A6. Inflate `SerenadaDiagnostics` with runtime flows
+
+**Rejected.** That class is the pre-flight utility, not the runtime telemetry surface.
+
+### A7. Re-engineer trickle ICE
+
+**Rejected.** Sender-side trickle is already today's behavior.
+
+### A8. Add an `IceConfig` knob with only `ENABLED`
+
+**Rejected.** Empty knobs are API noise.
+
+### A9. Audio dampening inside `ReconnectingChip`
+
+**Rejected.** Audio behavior is core SDK policy. Dampening is in L0+ via the `SessionMediaEngine.dampLocalAudio` seam.
+
+### A10. Persist `SessionRecoveryToken` inside the SDK via DataStore
+
+**Considered.** The SDK already persists via `RecoveryStorage` (SharedPreferences). The envelope is a cross-process serializer (e.g., FCM data payloads).
+
+### A11. Add `kotlinx-serialization-json`
+
+**Rejected.** `org.json.JSONObject` is already used everywhere in the SDK.
+
+### A12. Reflection-based API surface test
+
+**Rejected.** Plain compile-time usage is enforced by `kotlinc`.
+
+### A13. Default-on simulcast/FEC/LE Audio in the SDK from day one
+
+**Rejected.** Default-flip PRs follow Zello rollout, one knob at a time.
+
+### A14. Code-generate Kotlin types from a shared cross-platform schema
+
+**Rejected.** No second consumer; premature.
+
+### A15. Add Paparazzi/Roborazzi for visual regression
+
+**Deferred.** Compose semantics tests cover logic regressions.
+
+### A16. Default DTX = `AUTO`
+
+**Rejected.** AUTO would change media behavior. `OFF` is the true preserve-current setting; Zello flips to AUTO post-rollout.
+
+### A17. Use platform `AudioDeviceInfo` directly in `CallAudioRoutePolicy`
+
+**Rejected.** Hard to instantiate in unit tests. Policy consumes `AudioRouteDevice`; adaptation lives in `CallAudioSessionController`.
+
+### A18. Expose audio routes as `StateFlow<List<AudioRoute>>`
+
+**Rejected (review P1-2).** Bare `AudioRoute` cannot distinguish two Bluetooth devices or carry labels. The picker needs `AudioRouteDevice` with `id` and `label`.
+
+### A19. Fire `CallEvent.Recovered` at `resume()` start
+
+**Rejected (review P1-6).** Optimistic emission lies if the server later issues a `fresh` outcome (token expired). Emit only after the server-confirmed `reattached`/`recovered`.
+
+### A20. `NotImplementedError` stubs at API-Lock
+
+**Rejected (review P2-7).** Stubs are safe no-ops so the base branch can run end-to-end tests during stacked work.
+
+### A21. Keep `PeerConnectionSlotProtocol.collectWebRtcStats` callback shape unchanged and parse audio levels in `StatsPoller`
+
+**Rejected (review P0, iteration 6).** The slot is the only owner of the raw `RTCStatsReport` — by the time `StatsPoller` would see anything, the report has already been parsed and discarded inside the slot ([PeerConnectionSlot.kt:408](client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt)). Either the slot keeps holding the report (which we'd have to expose, doubling the work and inviting two parsing passes) or the slot widens its callback once. Widening the callback once is the cleaner change; smoothing state lives where the parsing already lives.
+
+### A22. Keep config model types in L2 (their natural home with the policies that read them)
+
+**Rejected (review P0-3, iteration 7).** It would mean L2 tracks introduce new public types, contradicting "all public API additions land in API-Lock". L2 already depends on the model types (e.g., L2-7a depends on `VideoQualityConfig` from L2-1a even though both run in parallel). Moving the bare data classes to API-Lock is the single small change that unbreaks the parallel DAG and keeps API-Lock a real lock.
+
+### A23. Implement VP9 SVC via `scalabilityMode`
+
+**Rejected (review P1-9, iteration 7).** `libwebrtc-7559_173` ([build.gradle.kts:56](client-android/serenada-core/build.gradle.kts)) doesn't expose `scalabilityMode` on `RtpParameters.Encoding`. AAR bumps are out of scope. SVC is deferred; this plan ships 3-layer simulcast on the existing encoding params.
+
+### A24. `QualityScorer` as a stateful object holding EWMA internally
+
+**Rejected (review P1-4, iteration 7).** Hidden global state in a singleton is unfriendly to multi-session tests. The pure-reducer form (`(state, sample) -> (state', quality)`) is testable in isolation; `StatsPoller` is the natural state holder.
+
+## Open Questions → Decisions
+
+1. **Token signing** — trust server validation; envelope is unsigned.
+2. **AUTO FEC hysteresis** — engage at 5 s loss > 0.5%, disengage after 30 s sustained < 0.2%.
+3. **Default-on simulcast on low-end devices** — SDK default off; Zello opts in; thermal governor downshifts.
+4. **Quality-score override hook** — none; SDK ships single reference impl.
+5. **Compose UI screenshot framework** — none; semantic-state assertions only.
+6. **LE Audio smoke testing** — documented in smoke-test README; selector unit-tested.
+7. **iOS/Web parity timeline** — not in this plan.
+8. **WebRTC test harness viability** — decided in API-Lock by `WebRtcHarnessProbeTest`; result recorded in `TESTING.md`.
+9. **Pre-existing on-disk recovery records (v1)** — cleared at load; `load()` returns `null` on the next call.
+10. **ABI compatibility** — explicitly broken across 0.5.x → 0.6.0 across `RecoveryRecord`, `JoinOptions`, `SerenadaConfig`, **and `JoinedEvent`**; source compat preserved via default-valued constructor parameters; CHANGELOG calls it out.
+11. **DTX default** — `OFF` to preserve today's behavior; Zello opts into `AUTO`.
+12. **Route policy input type** — SDK-owned `AudioRouteDevice`, not platform `AudioDeviceInfo`.
+13. **Audio route picker granularity** — `StateFlow<List<AudioRouteDevice>>` with id-based selection (resolves review P1-2).
+14. **`Recovered` event source** — emitted only on server-confirmed `reattached`/`recovered` outcomes after `resume()` (resolves review P1-6).
+15. **Reconnect damp seam** — `SessionMediaEngine.dampLocalAudio(durationMs, restoreIfEnabled)`; declared at API-Lock, body in L0+ (resolves review P1-3).
+16. **Stats seam for audio levels** — widen `PeerConnectionSlotProtocol.collectWebRtcStats` to deliver `WebRtcStatsSnapshot` (summary + realtime + audioLevels). `AudioLevelSampler` runs inside `PeerConnectionSlot` on the raw report; `StatsPoller` consumes snapshots only (resolves iteration-6 P0).
+17. **Public-config home** — bare data classes (`VideoQualityConfig`, `AudioQualityConfig`, `AudioProcessingConfig`, `BluetoothPolicy`, `ThermalConfig`) live in API-Lock; bodies that read them stay in L2 (resolves iteration-7 P0-3).
+18. **Recovery token + TTL on `JoinedEvent`** — `JoinedEvent` carries both fields; `SerenadaServerProvider` forwards them; `SignalingMessageRouter` plumbs them via `onJoined` (resolves iteration-7 P0-2).
+19. **`QualityScorer` shape** — pure reducer over `QualityScoreState`; `StatsPoller` holds the cell (resolves iteration-7 P1-4).
+20. **`StatsPoller` lifecycle** — owning `CoroutineScope`, injectable `Dispatchers.Default`, `start()`/`stop()`, per-slot `withTimeoutOrNull(1_000)`; cadence is 200 ms fast / 2 s slow = 10 fast + 1 slow per 2 s (resolves iteration-7 P1-5).
+21. **`PeerAudioLevels` / `AudioLevelSmoother` ownership** — L1-2a, so the policy file compiles standalone (resolves iteration-7 P1-6).
+22. **Damp body** — concrete in `WebRtcEngine`; `FakeMediaEngine` records calls (resolves iteration-7 P1-7).
+23. **Audio-route seam** — `SessionAudioController` interface widened in L2-Integrate (resolves iteration-7 P1-8).
+24. **VP9 SVC** — deferred; current AAR doesn't expose `scalabilityMode` (resolves iteration-7 P1-9).
+25. **Test deps** — `kotlinx-coroutines-test` added; `assertNoEngineRefs` wired into `:serenada-call-ui:check` (resolves iteration-7 P2-10, P2-12).
+26. **`AudioQualityAutoPolicy`** — explicit owner of FEC AUTO thresholds + dwell, called from L2-Integrate's slow-lane stats hook (resolves iteration-7 P2-11).
+27. **`StatsPoller` threading** — slot-list snapshot on `Main.immediate`, collection/merge on `Default`, publish hops back to `Main.immediate` (resolves iteration-8 review block #1).
+28. **`StatsPoller` failure isolation** — per-slot `runCatching`; null-merged slow tick `continue`s (resolves iteration-8 review block #2).
+29. **Reduced-motion seam** — `LocalReduceMotion` composition local + per-component `reduceMotion: Boolean` parameter; host reads `Settings.Global.TRANSITION_ANIMATION_SCALE`; tests pass `true` directly (resolves iteration-8 review block #4).
+30. **`ThermalSensor` test seam** — internal `ThermalStatusSource` interface; tests use `FakeThermalStatusSource`; production binds to `PowerManager.OnThermalStatusChangedListener` or constant source by API level (resolves iteration-8 review block #5).
+31. **Unproduced events** — `CallEvent.CodecSwitched` and `CallEvent.BitrateAdapted` (and their `MediaKind` / `Direction` enums) are deferred until a producer track exists. Empty event types are API noise (resolves iteration-9 review on declared-but-unwired events).
+32. **Recovery API surface ownership** — `JoinedEvent` token/TTL fields and `JoinOptions.reconnectToken` are signature-added in API-Lock; L0 owns only the parser/seed bodies. Restores the "all public API additions land in API-Lock" rule (resolves iteration-10 P1).
+33. **`CallEvent.Recovered.outcome`** reuses the existing `JoinReconnectOutcome` enum ([SignalingProvider.kt:50](client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt)); no parallel `ReconnectOutcome` is introduced (resolves iteration-10 P1).
+34. **`ConnectionDegraded` is degradation-only.** No event is emitted on quality upgrade — upgrades surface via `qualityScore` only. Codified in `ConnectionDegradedEventTest` (resolves iteration-10 P1).
+
+There are no remaining pre-track blockers — every prior open question is now a decision baked above.

--- a/docs/resilience-failure-modes.md
+++ b/docs/resilience-failure-modes.md
@@ -1,7 +1,7 @@
 # Resilience Failure Modes — Audit & Fix Plan
 
-**Status:** Phase 1 implemented (server + Web/Android/iOS SDKs); Phase 2 & 3 outstanding.
-**Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed)
+**Status:** Phase 1 implemented; Phase 2 partial (process-death recovery #5 landed end-to-end; #8/#10 in flight).
+**Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed) · 2026-04-26 (Phase 2 partial landed)
 **Scope:** Web, Android, iOS SDKs and the Go signaling server
 
 ## Background
@@ -64,7 +64,7 @@ must preserve the core UX model:
 | 2 | Reconnect creates a new CID instead of preserving identity | App thinks it rejoined; peers see duplicate/empty state   | Critical | S      | Phase 1 ✅ |
 | 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      | Phase 1 (server cleanup gate) · SDK presentation timer + emission pending |
 | 4 | ICE restart fires on stale peer map at reconnect          | Offers to ghost CIDs, missing offers to new peers         | High     | S      | Phase 1 (server epoch + post-reconnect snapshot) · SDK MediaEngine wiring pending |
-| 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      | Phase 2 |
+| 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      | Phase 2 ✅ (server `POST /api/leave` + per-platform recovery store + rejoin API) |
 | 6 | No explicit "you are suspended / about to be evicted"     | UI can't show countdown; apps can't make smart choices    | Medium   | S      | Phase 2 |
 | 7 | SSE transport hijack via SID reuse                        | Security: another connection can take over an SSE session | Critical | S      | Phase 2 — server `TODO(#7)` placed; needs SDK `resumeSse` first |
 | 8 | iOS background suspension keeps SDK in stale "connected"  | After long background, signaling appears alive but isn't  | High     | M      | Phase 2 |
@@ -477,7 +477,19 @@ top of existing reconnect flow.
 
 ## 5. Process death without clean teardown
 
-**Status (2026-04-25):** Not started — Phase 2.
+**Status (2026-04-26):** Landed end-to-end. Server exposes `POST /api/leave`
+that takes `{rid, cid, reconnectToken}`, validates the token (rejects
+expired or unsigned), and immediately hard-evicts via the new
+`Hub.evictByLeave`. Idempotent and rate-limited (12 req/min/IP). All
+three SDKs persist `{roomId, cid, reconnectToken, lastEpoch,
+sessionStartTs, expiresAtMs}` across launches: Web → `sessionStorage`,
+Android → app-private `SharedPreferences`, iOS → injectable
+`UserDefaults` (defaults to `.standard`; host apps can pass an
+app-group store). Each SDK exposes `getRecoverableSession()` and
+`discardRecoverableSession()` so host apps can offer a "Rejoin call?"
+prompt on relaunch. Recovery records are cleared on clean leave,
+`room_ended`, and `INVALID_RECONNECT_TOKEN`; expired records are dropped
+on read.
 
 ### Symptom
 
@@ -1399,6 +1411,60 @@ Out of scope for this document, listed for visibility:
   it deserves a fresh look.
 
 ## Change Log
+
+### 2026-04-26 — Phase 2 partial: process-death recovery (#5)
+
+- **Server (`server/leave_handler.go`)**: New `POST /api/leave` endpoint
+  for explicit terminal-leave intent. Validates `{rid, cid,
+  reconnectToken}` against the existing HMAC machinery (rejects expired
+  or unsigned tokens with 401), then calls the new `Hub.evictByLeave`
+  which removes the participant immediately, drops dirty/liveness state,
+  rebroadcasts `room_state` (or GCs the room when empty), and is
+  idempotent. Rate-limited at 12 req/min/IP via the existing
+  `rateLimitMiddleware` and gated by `enableCors`. Tests cover the happy
+  path, missing-field rejection, bogus and expired tokens, idempotency,
+  and method-not-allowed.
+
+- **All three SDKs**: Persistent recovery state lands per the doc.
+  Web → `sessionStorage` (per-tab; survives reload, lost on tab close),
+  Android → app-private `SharedPreferences`, iOS → injectable
+  `UserDefaults` (defaults `.standard`; host apps can pass an
+  app-group-scoped store before opening any session). Each SDK
+  surfaces a public `getRecoverableSession()` / `discardRecoverableSession()`
+  pair on `SerenadaCore`. The active session writes the record on every
+  successful `joined` (with the original `sessionStartTs` preserved
+  across reconnects) and clears it on clean leave, `room_ended`, or
+  `INVALID_RECONNECT_TOKEN`. Records expire on the wire-side
+  `reconnectTokenTTLMs` (Web) or the matching `suspendHardEvictionTimeout`
+  (Android/iOS, where the TTL was not previously plumbed).
+
+- **iOS-specific**: `JoinedEvent` gains `reconnectToken` and
+  `reconnectTokenTTLMs` fields so the session — which previously had no
+  visibility into provider-internal token state — can populate the
+  recovery record from the wire payload directly.
+
+- **Tests**:
+  - Server: `server/leave_handler_test.go` (6 tests) covers token
+    happy/sad paths and idempotency.
+  - Web: `recoveryStorage.test.ts` (7 tests) covers round-trip,
+    malformed JSON, expired entries, and missing-field rejection.
+  - Android: `RecoveryStorageTest` (5 tests, Robolectric) covers the
+    same matrix.
+  - iOS: `RecoveryStorageTests` (6 tests) covers the same matrix
+    plus injected-clock expiry semantics.
+  - All four suites green (server Go, Web vitest 308, Android gradle,
+    iOS xcodebuild 252).
+
+- **Deferred (still Phase 2)**:
+  - **#8 iOS scene-phase observer + foreground force-ping** — needs
+    `SignalingClient`-level "fresh ping with 2s deadline" plumbing the
+    SDK does not yet expose. Tracked for a follow-up slice.
+  - **#10 lifecycle serialization on `CallManager`** — current
+    `@MainActor` class serializes synchronous code but has interleave
+    holes across `await` suspension points. Needs a Task-chain
+    refactor; deferred.
+  - **#10 deep-link guard ("switch call?" prompt)** — host-app UI
+    territory; deferred to product/UX work.
 
 ### 2026-04-25 — Phase 1 implementation landed
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.5.0")
-    implementation("app.serenada:call-ui:0.5.0")
+    implementation("app.serenada:core:0.5.1")
+    implementation("app.serenada:call-ui:0.5.1")
 }
 ```
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.0")
-    implementation("app.serenada:call-ui:0.6.0")
+    implementation("app.serenada:core:0.6.1")
+    implementation("app.serenada:call-ui:0.6.1")
 }
 ```
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.5.1")
-    implementation("app.serenada:call-ui:0.5.1")
+    implementation("app.serenada:core:0.6.0")
+    implementation("app.serenada:call-ui:0.6.0")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.5.0 @serenada/react-ui@0.5.0 lucide-react
+npm install @serenada/core@0.5.1 @serenada/react-ui@0.5.1 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.5.1 @serenada/react-ui@0.5.1 lucide-react
+npm install @serenada/core@0.6.0 @serenada/react-ui@0.6.0 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.6.0 @serenada/react-ui@0.6.0 lucide-react
+npm install @serenada/core@0.6.1 @serenada/react-ui@0.6.1 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@serenada/core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.5.0"
+        "@serenada/core": "0.5.1"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.5.0",
+        "@serenada/core": "^0.5.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.0"
+        "@serenada/core": "0.6.1"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.0",
+        "@serenada/core": "^0.6.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@serenada/core",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.5.1"
+        "@serenada/core": "0.6.0"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.5.1",
+        "@serenada/core": "^0.6.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/server/leave_handler.go
+++ b/server/leave_handler.go
@@ -43,6 +43,11 @@ func handleLeave(hub *Hub) http.HandlerFunc {
 			http.Error(w, "Invalid room id", http.StatusBadRequest)
 			return
 		}
+		if reconnectSecret() == nil {
+			log.Printf("[API_LEAVE] Rejecting leave for CID %s in room %s: reconnect token secret is not configured", body.CID, body.RID)
+			http.Error(w, "Reconnect token validation unavailable", http.StatusUnauthorized)
+			return
+		}
 		ok, _ := validateReconnectToken(body.ReconnectToken, body.CID, body.RID)
 		if !ok {
 			http.Error(w, "Invalid reconnect token", http.StatusUnauthorized)

--- a/server/leave_handler.go
+++ b/server/leave_handler.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"serenada/server/internal/stats"
+)
+
+// handleLeave returns an HTTP handler for the explicit terminal-leave path.
+//
+// SDKs invoke this via `navigator.sendBeacon` or a normal HTTPS POST when the
+// user has explicitly chosen to leave (or end) the call and the page may
+// unload before the signaling-level `leave` message can be flushed. The body
+// must carry a valid `reconnectToken` for the (rid, cid) tuple — without that
+// proof the request is rejected, since this endpoint bypasses the suspension
+// hold and immediately hard-evicts the participant.
+//
+// Idempotent: repeated calls for an already-evicted CID return 204 without
+// further side effects.
+func handleLeave(hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body struct {
+			RID            string `json:"rid"`
+			CID            string `json:"cid"`
+			ReconnectToken string `json:"reconnectToken"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&body); err != nil {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if body.RID == "" || body.CID == "" || body.ReconnectToken == "" {
+			http.Error(w, "Missing rid, cid, or reconnectToken", http.StatusBadRequest)
+			return
+		}
+		if err := validateRoomID(body.RID); err != nil {
+			http.Error(w, "Invalid room id", http.StatusBadRequest)
+			return
+		}
+		ok, _ := validateReconnectToken(body.ReconnectToken, body.CID, body.RID)
+		if !ok {
+			http.Error(w, "Invalid reconnect token", http.StatusUnauthorized)
+			return
+		}
+
+		hub.evictByLeave(body.RID, body.CID)
+		stats.IncMessageRX("api_leave")
+
+		w.WriteHeader(http.StatusNoContent)
+		log.Printf("[API_LEAVE] Evicted CID %s from room %s", body.CID, body.RID)
+	}
+}

--- a/server/leave_handler_test.go
+++ b/server/leave_handler_test.go
@@ -89,6 +89,22 @@ func TestApiLeaveRejectsInvalidToken(t *testing.T) {
 	}
 }
 
+func TestApiLeaveRejectsUnsignedTokenWhenSecretMissing(t *testing.T) {
+	t.Setenv("TURN_SECRET", "")
+	t.Setenv("TURN_TOKEN_SECRET", "")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	w := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            "C-abc",
+		"reconnectToken": "unsigned-dev-token",
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when reconnect token secret is missing, got %d", w.Code)
+	}
+}
+
 func TestApiLeaveRejectsExpiredToken(t *testing.T) {
 	t.Setenv("TURN_SECRET", "test-leave-secret")
 	rid := mustTestRoomID(t)

--- a/server/leave_handler_test.go
+++ b/server/leave_handler_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func postLeave(t *testing.T, hub *Hub, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/leave", bytes.NewReader(raw))
+	w := httptest.NewRecorder()
+	handleLeave(hub).ServeHTTP(w, req)
+	return w
+}
+
+func TestApiLeaveEvictsParticipantWithValidToken(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-leave-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	w := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            first.CID,
+		"reconnectToken": first.ReconnectToken,
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%q", w.Code, w.Body.String())
+	}
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if exists {
+		t.Fatal("expected room to be GC'd after sole participant evicted")
+	}
+}
+
+func TestApiLeaveRejectsMissingFields(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-leave-secret")
+	hub := newHub(4)
+
+	for _, body := range []map[string]string{
+		{"cid": "C-x", "reconnectToken": "t"},
+		{"rid": "irrelevant", "reconnectToken": "t"},
+		{"rid": "irrelevant", "cid": "C-x"},
+		{},
+	} {
+		w := postLeave(t, hub, body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %+v, got %d", body, w.Code)
+		}
+	}
+}
+
+func TestApiLeaveRejectsInvalidToken(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-leave-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	w := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            first.CID,
+		"reconnectToken": "bogus.0",
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for bogus token, got %d", w.Code)
+	}
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if !exists {
+		t.Fatal("room should still exist after rejected leave")
+	}
+}
+
+func TestApiLeaveRejectsExpiredToken(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-leave-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+	expired := issueReconnectTokenWithExpiry(first.CID, rid, time.Now().Add(-5*time.Minute))
+
+	w := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            first.CID,
+		"reconnectToken": expired,
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired token, got %d", w.Code)
+	}
+}
+
+func TestApiLeaveIsIdempotent(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-leave-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	aJoined := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	captureJoined(t, b)
+
+	first := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            aJoined.CID,
+		"reconnectToken": aJoined.ReconnectToken,
+	})
+	second := postLeave(t, hub, map[string]string{
+		"rid":            rid,
+		"cid":            aJoined.CID,
+		"reconnectToken": aJoined.ReconnectToken,
+	})
+
+	if first.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on first call, got %d", first.Code)
+	}
+	if second.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on second call (idempotent), got %d", second.Code)
+	}
+}
+
+func TestApiLeaveRejectsNonPost(t *testing.T) {
+	hub := newHub(4)
+	req := httptest.NewRequest(http.MethodGet, "/api/leave", nil)
+	w := httptest.NewRecorder()
+	handleLeave(hub).ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", w.Code)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -87,6 +87,9 @@ func main() {
 	pushLimiter := NewIPLimiter(10.0/60.0, 5)
 	// Feedback: 3 requests per minute
 	feedbackLimiter := NewIPLimiter(3.0/60.0, 3)
+	// Explicit terminal leave: 12 requests per minute (allows a few retries
+	// per active call without inviting abuse).
+	leaveLimiter := NewIPLimiter(12.0/60.0, 6)
 
 	http.HandleFunc("/ws", rateLimitMiddleware(wsLimiter, func(w http.ResponseWriter, r *http.Request) {
 		if wsHang {
@@ -105,6 +108,7 @@ func main() {
 	http.HandleFunc("/api/turn-credentials", withTimeout(rateLimitMiddleware(turnCredsLimiter, enableCors(handleTurnCredentials())), 15*time.Second))
 	http.HandleFunc("/api/diagnostic-token", withTimeout(rateLimitMiddleware(diagnosticLimiter, enableCors(handleDiagnosticToken())), 15*time.Second))
 	http.HandleFunc("/api/room-id", withTimeout(rateLimitMiddleware(roomIDLimiter, enableCors(handleRoomID())), 15*time.Second))
+	http.HandleFunc("/api/leave", withTimeout(rateLimitMiddleware(leaveLimiter, enableCors(handleLeave(hub))), 5*time.Second))
 	http.HandleFunc("/api/internal/stats", withTimeout(handleInternalStats(hub), 5*time.Second))
 
 	// Push Routes

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -1692,6 +1692,55 @@ func (h *Hub) removeClientFromRoom(c *Client) {
 	h.broadcastRoomStatusUpdate(rid)
 }
 
+// evictByLeave is the explicit terminal-leave path used by `POST /api/leave`.
+// Unlike `disconnectClient` it does not start a suspend window — the
+// participant is removed immediately (the user explicitly chose to leave or
+// end the call, often during page unload). Idempotent: a second call for an
+// already-evicted CID is a no-op.
+//
+// The caller is responsible for verifying the reconnect token before calling
+// this helper. The participant record is removed regardless of whether a
+// signaling transport is currently attached, and any attached *Client is
+// detached + suspended-record cleaned up so the next reconnect with a stale
+// token can not silently revive the slot.
+func (h *Hub) evictByLeave(rid, cid string) {
+	h.mu.RLock()
+	room, exists := h.rooms[rid]
+	h.mu.RUnlock()
+	if !exists {
+		return
+	}
+
+	room.mu.Lock()
+	p := room.participantByCID(cid)
+	if p == nil {
+		room.mu.Unlock()
+		return
+	}
+	attachedClient := p.Client
+	room.removeParticipant(cid)
+	room.dropCIDFromDirty(cid)
+	room.dropMediaLivenessFor(cid)
+	room.transferHostIfNeeded(cid)
+	room.bumpEpoch()
+	isEmpty := room.participantCount() == 0
+	room.mu.Unlock()
+
+	if attachedClient != nil {
+		closeClientSend(attachedClient.send)
+		h.cleanupEvictedClient(attachedClient)
+	}
+
+	if isEmpty {
+		h.mu.Lock()
+		delete(h.rooms, rid)
+		h.mu.Unlock()
+	} else {
+		h.broadcastRoomState(room)
+	}
+	h.broadcastRoomStatusUpdate(rid)
+}
+
 func (h *Hub) broadcastRoomState(room *Room) {
 	// Must be called without room lock!
 

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -170,12 +170,12 @@ type Message struct {
 
 // Participant is the wire-format entry broadcast to clients in joined/room_state.
 type Participant struct {
-	CID              string                 `json:"cid"`
-	JoinedAt         int64                  `json:"joinedAt,omitempty"`
-	DisplayName      string                 `json:"displayName,omitempty"`
-	AudioEnabled     *bool                  `json:"audioEnabled,omitempty"`
-	VideoEnabled     *bool                  `json:"videoEnabled,omitempty"`
-	ConnectionStatus string                 `json:"connectionStatus,omitempty"` // "suspended" when transport detached; omitted (= "active") otherwise
+	CID              string                   `json:"cid"`
+	JoinedAt         int64                    `json:"joinedAt,omitempty"`
+	DisplayName      string                   `json:"displayName,omitempty"`
+	AudioEnabled     *bool                    `json:"audioEnabled,omitempty"`
+	VideoEnabled     *bool                    `json:"videoEnabled,omitempty"`
+	ConnectionStatus string                   `json:"connectionStatus,omitempty"` // "suspended" when transport detached; omitted (= "active") otherwise
 	ContentState     *ParticipantContentState `json:"contentState,omitempty"`
 }
 
@@ -1727,7 +1727,6 @@ func (h *Hub) evictByLeave(rid, cid string) {
 	room.mu.Unlock()
 
 	if attachedClient != nil {
-		closeClientSend(attachedClient.send)
 		h.cleanupEvictedClient(attachedClient)
 	}
 


### PR DESCRIPTION
## Summary

Implements **failure mode #5 (process death without clean teardown)** from [`docs/resilience-failure-modes.md`](docs/resilience-failure-modes.md) end-to-end. Stacks on top of [agatx/serenada#73](https://github.com/agatx/serenada/pull/73) (resilience Phase 1).

The two other Phase 2 items in the proposal — **#8** (iOS `scenePhase` observer + foreground force-ping) and **#10** (lifecycle serialization on `CallManager` + deep-link guard) — are deliberately scoped out for follow-up slices to keep this PR reviewable. The proposal doc's Status entries are updated accordingly.

### Server (`server/`)
- New `POST /api/leave` endpoint takes `{rid, cid, reconnectToken}`, validates the token (rejects expired or unsigned with 401), and immediately hard-evicts the participant via the new `Hub.evictByLeave`. **Idempotent** and rate-limited at 12 req/min/IP via the existing `rateLimitMiddleware` + `enableCors` stack.
- `Hub.evictByLeave` bypasses the suspension hold: removes the participant record, drops dirty-pair / media-liveness state, transfers host if needed, bumps the room epoch, and either GCs the room (when empty) or rebroadcasts `room_state`. Existing attached transports are detached and cleaned up via `cleanupEvictedClient` so a stale token cannot revive the slot via a late reconnect.

### SDKs (Web · Android · iOS)
- All three platforms persist `{roomId, cid, reconnectToken, lastEpoch, sessionStartTs, expiresAtMs}` across launches.
  - **Web** → `sessionStorage` (per-tab; survives reload, lost on tab close)
  - **Android** → app-private `SharedPreferences`
  - **iOS** → injectable `UserDefaults` (defaults to `.standard`; host apps can pass an app-group store before opening any session)
- Each SDK exposes `getRecoverableSession()` / `discardRecoverableSession()` on `SerenadaCore` so host apps can offer a "Rejoin call?" prompt on relaunch.
- The active session writes the record on every successful `joined` (with `sessionStartTs` preserved across reconnects) and clears it on clean leave, `room_ended`, or `INVALID_RECONNECT_TOKEN`.
- iOS-only: `JoinedEvent` gains `reconnectToken` and `reconnectTokenTTLMs` fields so the session — which previously had no visibility into provider-internal token state — can populate the recovery record from the wire payload directly.

## Test plan

- [x] `cd server && go test ./...` (server + new `leave_handler_test.go`)
- [x] `cd client && npm run test` (Web — 308 tests, +7 for `recoveryStorage`)
- [x] `cd client && npm run build` (TypeScript + Vite)
- [x] `cd client-android && ./gradlew :serenada-core:testDebugUnitTest` (+5 Robolectric tests)
- [x] `cd client-android && ./gradlew :serenada-core:assembleDebug :serenada-call-ui:assembleDebug :app:assembleDebug`
- [x] `cd client-ios && xcodegen generate && xcodebuild ... test` (252 unit tests, +6 for `RecoveryStorage`)
- [x] `node scripts/check-resilience-constants.mjs`
- [x] `node scripts/check-version-parity.mjs`
- [ ] Smoke test against a live deployment once Phase 1 (PR #73) lands

## Deferred to follow-up Phase 2 slices

- **#8 iOS scene-phase observer + foreground force-ping** — needs `SignalingClient`-level "fresh ping with 2s deadline" plumbing the SDK does not yet expose.
- **#10 `CallManager` lifecycle serialization** — current `@MainActor` class serializes synchronous code but has interleave holes across `await` suspension points. Needs a Task-chain refactor.
- **#10 Deep-link guard ("switch call?" prompt)** — host-app UI territory; product/UX work.

## Stack

- ⬇️ Base: [agatx/serenada#73](https://github.com/agatx/serenada/pull/73) — Resilience Phase 1: identity, tombstones, epoch, dirty-pair, content-state
- ⬆️ Head: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)