### PR TITLE
Phase 2 partial: foreground / Doze force-ping (#8)

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -119,6 +119,10 @@ internal class SerenadaServerProvider(
         sendRawMessage(type = type, payload = payload)
     }
 
+    override fun forceReconnectIfStale(timeoutMs: Long) {
+        signaling.forcePingWithDeadline(timeoutMs)
+    }
+
     override suspend fun getIceServers(): List<PeerConnection.IceServer> {
         val token = currentTurnToken?.takeIf { it.isNotBlank() } ?: return emptyList()
         return suspendCancellableCoroutine { continuation ->

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -1,11 +1,14 @@
 package app.serenada.core
 
+import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
@@ -120,6 +123,53 @@ class SerenadaSession internal constructor(
                 }
             }
         }
+    }
+
+    // App lifecycle (foreground / Doze release force-ping — see resilience #8).
+    // Activity-counting via the framework `ActivityLifecycleCallbacks` keeps the
+    // SDK dependency-free; ProcessLifecycleOwner would require lifecycle-process.
+    private var startedActivityCount = 0
+    private var lastBackgroundedAtMs: Long? = null
+    private val appLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+        override fun onActivityStarted(activity: Activity) {
+            handler.post {
+                val wasBackgrounded = startedActivityCount == 0
+                startedActivityCount += 1
+                if (wasBackgrounded) handleAppForegrounded()
+            }
+        }
+        override fun onActivityResumed(activity: Activity) {}
+        override fun onActivityPaused(activity: Activity) {}
+        override fun onActivityStopped(activity: Activity) {
+            handler.post {
+                startedActivityCount = (startedActivityCount - 1).coerceAtLeast(0)
+                if (startedActivityCount == 0) handleAppBackgrounded()
+            }
+        }
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+        override fun onActivityDestroyed(activity: Activity) {}
+    }
+
+    private fun handleAppBackgrounded() {
+        lastBackgroundedAtMs = clock.nowMs()
+    }
+
+    /**
+     * Force-ping hook for resilience #8: when Android resumes the app after
+     * a long enough background (or a Doze release), the WS that the OS
+     * silently killed gets detected inside `foregroundForcePingTimeoutMs`
+     * instead of waiting for the regular `pingIntervalMs` cycle.
+     */
+    private fun handleAppForegrounded() {
+        val backgroundedAt = lastBackgroundedAtMs
+        lastBackgroundedAtMs = null
+        if (backgroundedAt == null) return
+        val phase = _state.value.phase
+        if (phase != CallPhase.InCall && phase != CallPhase.Joining && phase != CallPhase.Waiting) return
+        val backgroundedMs = clock.nowMs() - backgroundedAt
+        if (backgroundedMs < FOREGROUND_RESUME_MIN_BACKGROUND_MS) return
+        signalingProvider.forceReconnectIfStale(WebRtcResilienceConstants.FOREGROUND_FORCE_PING_TIMEOUT_MS)
     }
 
     private var clientId: String? = null
@@ -1162,10 +1212,24 @@ class SerenadaSession internal constructor(
 
     private fun registerConnectivityListener() {
         runCatching { connectivityManager.registerNetworkCallback(NetworkRequest.Builder().build(), networkCallback) }
+        registerAppLifecycleListener()
     }
 
     private fun unregisterConnectivityListener() {
         runCatching { connectivityManager.unregisterNetworkCallback(networkCallback) }
+        unregisterAppLifecycleListener()
+    }
+
+    private fun registerAppLifecycleListener() {
+        val app = appContext as? Application ?: return
+        runCatching { app.registerActivityLifecycleCallbacks(appLifecycleCallbacks) }
+    }
+
+    private fun unregisterAppLifecycleListener() {
+        val app = appContext as? Application ?: return
+        runCatching { app.unregisterActivityLifecycleCallbacks(appLifecycleCallbacks) }
+        startedActivityCount = 0
+        lastBackgroundedAtMs = null
     }
 
     private fun hasRequiredPermissions(): Boolean {
@@ -1186,6 +1250,11 @@ class SerenadaSession internal constructor(
         // The recovery record stops offering rejoin past this window because
         // the persisted token would no longer be honored anyway.
         const val RecoveryTokenTTLMs = 10L * 60L * 1000L
+        // Background duration that triggers a foreground force-ping. Anything
+        // shorter is short enough that pings would have noticed the failure on
+        // their own; longer is the OS window where Doze / process freeze may
+        // have killed the WS.
+        const val FOREGROUND_RESUME_MIN_BACKGROUND_MS = 5_000L
         val REQUIRED_ANDROID_PERMISSIONS = arrayOf(
             android.Manifest.permission.CAMERA,
             android.Manifest.permission.RECORD_AUDIO,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -1,6 +1,7 @@
 package app.serenada.core
 
 import android.app.Activity
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
 import android.content.Intent
@@ -1230,6 +1231,8 @@ class SerenadaSession internal constructor(
 
     private fun registerAppLifecycleListener() {
         val app = appContext as? Application ?: return
+        startedActivityCount = if (isAppProcessForeground()) 1 else 0
+        lastBackgroundedAtMs = null
         runCatching { app.registerActivityLifecycleCallbacks(appLifecycleCallbacks) }
     }
 
@@ -1238,6 +1241,12 @@ class SerenadaSession internal constructor(
         runCatching { app.unregisterActivityLifecycleCallbacks(appLifecycleCallbacks) }
         startedActivityCount = 0
         lastBackgroundedAtMs = null
+    }
+
+    private fun isAppProcessForeground(): Boolean {
+        val processInfo = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(processInfo)
+        return processInfo.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE
     }
 
     private fun hasRequiredPermissions(): Boolean {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
@@ -121,6 +121,17 @@ interface SignalingProvider {
 
     suspend fun getIceServers(): List<PeerConnection.IceServer>
 
+    /**
+     * Hook the SDK calls when the host app returns to foreground after a
+     * background period long enough that the OS may have silently killed
+     * the underlying transport (e.g. Doze release or process freeze). The
+     * expected behavior for transport-owning providers is to send a
+     * synthetic ping and arm a `timeoutMs` deadline, then force-close the
+     * transport on miss so the normal reconnect path runs. Default is
+     * no-op for providers that manage their own lifecycle.
+     */
+    fun forceReconnectIfStale(timeoutMs: Long) {}
+
     interface Listener {
         fun onConnected(info: ConnectionInfo = ConnectionInfo()) {}
         fun onDisconnected(reason: String?) {}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionSignaling.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionSignaling.kt
@@ -13,4 +13,14 @@ internal interface SessionSignaling {
     fun send(message: SignalingMessage)
     fun close()
     fun recordPong()
+
+    /**
+     * Send a synthetic ping and arm a short deadline; if no pong arrives,
+     * force-close the transport so the normal reconnect path kicks in.
+     * Used by the session's foreground/Doze-release lifecycle hook so a
+     * stalled WS that the OS killed during background gets detected
+     * immediately instead of waiting for the regular `pingIntervalMs`
+     * cycle. Default is no-op for transports that don't support it.
+     */
+    fun forcePingWithDeadline(timeoutMs: Long) {}
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingClient.kt
@@ -42,8 +42,10 @@ internal class SignalingClient(
     @Volatile private var connecting = false
     private var pingRunnable: Runnable? = null
     private var connectTimeoutRunnable: Runnable? = null
+    private var forcePingRunnable: Runnable? = null
     private var wsConsecutiveFailures = 0
     private var lastPongAt = System.currentTimeMillis()
+    private var pongSeq = 0L
     private var missedPongs = 0
     private var connectionAttemptId = 0
     private var activeAttemptId = 0
@@ -82,6 +84,7 @@ internal class SignalingClient(
         closedByClient = true
         stopPing()
         clearConnectTimeout()
+        clearForcePing()
         connecting = false
         connected = false
         activeAttemptId = -kotlin.math.abs(activeAttemptId)
@@ -91,6 +94,38 @@ internal class SignalingClient(
         normalizedHost = null
         resetTransportState()
         resetTransportSessions()
+    }
+
+    override fun forcePingWithDeadline(timeoutMs: Long) {
+        if (!connected) return
+        val kind = activeTransport ?: return
+        val attemptId = activeAttemptId
+        val pongSeqAtPing = pongSeq
+        clearForcePing()
+
+        val payload = SignalingMessage(
+            type = "ping",
+            rid = null,
+            sid = null,
+            cid = null,
+            to = null,
+            payload = null
+        )
+        send(payload)
+
+        val runnable = Runnable {
+            if (!isAttemptActive(attemptId, kind)) return@Runnable
+            if (!connected) return@Runnable
+            if (pongSeq > pongSeqAtPing) return@Runnable
+            handleTransportClosed(attemptId, kind, "foreground_force_ping_timeout")
+        }
+        forcePingRunnable = runnable
+        handler.postDelayed(runnable, timeoutMs.coerceAtLeast(0L))
+    }
+
+    private fun clearForcePing() {
+        forcePingRunnable?.let { handler.removeCallbacks(it) }
+        forcePingRunnable = null
     }
 
     private fun startPing() {
@@ -276,6 +311,7 @@ internal class SignalingClient(
 
     override fun recordPong() {
         lastPongAt = System.currentTimeMillis()
+        pongSeq += 1L
         missedPongs = 0
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
@@ -33,4 +33,10 @@ object WebRtcResilienceConstants {
 
     // ── Snapshot ─────────────────────────────────────────────────────
     const val SNAPSHOT_PREPARE_TIMEOUT_MS = 2_000L
+
+    // ── Foreground / Doze recovery ───────────────────────────────────
+    // After the app returns to foreground from background, the SDK issues a
+    // synthetic ping and waits this long for a pong before force-closing the
+    // transport and triggering the normal reconnect path.
+    const val FOREGROUND_FORCE_PING_TIMEOUT_MS = 2_000L
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SignalingClientForcePingTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SignalingClientForcePingTest.kt
@@ -1,0 +1,174 @@
+/**
+ * Tests for SignalingClient.forcePingWithDeadline (resilience #8).
+ *
+ * Verifies that the foreground force-ping path sends a synthetic ping,
+ * closes the transport when no pong arrives within the deadline, and
+ * stays no-op when not connected.
+ */
+package app.serenada.core
+
+import android.os.Handler
+import android.os.Looper
+import app.serenada.core.call.SignalingClient
+import app.serenada.core.call.SignalingMessage
+import app.serenada.core.call.SessionSignaling
+import app.serenada.core.fakes.FakeSignalingTransport
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SignalingClientForcePingTest {
+
+    private val transports = mutableListOf<FakeSignalingTransport>()
+    private lateinit var client: SignalingClient
+    private lateinit var listener: RecordingListener
+
+    @Before
+    fun setUp() {
+        listener = RecordingListener()
+        client = SignalingClient(
+            okHttpClient = OkHttpClient(),
+            handler = Handler(Looper.getMainLooper()),
+            transportFactory = { kind ->
+                FakeSignalingTransport(kind).also { transports += it }
+            },
+        )
+        client.listener = listener
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        ShadowLooper.idleMainLooper()
+    }
+
+    private val wsTransport: FakeSignalingTransport
+        get() = transports.first { it.kind == SignalingClient.TransportKind.WS }
+
+    private fun connectAndOpen() {
+        client.connect("example.com")
+        ShadowLooper.idleMainLooper()
+        wsTransport.simulateOpen()
+        ShadowLooper.idleMainLooper()
+        assertTrue(client.isConnected())
+        wsTransport.sentMessages.clear()
+    }
+
+    @Test
+    fun `forcePing sends synthetic ping immediately`() {
+        connectAndOpen()
+
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper()
+
+        val pings = wsTransport.sentMessages.filter { it.type == "ping" }
+        assertEquals(1, pings.size)
+    }
+
+    @Test
+    fun `forcePing closes transport when pong does not arrive before deadline`() {
+        connectAndOpen()
+
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper()
+
+        // Advance past deadline without a pong.
+        ShadowLooper.idleMainLooper(2_500, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        assertFalse(client.isConnected())
+        assertEquals(listOf("foreground_force_ping_timeout"), listener.closeReasons)
+    }
+
+    @Test
+    fun `forcePing does not close when pong arrives before deadline`() {
+        connectAndOpen()
+
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper()
+
+        // Pong arrives well before deadline.
+        client.recordPong()
+
+        // Advance past deadline.
+        ShadowLooper.idleMainLooper(2_500, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        assertTrue(client.isConnected())
+        assertTrue(listener.closeReasons.isEmpty())
+    }
+
+    @Test
+    fun `forcePing is no-op when not connected`() {
+        // Never connected.
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper(2_500, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        // No ping was sent and no close fired.
+        val ws = transports.firstOrNull { it.kind == SignalingClient.TransportKind.WS }
+        assertEquals(0, ws?.sentMessages?.size ?: 0)
+        assertTrue(listener.closeReasons.isEmpty())
+    }
+
+    @Test
+    fun `forcePing called twice cancels earlier deadline`() {
+        connectAndOpen()
+
+        client.forcePingWithDeadline(5_000L)
+        ShadowLooper.idleMainLooper()
+        // Advance partway, then issue a fresh force-ping with a new deadline.
+        ShadowLooper.idleMainLooper(1_000, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper()
+        // Pong arrives before the second deadline (and well before the first).
+        client.recordPong()
+        ShadowLooper.idleMainLooper(2_500, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        assertTrue(client.isConnected())
+        assertTrue(listener.closeReasons.isEmpty())
+    }
+
+    @Test
+    fun `forcePing after close is no-op`() {
+        connectAndOpen()
+        client.close()
+        ShadowLooper.idleMainLooper()
+        wsTransport.sentMessages.clear()
+
+        client.forcePingWithDeadline(2_000L)
+        ShadowLooper.idleMainLooper(2_500, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        // Nothing sent post-close.
+        assertEquals(0, wsTransport.sentMessages.size)
+    }
+
+    // ── Recording listener ──────────────────────────────────────────────
+
+    private class RecordingListener : SessionSignaling.Listener {
+        val openTransports = mutableListOf<String>()
+        val messages = mutableListOf<SignalingMessage>()
+        val closeReasons = mutableListOf<String>()
+
+        override fun onOpen(activeTransport: String) {
+            openTransports += activeTransport
+        }
+
+        override fun onMessage(message: SignalingMessage) {
+            messages += message
+        }
+
+        override fun onClosed(reason: String) {
+            closeReasons += reason
+        }
+    }
+}

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
@@ -36,6 +36,13 @@ public enum WebRtcResilience {
     // MARK: - Snapshot
 
     public static let snapshotPrepareTimeoutMs = 2_000
+
+    // MARK: - Foreground / Doze recovery
+
+    /// After the app returns to foreground from background, the SDK issues a
+    /// synthetic ping and waits this long for a pong before force-closing the
+    /// transport and triggering the normal reconnect path.
+    public static let foregroundForcePingTimeoutMs = 2_000
 }
 
 // MARK: - Nanosecond convenience accessors

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -125,6 +125,18 @@ internal final class SerenadaServerProvider: SignalingProvider {
         }
     }
 
+    func forceReconnectIfStale(timeoutMs: Int) {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                signaling.forcePingWithDeadline(timeoutMs: timeoutMs)
+            }
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.signaling.forcePingWithDeadline(timeoutMs: timeoutMs)
+            }
+        }
+    }
+
     func sendToPeer(_ peerId: String, type: String, payload: SignalingPayload?) {
         if Thread.isMainThread {
             MainActor.assumeIsolated {

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -147,6 +147,11 @@ public final class SerenadaSession: ObservableObject {
     private let pathMonitor = NWPathMonitor()
     private let pathMonitorQueue = DispatchQueue(label: "SerenadaSession.PathMonitor")
 
+    // App lifecycle (foreground force-ping — see resilience #8)
+    private var foregroundObserver: NSObjectProtocol?
+    private var backgroundObserver: NSObjectProtocol?
+    private var lastBackgroundedAtMs: Int64?
+
     // Session state
     private var internalPhase: CallPhase = .joining
     private var participantCount = 0
@@ -310,6 +315,8 @@ public final class SerenadaSession: ObservableObject {
     deinit {
         pathMonitor.cancel()
         reconnectTask?.cancel()
+        if let foregroundObserver { NotificationCenter.default.removeObserver(foregroundObserver) }
+        if let backgroundObserver { NotificationCenter.default.removeObserver(backgroundObserver) }
     }
 
     // MARK: - Public API
@@ -1150,7 +1157,49 @@ public final class SerenadaSession: ObservableObject {
             }
         }
         pathMonitor.start(queue: pathMonitorQueue)
+        startAppLifecycleMonitoring()
     }
+
+    private func startAppLifecycleMonitoring() {
+        let center = NotificationCenter.default
+        backgroundObserver = center.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.handleAppBackgrounded() }
+        }
+        foregroundObserver = center.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.handleAppForegrounded() }
+        }
+    }
+
+    private func handleAppBackgrounded() {
+        lastBackgroundedAtMs = Self.nowMs()
+    }
+
+    /// Force-ping hook for resilience #8: when iOS resumes the app after a
+    /// long enough background, the WS the OS killed silently is detected
+    /// inside `foregroundForcePingTimeoutMs` instead of waiting a full
+    /// `pingIntervalMs` cycle.
+    private func handleAppForegrounded() {
+        let backgroundedAt = lastBackgroundedAtMs
+        lastBackgroundedAtMs = nil
+        guard let backgroundedAt else { return }
+        guard internalPhase == .inCall || internalPhase == .joining || internalPhase == .waiting else { return }
+        let backgroundedMs = Self.nowMs() - backgroundedAt
+        guard backgroundedMs >= Self.foregroundResumeMinBackgroundMs else { return }
+        signalingProvider.forceReconnectIfStale(timeoutMs: WebRtcResilience.foregroundForcePingTimeoutMs)
+    }
+
+    /// Background duration that triggers a foreground force-ping. Anything
+    /// shorter is short enough that pings would have noticed the failure on
+    /// their own; longer is the OS window where iOS may have killed the WS.
+    private static let foregroundResumeMinBackgroundMs: Int64 = 5_000
 
     /// Snapshots the in-memory reconnect state into the cross-launch
     /// recovery store so a relaunched process can offer a "Rejoin call?"

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -1188,7 +1188,7 @@ public final class SerenadaSession: ObservableObject {
     }
 
     private func handleAppBackgrounded() {
-        lastBackgroundedAtMs = Self.nowMs()
+        lastBackgroundedAtMs = clock.nowMs()
     }
 
     /// Force-ping hook for resilience #8: when iOS resumes the app after a
@@ -1200,7 +1200,7 @@ public final class SerenadaSession: ObservableObject {
         lastBackgroundedAtMs = nil
         guard let backgroundedAt else { return }
         guard internalPhase == .inCall || internalPhase == .joining || internalPhase == .waiting else { return }
-        let backgroundedMs = Self.nowMs() - backgroundedAt
+        let backgroundedMs = clock.nowMs() - backgroundedAt
         guard backgroundedMs >= Self.foregroundResumeMinBackgroundMs else { return }
         signalingProvider.forceReconnectIfStale(timeoutMs: WebRtcResilience.foregroundForcePingTimeoutMs)
     }

--- a/client-ios/SerenadaCore/Sources/Signaling/SessionSignaling.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SessionSignaling.swift
@@ -8,4 +8,15 @@ protocol SessionSignaling: AnyObject {
     func send(_ message: SignalingMessage)
     func close()
     func recordPong()
+
+    /// Send a synthetic ping and arm a short deadline; if no pong arrives,
+    /// force-close the transport so the normal reconnect path kicks in.
+    /// Used by the session's foreground lifecycle hook so a stalled WS that
+    /// the OS killed during background gets detected immediately instead of
+    /// waiting for the regular `pingIntervalMs` cycle.
+    func forcePingWithDeadline(timeoutMs: Int)
+}
+
+extension SessionSignaling {
+    func forcePingWithDeadline(timeoutMs: Int) {}
 }

--- a/client-ios/SerenadaCore/Sources/Signaling/SignalingClient.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SignalingClient.swift
@@ -24,6 +24,8 @@ final class SignalingClient: SessionSignaling {
     private var connecting = false
     private var pingTask: Task<Void, Never>?
     private var connectTimeoutTask: Task<Void, Never>?
+    private var forcePingTask: Task<Void, Never>?
+    private var pongSeq: Int64 = 0
 
     private var connectionAttemptId = 0
     private var activeAttemptId = 0
@@ -84,6 +86,7 @@ final class SignalingClient: SessionSignaling {
         closedByClient = true
         stopPing()
         clearConnectTimeout()
+        clearForcePing()
 
         connecting = false
         connected = false
@@ -99,7 +102,32 @@ final class SignalingClient: SessionSignaling {
 
     func recordPong() {
         lastPongAtMs = clock.nowMs()
+        pongSeq += 1
         missedPongs = 0
+    }
+
+    func forcePingWithDeadline(timeoutMs: Int) {
+        guard connected, let kind = activeTransport else { return }
+        clearForcePing()
+
+        let attemptId = activeAttemptId
+        let pongSeqAtPing = pongSeq
+        send(SignalingMessage(type: "ping"))
+
+        forcePingTask = Task { [weak self] in
+            guard let self else { return }
+            try? await self.clock.sleep(nanoseconds: UInt64(max(timeoutMs, 0)) * 1_000_000)
+            if Task.isCancelled { return }
+            guard self.isAttemptActive(attemptId: attemptId, kind: kind) else { return }
+            guard self.connected else { return }
+            if self.pongSeq > pongSeqAtPing { return }
+            self.handleTransportClosed(attemptId: attemptId, kind: kind, reason: "foreground_force_ping_timeout")
+        }
+    }
+
+    private func clearForcePing() {
+        forcePingTask?.cancel()
+        forcePingTask = nil
     }
 
     private func startPing() {

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -225,6 +225,14 @@ public protocol SignalingProvider: AnyObject {
     func sendToPeer(_ peerId: String, type: String, payload: SignalingPayload?)
     func broadcast(type: String, payload: SignalingPayload?)
     func getIceServers() async throws -> [IceServerConfig]
+
+    /// Hook the SDK calls when the host app returns to foreground after a
+    /// background period long enough that the OS may have silently killed
+    /// the underlying transport. The expected behavior for transport-owning
+    /// providers is to send a synthetic ping and arm a `timeoutMs` deadline,
+    /// then force-close the transport on miss so the normal reconnect path
+    /// runs. Default is no-op for providers that manage their own lifecycle.
+    func forceReconnectIfStale(timeoutMs: Int)
 }
 
 public extension SignalingProvider {
@@ -234,4 +242,6 @@ public extension SignalingProvider {
     func joinRoom(_ roomId: String) {
         joinRoom(roomId, options: JoinOptions())
     }
+
+    func forceReconnectIfStale(timeoutMs: Int) {}
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSessionSignaling.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSessionSignaling.swift
@@ -9,6 +9,7 @@ final class FakeSessionSignaling: SessionSignaling {
     private(set) var sentMessages: [SignalingMessage] = []
     private(set) var closeCalls = 0
     private(set) var recordPongCalls = 0
+    private(set) var forcePingTimeouts: [Int] = []
     var connected = false
 
     func connect(host: String) {
@@ -30,6 +31,10 @@ final class FakeSessionSignaling: SessionSignaling {
 
     func recordPong() {
         recordPongCalls += 1
+    }
+
+    func forcePingWithDeadline(timeoutMs: Int) {
+        forcePingTimeouts.append(timeoutMs)
     }
 
     func clearSentMessages() {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSignalingTransport.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSignalingTransport.swift
@@ -50,4 +50,8 @@ final class FakeSignalingTransport: SignalingTransport {
     func simulateMessage(_ message: SignalingMessage) {
         onMessage?(message)
     }
+
+    func clearSentMessages() {
+        sentMessages.removeAll()
+    }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SignalingClientForcePingTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SignalingClientForcePingTests.swift
@@ -1,0 +1,157 @@
+/// Tests for SignalingClient.forcePingWithDeadline (resilience #8).
+///
+/// Verifies that the foreground force-ping path sends a synthetic ping,
+/// closes the transport when no pong arrives within the deadline, and
+/// stays no-op when not connected.
+
+import XCTest
+@testable import SerenadaCore
+
+@MainActor
+final class SignalingClientForcePingTests: XCTestCase {
+
+    private var transports: [FakeSignalingTransport] = []
+    private var client: SignalingClient!
+    private var listener: RecordingListener!
+    private var fakeClock: FakeSessionClock!
+
+    override func setUp() {
+        transports = []
+        listener = RecordingListener()
+        fakeClock = FakeSessionClock()
+        client = SignalingClient(clock: fakeClock, transportFactory: { [self] kind in
+            let t = FakeSignalingTransport(kind: kind)
+            self.transports.append(t)
+            return t
+        })
+        client.listener = listener
+    }
+
+    override func tearDown() {
+        client.close()
+        client = nil
+        listener = nil
+        transports = []
+    }
+
+    private func settle() async {
+        for _ in 0..<20 { await Task.yield() }
+    }
+
+    private var wsTransport: FakeSignalingTransport? {
+        transports.first { $0.kind == .ws }
+    }
+
+    private func connectAndOpen() async {
+        client.connect(host: "example.com")
+        await settle()
+        wsTransport?.simulateOpen()
+        await settle()
+        XCTAssertTrue(client.isConnected())
+        wsTransport?.clearSentMessages()
+    }
+
+    func testForcePingSendsSyntheticPingImmediately() async {
+        await connectAndOpen()
+
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await settle()
+
+        let pings = wsTransport?.sentMessages.filter { $0.type == "ping" } ?? []
+        XCTAssertEqual(pings.count, 1)
+    }
+
+    func testForcePingClosesTransportWhenPongDoesNotArrive() async {
+        await connectAndOpen()
+
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await settle()
+
+        // Advance past deadline without a pong.
+        await fakeClock.advance(byMs: 2_500)
+        await settle()
+
+        XCTAssertFalse(client.isConnected())
+        XCTAssertEqual(listener.closeReasons, ["foreground_force_ping_timeout"])
+    }
+
+    func testForcePingDoesNotCloseWhenPongArrives() async {
+        await connectAndOpen()
+
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await settle()
+
+        // Pong arrives well before deadline.
+        client.recordPong()
+
+        // Advance past deadline.
+        await fakeClock.advance(byMs: 2_500)
+        await settle()
+
+        XCTAssertTrue(client.isConnected())
+        XCTAssertTrue(listener.closeReasons.isEmpty)
+    }
+
+    func testForcePingIsNoOpWhenNotConnected() async {
+        // Never connected.
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await fakeClock.advance(byMs: 2_500)
+        await settle()
+
+        let ws = transports.first { $0.kind == .ws }
+        XCTAssertEqual(ws?.sentMessages.count ?? 0, 0)
+        XCTAssertTrue(listener.closeReasons.isEmpty)
+    }
+
+    func testForcePingCalledTwiceCancelsEarlierDeadline() async {
+        await connectAndOpen()
+
+        client.forcePingWithDeadline(timeoutMs: 5_000)
+        await settle()
+        // Advance partway, then issue a fresh force-ping with a new deadline.
+        await fakeClock.advance(byMs: 1_000)
+        await settle()
+
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await settle()
+        // Pong arrives before the second deadline (and well before the first).
+        client.recordPong()
+        await fakeClock.advance(byMs: 2_500)
+        await settle()
+
+        XCTAssertTrue(client.isConnected())
+        XCTAssertTrue(listener.closeReasons.isEmpty)
+    }
+
+    func testForcePingAfterCloseIsNoOp() async {
+        await connectAndOpen()
+        client.close()
+        await settle()
+        wsTransport?.clearSentMessages()
+
+        client.forcePingWithDeadline(timeoutMs: 2_000)
+        await fakeClock.advance(byMs: 2_500)
+        await settle()
+
+        XCTAssertEqual(wsTransport?.sentMessages.count ?? 0, 0)
+    }
+}
+
+@MainActor
+private final class RecordingListener: SignalingClientListener {
+    var openTransports: [String] = []
+    var messages: [SignalingMessage] = []
+    var closeReasons: [String] = []
+
+    func onOpen(activeTransport: String) {
+        openTransports.append(activeTransport)
+    }
+
+    func onMessage(_ message: SignalingMessage) {
+        messages.append(message)
+    }
+
+    func onClosed(reason: String) {
+        closeReasons.append(reason)
+    }
+}

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		C8363EE39A1335203566D71B /* RoomStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */; };
 		CAD139965FF8325D89A8113A /* ErrorScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AA70D76623801E762E2DB /* ErrorScreen.swift */; };
 		CB94D71B6D37742D4EAAC565 /* SessionOrchestrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */; };
+		CC3D167A630FB82F98509DDF /* SignalingClientForcePingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2A1B8AEF0CE257BBAB5F0F /* SignalingClientForcePingTests.swift */; };
 		CEEA0CFAF57BC2B4A48F8441 /* DeepLinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BC48440A4DD113050C3E29 /* DeepLinkParserTests.swift */; };
 		D05E6EDD64E9A169FF7DAD21 /* SerenadaCoreProviderModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF59DDD3EB32D08B6F0B913 /* SerenadaCoreProviderModeTests.swift */; };
 		D137590CDB7A1FC9C94D3F74 /* SignalingClientFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62ED85E9C29EE8FB7BC0806 /* SignalingClientFallbackTests.swift */; };
@@ -226,6 +227,7 @@
 		FCB3288DA9DF528251D2A52D /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
 		FD06F6B1E706207C4ED2D7DD /* SignalingPayloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingPayloadsTests.swift; sourceTree = "<group>"; };
 		FD2E85BAF2302D3C1569C2E5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FF2A1B8AEF0CE257BBAB5F0F /* SignalingClientForcePingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingClientForcePingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -418,6 +420,7 @@
 				8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */,
 				09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */,
 				C62ED85E9C29EE8FB7BC0806 /* SignalingClientFallbackTests.swift */,
+				FF2A1B8AEF0CE257BBAB5F0F /* SignalingClientForcePingTests.swift */,
 				1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */,
 				FD06F6B1E706207C4ED2D7DD /* SignalingPayloadsTests.swift */,
 				DA4E5581F6502FD66EEAB5CD /* Fakes */,
@@ -825,6 +828,7 @@
 				CB94D71B6D37742D4EAAC565 /* SessionOrchestrationTests.swift in Sources */,
 				90E4D65F01CB4CBE8E6CA6EF /* SessionTestHarness.swift in Sources */,
 				D137590CDB7A1FC9C94D3F74 /* SignalingClientFallbackTests.swift in Sources */,
+				CC3D167A630FB82F98509DDF /* SignalingClientForcePingTests.swift in Sources */,
 				60DD419576BB73E40DC4D993 /* SignalingMessageTests.swift in Sources */,
 				887A6F874A06A47C37E73A85 /* SignalingPayloadsTests.swift in Sources */,
 			);

--- a/client/packages/core/src/constants.ts
+++ b/client/packages/core/src/constants.ts
@@ -35,6 +35,12 @@ export const ENDING_SCREEN_MS = 3000;
 // Snapshot
 export const SNAPSHOT_PREPARE_TIMEOUT_MS = 2000;
 
+// Foreground / Doze recovery
+// After the app returns to foreground from background, the SDK issues a
+// synthetic ping and waits this long for a pong before force-closing the
+// transport and triggering the normal reconnect path.
+export const FOREGROUND_FORCE_PING_TIMEOUT_MS = 2000;
+
 // Connection Status
 export const CONNECTION_RETRYING_DELAY_MS = 10_000;
 

--- a/docs/resilience-failure-modes.md
+++ b/docs/resilience-failure-modes.md
@@ -1,6 +1,6 @@
 # Resilience Failure Modes — Audit & Fix Plan
 
-**Status:** Phase 1 implemented; Phase 2 partial (process-death recovery #5 landed end-to-end; #8/#10 in flight).
+**Status:** Phase 1 implemented; Phase 2 partial (process-death recovery #5 and foreground/Doze force-ping #8 landed end-to-end; #6/#7/#10 outstanding).
 **Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed) · 2026-04-26 (Phase 2 partial landed)
 **Scope:** Web, Android, iOS SDKs and the Go signaling server
 
@@ -67,7 +67,7 @@ must preserve the core UX model:
 | 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      | Phase 2 ✅ (server `POST /api/leave` + per-platform recovery store + rejoin API) |
 | 6 | No explicit "you are suspended / about to be evicted"     | UI can't show countdown; apps can't make smart choices    | Medium   | S      | Phase 2 |
 | 7 | SSE transport hijack via SID reuse                        | Security: another connection can take over an SSE session | Critical | S      | Phase 2 — server `TODO(#7)` placed; needs SDK `resumeSse` first |
-| 8 | iOS background suspension keeps SDK in stale "connected"  | After long background, signaling appears alive but isn't  | High     | M      | Phase 2 |
+| 8 | iOS background suspension keeps SDK in stale "connected"  | After long background, signaling appears alive but isn't  | High     | M      | Phase 2 ✅ |
 | 9 | TURN credentials expire while signaling is down           | Relay path fails; cannot recover even when signaling back | Medium   | S      | Phase 3 |
 | 10| Push-to-rejoin races with local cleanup                   | Duplicate sessions, ghost slot on server                  | High     | M      | Phase 2 |
 | 11| `end_room` doesn't notify suspended peers                 | Suspended peer reconnect-loops a dead room                | Medium   | XS     | Phase 1 ✅ (tombstone + ROOM_ENDED) |
@@ -746,7 +746,17 @@ behind a server feature flag for one release; clients gain `resumeSse` first.
 
 ## 8. iOS background suspension keeps SDK in stale "connected" state
 
-**Status (2026-04-25):** Not started — Phase 2.
+**Status (2026-04-26):** Landed end-to-end. Both iOS and Android SDKs
+auto-detect foreground transitions after a ≥ 5 s background and call a
+new `signalingProvider.forceReconnectIfStale(timeoutMs:)` hook that
+sends a synthetic ping, arms a `foregroundForcePingTimeoutMs = 2_000`
+deadline, and force-closes the transport on miss so the existing
+reconnect path runs. iOS observes `UIApplication.willEnterForeground`
+notifications; Android tracks Activity start/stop counts via
+`Application.ActivityLifecycleCallbacks` (no new dependency on
+`lifecycle-process`). The internal `SessionSignaling.forcePingWithDeadline`
+uses a monotonic pong-sequence counter so the deadline arms the close
+only when no pong arrives between ping and timeout.
 
 ### Symptom
 
@@ -1411,6 +1421,69 @@ Out of scope for this document, listed for visibility:
   it deserves a fresh look.
 
 ## Change Log
+
+### 2026-04-26 — Phase 2 partial: foreground / Doze force-ping (#8)
+
+- **Shared resilience constants**: New
+  `foregroundForcePingTimeoutMs = 2_000` added to all three SDKs
+  (`client/packages/core/src/constants.ts`,
+  `client-android/.../call/WebRtcResilienceConstants.kt`,
+  `client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift`)
+  and surfaced in `scripts/check-resilience-constants.mjs`'s parity check
+  (now 19 cross-platform constants).
+
+- **iOS SDK**: `SessionSignaling` gains a `forcePingWithDeadline(timeoutMs:)`
+  hook with a default no-op extension; `SignalingClient` implements it by
+  sending a synthetic ping, recording a monotonic `pongSeq` snapshot, and
+  arming a deadline `Task` that calls `handleTransportClosed` with reason
+  `foreground_force_ping_timeout` on miss. `SignalingProvider` gets a
+  matching public `forceReconnectIfStale(timeoutMs:)` (default no-op) so
+  custom providers can opt out; `SerenadaServerProvider` forwards to the
+  signaling client. `SerenadaSession` subscribes to
+  `UIApplication.didEnterBackground` / `willEnterForeground` notifications
+  in `startNetworkMonitoring`, tracks `lastBackgroundedAtMs`, and on
+  foreground transitions where the app was backgrounded for
+  ≥ `foregroundResumeMinBackgroundMs = 5_000` and the call is in
+  `joining` / `waiting` / `inCall`, calls
+  `signalingProvider.forceReconnectIfStale(timeoutMs:)`. Observers are
+  removed in `deinit`.
+
+- **Android SDK**: `SessionSignaling` gains a default-no-op
+  `forcePingWithDeadline(timeoutMs: Long)`; `SignalingClient` implements it
+  with the same monotonic `pongSeq` discipline and posts a `Runnable`
+  through the session handler that closes the transport with
+  `foreground_force_ping_timeout` on miss. `SignalingProvider` gains a
+  default-no-op `forceReconnectIfStale(timeoutMs:)`;
+  `SerenadaServerProvider` forwards. `SerenadaSession` registers an
+  `Application.ActivityLifecycleCallbacks` (no new
+  `lifecycle-process` dependency) that counts started Activities;
+  transitions from 0 → 1 are treated as foreground and from 1 → 0 as
+  background. Same 5_000 ms minimum-background threshold as iOS. The
+  observer is registered/unregistered alongside the existing connectivity
+  network callback.
+
+- **Tests**:
+  - iOS `SignalingClientForcePingTests` (6 tests, xcodebuild green) covers
+    ping emission, deadline-miss closes the transport, pong-arrival
+    cancels the close, no-op while disconnected, repeated calls cancel
+    earlier deadlines, and post-close calls stay no-op.
+  - Android `SignalingClientForcePingTest` (6 tests, Robolectric, gradle
+    green) mirrors the iOS matrix with `ShadowLooper` time advancement.
+  - `scripts/check-resilience-constants.mjs` and
+    `scripts/check-version-parity.mjs` green.
+
+- **Deferred (still Phase 2)**:
+  - **#6 explicit suspension state surface** — needs the
+    `peerSuspendedUiTimeoutMs` / `suspendHardEvictionTimeoutMs` /
+    `epochResyncTimeoutMs` shared constants and the
+    `SignalingState.suspended` model on top of the constants this slice
+    added. Tracked for a follow-up slice.
+  - **#7 SSE transport hijack** — server `TODO(#7)` still in place; the
+    SDK `resumeSse` envelope and pending-session model is the remaining
+    piece.
+  - **#10 lifecycle serialization on `CallManager`** and **#10 deep-link
+    guard ("switch call?" prompt)** — both deferred to product/UX work
+    on the host apps.
 
 ### 2026-04-26 — Phase 2 partial: process-death recovery (#5)
 


### PR DESCRIPTION
When iOS suspends a backgrounded process or Android puts it in Doze, the
WebSocket can be silently killed without the SDK noticing. Today the only
detection is the regular ping cycle, so the SDK reports `connected` for
up to `pingIntervalMs = 12 s` after the app comes back. This adds an
explicit foreground hook that issues a synthetic ping and arms a 2 s
deadline, force-closing the transport on miss so the existing reconnect
path runs immediately.

- Shared `foregroundForcePingTimeoutMs = 2_000` constant lands in all
  three SDKs and the parity check.
- iOS subscribes to `UIApplication.willEnterForeground` /
  `didEnterBackground`; Android tracks Activity start/stop counts via
  `Application.ActivityLifecycleCallbacks` (no new dep on
  `lifecycle-process`).
- `SignalingProvider.forceReconnectIfStale(timeoutMs:)` is the new
  public hook (default no-op); `SessionSignaling.forcePingWithDeadline`
  is the internal one.
- `SignalingClient` uses a monotonic `pongSeq` counter so the deadline
  arms close only when no pong arrives between ping and timeout —
  robust against same-ms test clocks.

Tests: 6 iOS + 6 Android cover ping emission, deadline-miss close,
pong-arrival cancel, no-op when disconnected, repeated calls cancel
prior deadlines, and post-close calls stay no-op.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>