### PR TITLE
Fix stale aspect on remote SurfaceViewRenderer (Android 9)

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -390,7 +390,11 @@ internal class WebRtcEngine(
             return
         }
         renderer.init(eglBase.eglBaseContext, rendererEvents)
-        renderer.setEnableHardwareScaler(true)
+        // Hardware scaler issues setFixedSize(...) with a buffer smaller than the view.
+        // On Android 9 / older SurfaceFlinger this leaves the surface anchored at top-left
+        // after a remote resolution change, producing a black bar on the right until the
+        // next forced layout pass. Sizing the buffer from layout avoids the race.
+        renderer.setEnableHardwareScaler(false)
     }
 
     private fun applyAudioTrackHints() {


### PR DESCRIPTION
## Summary
- Disable WebRTC's hardware scaler on `SurfaceViewRenderer` instances in `WebRtcEngine.initRenderer`. With the scaler on, each remote resolution change calls `SurfaceHolder.setFixedSize()` with a buffer smaller than the view; on Android 9 SurfaceFlinger then anchors the surface at the view's top-left instead of scaling it to fill, producing the black bar on the right edge reported in #76 until the next forced layout pass. Letting the buffer size follow the layout pushes aspect handling into the GL shader via `setLayoutAspectRatio`, eliminating the race. Fragment-shading at view resolution is well within capabilities of even 2017-era SoCs, so the perf cost is negligible.

Fixes #76

## Test plan
- [x] `./gradlew :serenada-core:compileDebugKotlin :serenada-call-ui:compileDebugKotlin`
- [x] `./gradlew :serenada-core:testDebugUnitTest`
- [ ] Manual: place a video call from a Galaxy S8 (Android 9) and confirm the remote tile no longer drops into the broken framing after a renegotiation / resolution change

🤖 Generated with [Claude Code](https://claude.com/claude-code)