### PR TITLE
Add host-supplied avatars to call UI

### DIFF
--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AvatarProvider.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AvatarProvider.kt
@@ -21,7 +21,7 @@ fun interface AvatarProvider {
 
 /** Image payload returned by an [AvatarProvider]. */
 sealed class AvatarSource {
-    /** A remote URL that the call UI loads via the host's image-loading stack. */
+    /** A remote URL that the call UI fetches and decodes itself (no host image-loading library required). */
     data class Url(val url: String) : AvatarSource()
 
     /** Encoded image bytes (e.g. JPEG, PNG); decoded once at render time. */

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AvatarProvider.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AvatarProvider.kt
@@ -1,0 +1,40 @@
+package app.serenada.callui
+
+import android.graphics.Bitmap
+
+/**
+ * Resolves an avatar for a remote participant's host-supplied `peerId` (passed to
+ * `SerenadaCore.join`). The call UI renders the returned avatar cover-fit, cropped
+ * to a circle above the participant's name when their remote video track is off.
+ *
+ * Behavior:
+ * - Each `peerId` is resolved at most once per call and cached for the call's lifetime.
+ * - Called lazily on the first frame the placeholder is needed — silent peers don't
+ *   trigger a fetch.
+ * - Returning `null` or throwing falls back to an initials placeholder.
+ * - The call UI never blocks on the resolver; it shows initials immediately and
+ *   swaps in the avatar when the suspend function returns.
+ */
+fun interface AvatarProvider {
+    suspend fun resolve(peerId: String): AvatarSource?
+}
+
+/** Image payload returned by an [AvatarProvider]. */
+sealed class AvatarSource {
+    /** A remote URL that the call UI loads via the host's image-loading stack. */
+    data class Url(val url: String) : AvatarSource()
+
+    /** Encoded image bytes (e.g. JPEG, PNG); decoded once at render time. */
+    data class Bytes(val bytes: ByteArray) : AvatarSource() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Bytes) return false
+            return bytes.contentEquals(other.bytes)
+        }
+
+        override fun hashCode(): Int = bytes.contentHashCode()
+    }
+
+    /** A pre-decoded bitmap. */
+    data class Bitmap(val bitmap: android.graphics.Bitmap) : AvatarSource()
+}

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -286,7 +286,10 @@ internal fun CallScreen(
         }
     }
 
+    val avatarCache = rememberAvatarCache(config.avatarProvider)
+
     SerenadaTheme(theme) {
+      androidx.compose.runtime.CompositionLocalProvider(LocalAvatarCache provides avatarCache) {
         BoxWithConstraints(
             modifier =
                 Modifier.fillMaxSize().background(theme.backgroundColor)
@@ -543,6 +546,7 @@ internal fun CallScreen(
                     text = text,
                     fontSize = if (isLocalLarge) 10.sp else 16.sp,
                     displayName = nameToShow,
+                    peerId = remoteP?.peerId,
                 )
             }
         }
@@ -810,6 +814,7 @@ internal fun CallScreen(
             }
         }
         }
+      }
     }
 }
 
@@ -1852,6 +1857,7 @@ private fun RemoteParticipantStageTile(
                     text = resolveString(SerenadaString.CallVideoOff, strings),
                     fontSize = 14.sp,
                     displayName = participant.displayName,
+                    peerId = participant.peerId,
                 )
             }
         }
@@ -2135,22 +2141,40 @@ private fun VideoPlaceholder(
     text: String,
     fontSize: androidx.compose.ui.unit.TextUnit = 16.sp,
     displayName: String? = null,
+    peerId: String? = null,
 ) {
+    val avatarCache = LocalAvatarCache.current
+    val isLargeTile = fontSize >= 14.sp
+    val avatarSize = if (isLargeTile) 96.dp else 56.dp
+    val avatarFontSize = if (isLargeTile) 36.sp else 22.sp
     Box(
         modifier = Modifier.fillMaxSize().background(Color(0xFF111111)),
         contentAlignment = Alignment.Center
     ) {
         if (displayName != null) {
-            Text(
-                text = displayName,
-                color = Color.White.copy(alpha = 0.85f),
-                fontSize = 18.sp,
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.Center,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.padding(horizontal = 16.dp),
-            )
+            ) {
+                if (avatarCache != null) {
+                    RemoteAvatar(
+                        peerId = peerId,
+                        displayName = displayName,
+                        size = avatarSize,
+                        fontSize = avatarFontSize,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+                Text(
+                    text = displayName,
+                    color = Color.White.copy(alpha = 0.85f),
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         } else {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
@@ -146,9 +146,18 @@ internal fun RemoteAvatar(
 
 internal fun initialsFor(displayName: String?): String {
     if (displayName.isNullOrBlank()) return ""
-    val parts = displayName.trim().split(Regex("\\s+"))
-    val first = parts.first().firstOrNull()?.toString() ?: return ""
-    if (parts.size == 1) return first.uppercase()
-    val last = parts.last().firstOrNull()?.toString() ?: ""
-    return (first + last).uppercase()
+    val initials = mutableListOf<String>()
+    for (part in displayName.trim().split(Regex("\\s+"))) {
+        for (ch in part) {
+            if (ch.isLetterOrDigit()) {
+                initials.add(ch.toString().uppercase())
+                break
+            }
+        }
+    }
+    return when {
+        initials.isEmpty() -> ""
+        initials.size == 1 -> initials.first()
+        else -> initials.first() + initials.last()
+    }
 }

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
@@ -10,10 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -27,8 +24,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Text
 import java.net.HttpURLConnection
 import java.net.URL
@@ -56,9 +51,13 @@ internal class AvatarCache(private val provider: AvatarProvider?) {
         entries[peerId] = state
         if (provider != null && pending.add(peerId)) {
             scope.launch {
+                // Hop off the main thread before invoking the host's provider so any
+                // sync work it does before its first suspension point doesn't jank the UI.
                 val bitmap = runCatching {
-                    val source = provider.resolve(peerId) ?: return@runCatching null
-                    materialize(source)
+                    withContext(Dispatchers.IO) {
+                        val source = provider.resolve(peerId) ?: return@withContext null
+                        materialize(source)
+                    }
                 }.onFailure { error ->
                     Log.w("Serenada", "avatarProvider failed for $peerId", error)
                 }.getOrNull()
@@ -74,12 +73,10 @@ internal class AvatarCache(private val provider: AvatarProvider?) {
         pending.clear()
     }
 
-    private suspend fun materialize(source: AvatarSource): Bitmap? = withContext(Dispatchers.IO) {
-        when (source) {
-            is AvatarSource.Bitmap -> source.bitmap
-            is AvatarSource.Bytes -> BitmapFactory.decodeByteArray(source.bytes, 0, source.bytes.size)
-            is AvatarSource.Url -> fetchBitmap(source.url)
-        }
+    private fun materialize(source: AvatarSource): Bitmap? = when (source) {
+        is AvatarSource.Bitmap -> source.bitmap
+        is AvatarSource.Bytes -> BitmapFactory.decodeByteArray(source.bytes, 0, source.bytes.size)
+        is AvatarSource.Url -> fetchBitmap(source.url)
     }
 
     private fun fetchBitmap(urlString: String): Bitmap? {

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
@@ -1,0 +1,154 @@
+package app.serenada.callui
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Lazily resolves and caches avatars for the lifetime of the call UI.
+ * Each `peerId` is sent through [AvatarProvider.resolve] at most once per call,
+ * with the result (decoded [Bitmap] or null) cached for the rest of the call.
+ */
+internal class AvatarCache(private val provider: AvatarProvider?) {
+    private val entries = mutableMapOf<String, MutableState<Bitmap?>>()
+    private val pending = mutableSetOf<String>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    fun get(peerId: String): MutableState<Bitmap?> {
+        val existing = entries[peerId]
+        if (existing != null) return existing
+        val state = mutableStateOf<Bitmap?>(null)
+        entries[peerId] = state
+        if (provider != null && pending.add(peerId)) {
+            scope.launch {
+                val bitmap = runCatching {
+                    val source = provider.resolve(peerId) ?: return@runCatching null
+                    materialize(source)
+                }.onFailure { error ->
+                    Log.w("Serenada", "avatarProvider failed for $peerId", error)
+                }.getOrNull()
+                state.value = bitmap
+            }
+        }
+        return state
+    }
+
+    fun release() {
+        scope.cancel()
+        entries.clear()
+        pending.clear()
+    }
+
+    private suspend fun materialize(source: AvatarSource): Bitmap? = withContext(Dispatchers.IO) {
+        when (source) {
+            is AvatarSource.Bitmap -> source.bitmap
+            is AvatarSource.Bytes -> BitmapFactory.decodeByteArray(source.bytes, 0, source.bytes.size)
+            is AvatarSource.Url -> fetchBitmap(source.url)
+        }
+    }
+
+    private fun fetchBitmap(urlString: String): Bitmap? {
+        val connection = (URL(urlString).openConnection() as? HttpURLConnection) ?: return null
+        return try {
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 10_000
+            connection.instanceFollowRedirects = true
+            connection.inputStream.use(BitmapFactory::decodeStream)
+        } finally {
+            connection.disconnect()
+        }
+    }
+}
+
+internal val LocalAvatarCache = staticCompositionLocalOf<AvatarCache?> { null }
+
+@Composable
+internal fun rememberAvatarCache(provider: AvatarProvider?): AvatarCache {
+    val cache = remember(provider) { AvatarCache(provider) }
+    DisposableEffect(cache) {
+        onDispose { cache.release() }
+    }
+    return cache
+}
+
+@Composable
+internal fun RemoteAvatar(
+    peerId: String?,
+    displayName: String?,
+    size: Dp,
+    fontSize: TextUnit,
+) {
+    val cache = LocalAvatarCache.current
+    val bitmapState = if (peerId != null && cache != null) cache.get(peerId) else null
+    val bitmap = bitmapState?.value
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(Color(0xFF2A2A2A)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(size),
+            )
+        } else {
+            Text(
+                text = initialsFor(displayName).ifBlank { "•" },
+                color = Color.White.copy(alpha = 0.85f),
+                style = TextStyle(
+                    fontSize = fontSize,
+                    fontWeight = FontWeight.SemiBold,
+                ),
+            )
+        }
+    }
+}
+
+internal fun initialsFor(displayName: String?): String {
+    if (displayName.isNullOrBlank()) return ""
+    val parts = displayName.trim().split(Regex("\\s+"))
+    val first = parts.first().firstOrNull()?.toString() ?: return ""
+    if (parts.size == 1) return first.uppercase()
+    val last = parts.last().firstOrNull()?.toString() ?: ""
+    return (first + last).uppercase()
+}

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/RemoteAvatar.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private const val AVATAR_FETCH_TIMEOUT_MS = 10_000
+
 /**
  * Lazily resolves and caches avatars for the lifetime of the call UI.
  * Each `peerId` is sent through [AvatarProvider.resolve] at most once per call,
@@ -41,22 +43,19 @@ import kotlinx.coroutines.withContext
  */
 internal class AvatarCache(private val provider: AvatarProvider?) {
     private val entries = mutableMapOf<String, MutableState<Bitmap?>>()
-    private val pending = mutableSetOf<String>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     fun get(peerId: String): MutableState<Bitmap?> {
-        val existing = entries[peerId]
-        if (existing != null) return existing
+        entries[peerId]?.let { return it }
         val state = mutableStateOf<Bitmap?>(null)
         entries[peerId] = state
-        if (provider != null && pending.add(peerId)) {
+        if (provider != null) {
             scope.launch {
-                // Hop off the main thread before invoking the host's provider so any
-                // sync work it does before its first suspension point doesn't jank the UI.
                 val bitmap = runCatching {
+                    // Hop off the main thread so a host's pre-suspension sync work
+                    // doesn't jank the UI.
                     withContext(Dispatchers.IO) {
-                        val source = provider.resolve(peerId) ?: return@withContext null
-                        materialize(source)
+                        provider.resolve(peerId)?.let(::materialize)
                     }
                 }.onFailure { error ->
                     Log.w("Serenada", "avatarProvider failed for $peerId", error)
@@ -70,7 +69,6 @@ internal class AvatarCache(private val provider: AvatarProvider?) {
     fun release() {
         scope.cancel()
         entries.clear()
-        pending.clear()
     }
 
     private fun materialize(source: AvatarSource): Bitmap? = when (source) {
@@ -82,8 +80,8 @@ internal class AvatarCache(private val provider: AvatarProvider?) {
     private fun fetchBitmap(urlString: String): Bitmap? {
         val connection = (URL(urlString).openConnection() as? HttpURLConnection) ?: return null
         return try {
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 10_000
+            connection.connectTimeout = AVATAR_FETCH_TIMEOUT_MS
+            connection.readTimeout = AVATAR_FETCH_TIMEOUT_MS
             connection.instanceFollowRedirects = true
             connection.inputStream.use(BitmapFactory::decodeStream)
         } finally {

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlowConfig.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlowConfig.kt
@@ -10,4 +10,11 @@ data class SerenadaCallFlowConfig(
      * `false`, the controls are always visible and the idle timer never runs.
      */
     val autoHideControls: Boolean = true,
+    /**
+     * Optional resolver that returns an avatar for a remote participant's
+     * host-supplied `peerId` (passed to `SerenadaCore.join`). When unset or
+     * when `peerId` is absent on the participant, the call UI shows an
+     * initials placeholder derived from their display name.
+     */
+    val avatarProvider: AvatarProvider? = null,
 )

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -38,8 +38,12 @@ class SerenadaCore(
 
     /**
      * Join a call using a full URL (e.g., "https://serenada.app/call/ABC123").
+     *
+     * @param peerId optional host-supplied stable identity for this user (distinct from
+     *   the per-call client ID). Surfaced on remote participants so the call UI can
+     *   resolve avatars via [SerenadaCallFlowConfig.avatarProvider].
      */
-    fun join(url: String, displayName: String? = null): SerenadaSession {
+    fun join(url: String, displayName: String? = null, peerId: String? = null): SerenadaSession {
         assertMainThread()
         val resolved = resolveRoomUrl(url)
         val roomId = resolved?.roomId ?: url
@@ -54,6 +58,7 @@ class SerenadaCore(
             initialSignalingProvider = createSignalingProvider(sessionConfig),
             logger = logger,
             displayName = displayName,
+            peerId = peerId,
         )
         session.start()
         return session
@@ -61,8 +66,15 @@ class SerenadaCore(
 
     /**
      * Join a call using a room ID.
+     *
+     * @param peerId optional host-supplied stable identity — see the URL [join] overload.
      */
-    fun join(roomId: String, serverHost: String? = resolvedConfig.serverHost, displayName: String? = null): SerenadaSession {
+    fun join(
+        roomId: String,
+        serverHost: String? = resolvedConfig.serverHost,
+        displayName: String? = null,
+        peerId: String? = null,
+    ): SerenadaSession {
         assertMainThread()
         val sessionConfig = sessionConfigFor(serverHost)
         val roomUrl = resolvedConfig.serverHost?.let { buildRoomUrl(serverHost ?: it, roomId) }
@@ -76,6 +88,7 @@ class SerenadaCore(
             initialSignalingProvider = createSignalingProvider(sessionConfig),
             logger = logger,
             displayName = displayName,
+            peerId = peerId,
         )
         session.start()
         return session

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -68,6 +68,7 @@ internal class SerenadaServerProvider(
     private var closedByClient = false
     private var pendingJoinRoomId: String? = null
     private var currentDisplayName: String? = null
+    private var currentAppPeerId: String? = null
 
     override fun connect() {
         closedByClient = false
@@ -91,6 +92,9 @@ internal class SerenadaServerProvider(
         currentReconnectPeerId = options.reconnectPeerId
         if (options.displayName != null) {
             currentDisplayName = options.displayName
+        }
+        if (options.appPeerId != null) {
+            currentAppPeerId = options.appPeerId
         }
         if (signaling.isConnected()) {
             pendingJoinRoomId = null
@@ -227,6 +231,7 @@ internal class SerenadaServerProvider(
                 peerId = participant.cid,
                 joinedAt = participant.joinedAt,
                 displayName = participant.displayName,
+                appPeerId = participant.peerId,
                 audioEnabled = participant.audioEnabled,
                 videoEnabled = participant.videoEnabled,
                 connectionStatus = participant.signalingStatus,
@@ -253,6 +258,7 @@ internal class SerenadaServerProvider(
                 peerId = participant.cid,
                 joinedAt = participant.joinedAt,
                 displayName = participant.displayName,
+                appPeerId = participant.peerId,
                 audioEnabled = participant.audioEnabled,
                 videoEnabled = participant.videoEnabled,
                 connectionStatus = participant.signalingStatus,
@@ -275,12 +281,12 @@ internal class SerenadaServerProvider(
         val nextParticipants = participants.associateBy { it.peerId }
         for ((peerId, participant) in nextParticipants) {
             if (!previousParticipants.containsKey(peerId)) {
-                listener?.onPeerJoined(PeerEvent(peerId = peerId, joinedAt = participant.joinedAt, displayName = participant.displayName))
+                listener?.onPeerJoined(PeerEvent(peerId = peerId, joinedAt = participant.joinedAt, displayName = participant.displayName, appPeerId = participant.appPeerId))
             }
         }
         for ((peerId, participant) in previousParticipants) {
             if (!nextParticipants.containsKey(peerId)) {
-                listener?.onPeerLeft(PeerEvent(peerId = peerId, joinedAt = participant.joinedAt, displayName = participant.displayName))
+                listener?.onPeerLeft(PeerEvent(peerId = peerId, joinedAt = participant.joinedAt, displayName = participant.displayName, appPeerId = participant.appPeerId))
             }
         }
     }
@@ -303,6 +309,7 @@ internal class SerenadaServerProvider(
             )
             put("createMaxParticipants", currentMaxParticipants)
             currentDisplayName?.let { put("displayName", it) }
+            currentAppPeerId?.let { put("peerId", it) }
             reconnectToken?.let { put("reconnectToken", it) }
             currentReconnectPeerId?.let { put("reconnectCid", it) }
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -80,6 +80,7 @@ class SerenadaSession internal constructor(
     clock: SessionClock? = null,
     private val logger: SerenadaLogger? = null,
     private val displayName: String? = null,
+    private val peerId: String? = null,
 ) {
     private val appContext = context.applicationContext
     private val handler = Handler(Looper.getMainLooper())
@@ -148,7 +149,12 @@ class SerenadaSession internal constructor(
         joinRoom = { targetRoomId, reconnectPeerId ->
             signalingProvider.joinRoom(
                 targetRoomId,
-                JoinOptions(reconnectPeerId = reconnectPeerId, maxParticipants = 4, displayName = displayName),
+                JoinOptions(
+                    reconnectPeerId = reconnectPeerId,
+                    maxParticipants = 4,
+                    displayName = displayName,
+                    appPeerId = peerId,
+                ),
             )
         },
         onJoinTimeout = {
@@ -904,7 +910,12 @@ class SerenadaSession internal constructor(
         localPeerId: String?,
     ): RoomState? {
         val participants = dedupeParticipants(
-            (roomState?.participants ?: emptyList()) + Participant(cid = event.peerId, joinedAt = event.joinedAt),
+            (roomState?.participants ?: emptyList()) + Participant(
+                cid = event.peerId,
+                joinedAt = event.joinedAt,
+                displayName = event.displayName,
+                peerId = event.appPeerId,
+            ),
             localPeerId,
         )
         val host = roomState?.hostCid ?: localPeerId ?: participants.firstOrNull()?.cid ?: return null
@@ -1022,6 +1033,7 @@ class SerenadaSession internal constructor(
             RemoteParticipant(
                 cid = cid,
                 displayName = participant?.displayName,
+                peerId = participant?.peerId,
                 audioEnabled = peerState?.audioEnabled ?: participant?.audioEnabled ?: true,
                 videoEnabled = peerState?.videoEnabled ?: participant?.videoEnabled ?: slot.isRemoteVideoTrackEnabled(),
                 connectionState = SerenadaPeerConnectionState.fromRtcState(slot.getConnectionState()),

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
@@ -15,6 +15,12 @@ data class JoinOptions(
     val reconnectPeerId: String? = null,
     val maxParticipants: Int? = null,
     val displayName: String? = null,
+    /**
+     * Host-supplied stable identity for this user. Distinct from `peerId`/cid
+     * (per-call, server-issued) — lets host applications correlate a participant
+     * to their own user identity (avatar lookup, telemetry).
+     */
+    val appPeerId: String? = null,
 )
 
 /**
@@ -29,6 +35,8 @@ data class SignalingProviderParticipant(
     val peerId: String,
     val joinedAt: Long? = null,
     val displayName: String? = null,
+    /** Host-supplied stable identity — see [JoinOptions.appPeerId]. */
+    val appPeerId: String? = null,
     val audioEnabled: Boolean? = null,
     val videoEnabled: Boolean? = null,
     val connectionStatus: ParticipantSignalingStatus = ParticipantSignalingStatus.ACTIVE,
@@ -51,6 +59,8 @@ data class PeerEvent(
     val peerId: String,
     val joinedAt: Long? = null,
     val displayName: String? = null,
+    /** Host-supplied stable identity — see [JoinOptions.appPeerId]. */
+    val appPeerId: String? = null,
 )
 
 data class PeerMessage(

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
@@ -5,6 +5,12 @@ import app.serenada.core.ParticipantSignalingStatus
 data class RemoteParticipant(
     val cid: String,
     val displayName: String? = null,
+    /**
+     * Host-supplied stable identity passed to [SerenadaCore.join]'s `peerId`.
+     * Distinct from [cid] (per-call, server-issued). Surfaced for the call UI
+     * to look up avatars or correlate to host-side records.
+     */
+    val peerId: String? = null,
     val audioEnabled: Boolean = true,
     val videoEnabled: Boolean,
     val connectionState: SerenadaPeerConnectionState,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/RoomState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/RoomState.kt
@@ -12,6 +12,8 @@ internal data class Participant(
     val cid: String,
     val joinedAt: Long?,
     val displayName: String? = null,
+    /** Host-supplied stable identity; opaque to the SDK, surfaced for avatar lookup. */
+    val peerId: String? = null,
     val audioEnabled: Boolean? = null,
     val videoEnabled: Boolean? = null,
     val signalingStatus: ParticipantSignalingStatus = ParticipantSignalingStatus.ACTIVE,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
@@ -114,6 +114,7 @@ internal fun JSONArray?.toParticipantList(): List<Participant> {
                 cid = cid,
                 joinedAt = p.optLong("joinedAt").takeIf { it > 0 },
                 displayName = p.optString("displayName").ifBlank { null },
+                peerId = p.optString("peerId").ifBlank { null },
                 audioEnabled = if (p.has("audioEnabled")) p.optBoolean("audioEnabled") else null,
                 videoEnabled = if (p.has("videoEnabled")) p.optBoolean("videoEnabled") else null,
                 signalingStatus = status,

--- a/client-ios/SerenadaCallUI/Sources/AvatarProvider.swift
+++ b/client-ios/SerenadaCallUI/Sources/AvatarProvider.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+
+/// Resolves an avatar for a remote participant's host-supplied `peerId`
+/// (passed to `SerenadaCore.join`). The call UI renders the returned avatar
+/// cover-fit, cropped to a circle above the participant's name when their
+/// remote video track is off.
+///
+/// Behavior:
+/// - Each `peerId` is resolved at most once per call and cached for the call's lifetime.
+/// - Called lazily on the first frame the placeholder is needed — silent peers don't
+///   trigger a fetch.
+/// - Returning `nil` or throwing falls back to an initials placeholder.
+/// - The call UI never blocks on the resolver; it shows initials immediately and
+///   swaps in the avatar when the async function returns.
+public protocol AvatarProvider: Sendable {
+    func resolve(peerId: String) async -> AvatarSource?
+}
+
+/// Image payload returned by an `AvatarProvider`.
+public enum AvatarSource: Sendable {
+    /// A remote URL that the call UI will fetch with `URLSession`.
+    case url(URL)
+    /// Encoded image bytes (e.g. JPEG, PNG); decoded once at render time.
+    case data(Data)
+    /// A pre-decoded `UIImage`.
+    case image(UIImage)
+}

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -375,6 +375,8 @@ struct CallScreenView: View {
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
                 smallRemoteView
             } else {
+                let inCall = uiState.phase == .inCall
+                let firstRemote = uiState.remoteParticipants.first
                 ZStack(alignment: .bottomLeading) {
                     mainVideoSurface(
                         kind: .remote,
@@ -383,10 +385,11 @@ struct CallScreenView: View {
                             phase: uiState.phase,
                             remoteVideoEnabled: uiState.remoteVideoEnabled
                         ),
-                        placeholderText: uiState.phase == .inCall ? str(.callVideoOff) : nil,
-                        placeholderDisplayName: uiState.phase == .inCall ? uiState.remoteParticipants.first?.displayName : nil
+                        placeholderText: inCall ? str(.callVideoOff) : nil,
+                        placeholderDisplayName: inCall ? firstRemote?.displayName : nil,
+                        placeholderPeerId: inCall ? firstRemote?.peerId : nil
                     )
-                    ParticipantBadge(muted: uiState.remoteParticipants.first?.audioEnabled == false, displayName: uiState.remoteParticipants.first?.displayName)
+                    ParticipantBadge(muted: firstRemote?.audioEnabled == false, displayName: firstRemote?.displayName)
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
                 smallLocalView
@@ -498,7 +501,8 @@ struct CallScreenView: View {
         videoContentMode: UIView.ContentMode = .scaleAspectFill,
         showPlaceholder: Bool,
         placeholderText: String?,
-        placeholderDisplayName: String? = nil
+        placeholderDisplayName: String? = nil,
+        placeholderPeerId: String? = nil
     ) -> some View {
         ZStack {
             Color.black.ignoresSafeArea()
@@ -511,7 +515,7 @@ struct CallScreenView: View {
                 .ignoresSafeArea()
 
             if showPlaceholder {
-                VideoPlaceholderTile(text: placeholderText, compact: false, displayName: placeholderDisplayName)
+                VideoPlaceholderTile(text: placeholderText, compact: false, displayName: placeholderDisplayName, peerId: placeholderPeerId)
                     .ignoresSafeArea()
             }
         }
@@ -559,7 +563,8 @@ struct CallScreenView: View {
                 VideoPlaceholderTile(
                     text: uiState.phase == .inCall ? str(.callVideoOff) : nil,
                     compact: true,
-                    displayName: uiState.phase == .inCall ? uiState.remoteParticipants.first?.displayName : nil
+                    displayName: uiState.phase == .inCall ? uiState.remoteParticipants.first?.displayName : nil,
+                    peerId: uiState.phase == .inCall ? uiState.remoteParticipants.first?.peerId : nil
                 )
             }
 
@@ -1010,7 +1015,7 @@ private struct MultiPartyStage: View {
                                     }
                                 )
                                 if !participant.videoEnabled {
-                                    VideoPlaceholderTile(text: str(.callVideoOff), compact: false, displayName: participant.displayName)
+                                    VideoPlaceholderTile(text: str(.callVideoOff), compact: false, displayName: participant.displayName, peerId: participant.peerId)
                                 }
                             }
 
@@ -1179,7 +1184,7 @@ private struct RemoteParticipantStageTile: View {
                 onVideoSizeChanged: onVideoSizeChanged
             )
             if !participant.videoEnabled {
-                VideoPlaceholderTile(text: resolveString(.callVideoOff, overrides: strings), compact: false, displayName: participant.displayName)
+                VideoPlaceholderTile(text: resolveString(.callVideoOff, overrides: strings), compact: false, displayName: participant.displayName, peerId: participant.peerId)
             }
             ParticipantBadge(muted: participant.audioEnabled == false, displayName: participant.displayName)
         }
@@ -1229,17 +1234,29 @@ struct VideoPlaceholderTile: View {
     let text: String?
     let compact: Bool
     var displayName: String? = nil
+    var peerId: String? = nil
+
+    @Environment(\.avatarCache) private var avatarCache
 
     var body: some View {
         ZStack {
             Color.black
             if let name = displayName, !name.isEmpty {
-                Text(name)
-                    .font(compact ? .system(size: 13, weight: .semibold) : .system(size: 18, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.85))
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
-                    .padding(.horizontal, compact ? 6 : 16)
+                VStack(spacing: compact ? 6 : 12) {
+                    if avatarCache != nil {
+                        RemoteAvatarView(
+                            peerId: peerId,
+                            displayName: name,
+                            size: compact ? 48 : 96
+                        )
+                    }
+                    Text(name)
+                        .font(compact ? .system(size: 13, weight: .semibold) : .system(size: 18, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .padding(.horizontal, compact ? 6 : 16)
+                }
             } else {
                 VStack(spacing: compact ? 6 : 10) {
                     Image(systemName: "video.slash.fill")

--- a/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
+++ b/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
@@ -3,31 +3,42 @@ import UIKit
 
 /// Lazily resolves and caches avatars for the lifetime of the call UI. Each
 /// `peerId` is sent through `AvatarProvider.resolve` at most once per call,
-/// with the resulting `UIImage` (or `nil`) cached for the rest of the call.
+/// with the resulting `UIImage` (or a sentinel for "no avatar") cached for
+/// the rest of the call.
 @MainActor
 final class AvatarCache: ObservableObject {
+    private enum Entry {
+        case pending
+        case resolved(UIImage?)
+    }
+
     private let provider: AvatarProvider?
-    @Published private var entries: [String: UIImage?] = [:]
-    private var inFlight: Set<String> = []
+    @Published private var entries: [String: Entry] = [:]
 
     nonisolated init(provider: AvatarProvider?) {
         self.provider = provider
     }
 
     func image(for peerId: String) -> UIImage? {
-        if let cached = entries[peerId] { return cached ?? nil }
-        guard let provider, !inFlight.contains(peerId) else { return nil }
-        inFlight.insert(peerId)
-        Task { [weak self] in
-            let source = await provider.resolve(peerId: peerId)
-            let image = await Self.materialize(source)
-            await MainActor.run {
-                guard let self else { return }
-                self.entries[peerId] = image
-                self.inFlight.remove(peerId)
+        switch entries[peerId] {
+        case .resolved(let image):
+            return image
+        case .pending:
+            return nil
+        case .none:
+            guard let provider else { return nil }
+            entries[peerId] = .pending
+            // Detached so the provider's pre-suspension work runs off the main actor;
+            // we hop back to main to publish the result.
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let source = await provider.resolve(peerId: peerId)
+                let image = await Self.materialize(source)
+                await MainActor.run {
+                    self?.entries[peerId] = .resolved(image)
+                }
             }
+            return nil
         }
-        return nil
     }
 
     private static func materialize(_ source: AvatarSource?) async -> UIImage? {
@@ -76,7 +87,8 @@ struct RemoteAvatarView: View {
                     .frame(width: size, height: size)
                     .clipShape(Circle())
             } else {
-                Text(initialsFor(displayName: displayName).isEmpty ? "•" : initialsFor(displayName: displayName))
+                let initials = initialsFor(displayName: displayName)
+                Text(initials.isEmpty ? "•" : initials)
                     .font(.system(size: size * 0.4, weight: .semibold))
                     .foregroundColor(.white.opacity(0.85))
             }

--- a/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
+++ b/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
@@ -90,9 +90,14 @@ func initialsFor(displayName: String?) -> String {
     guard let name = displayName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
         return ""
     }
-    let parts = name.split(whereSeparator: { $0.isWhitespace })
-    guard let first = parts.first?.first else { return "" }
-    if parts.count == 1 { return String(first).uppercased() }
-    let last = parts.last?.first.map(String.init) ?? ""
-    return (String(first) + last).uppercased()
+    var initials: [String] = []
+    for part in name.split(whereSeparator: { $0.isWhitespace }) {
+        for ch in part where ch.isLetter || ch.isNumber {
+            initials.append(String(ch).uppercased())
+            break
+        }
+    }
+    if initials.isEmpty { return "" }
+    if initials.count == 1 { return initials[0] }
+    return initials[0] + initials[initials.count - 1]
 }

--- a/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
+++ b/client-ios/SerenadaCallUI/Sources/RemoteAvatarView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import UIKit
+
+/// Lazily resolves and caches avatars for the lifetime of the call UI. Each
+/// `peerId` is sent through `AvatarProvider.resolve` at most once per call,
+/// with the resulting `UIImage` (or `nil`) cached for the rest of the call.
+@MainActor
+final class AvatarCache: ObservableObject {
+    private let provider: AvatarProvider?
+    @Published private var entries: [String: UIImage?] = [:]
+    private var inFlight: Set<String> = []
+
+    nonisolated init(provider: AvatarProvider?) {
+        self.provider = provider
+    }
+
+    func image(for peerId: String) -> UIImage? {
+        if let cached = entries[peerId] { return cached ?? nil }
+        guard let provider, !inFlight.contains(peerId) else { return nil }
+        inFlight.insert(peerId)
+        Task { [weak self] in
+            let source = await provider.resolve(peerId: peerId)
+            let image = await Self.materialize(source)
+            await MainActor.run {
+                guard let self else { return }
+                self.entries[peerId] = image
+                self.inFlight.remove(peerId)
+            }
+        }
+        return nil
+    }
+
+    private static func materialize(_ source: AvatarSource?) async -> UIImage? {
+        guard let source else { return nil }
+        switch source {
+        case .image(let image):
+            return image
+        case .data(let data):
+            return UIImage(data: data)
+        case .url(let url):
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                return UIImage(data: data)
+            } catch {
+                return nil
+            }
+        }
+    }
+}
+
+private struct AvatarCacheKey: EnvironmentKey {
+    @MainActor static let defaultValue: AvatarCache? = nil
+}
+
+extension EnvironmentValues {
+    var avatarCache: AvatarCache? {
+        get { self[AvatarCacheKey.self] }
+        set { self[AvatarCacheKey.self] = newValue }
+    }
+}
+
+struct RemoteAvatarView: View {
+    let peerId: String?
+    let displayName: String?
+    let size: CGFloat
+
+    @Environment(\.avatarCache) private var cache
+
+    var body: some View {
+        ZStack {
+            Circle().fill(Color(white: 0.16))
+            if let peerId, let cache, let image = cache.image(for: peerId) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+            } else {
+                Text(initialsFor(displayName: displayName).isEmpty ? "•" : initialsFor(displayName: displayName))
+                    .font(.system(size: size * 0.4, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.85))
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+}
+
+func initialsFor(displayName: String?) -> String {
+    guard let name = displayName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+        return ""
+    }
+    let parts = name.split(whereSeparator: { $0.isWhitespace })
+    guard let first = parts.first?.first else { return "" }
+    if parts.count == 1 { return String(first).uppercased() }
+    let last = parts.last?.first.map(String.init) ?? ""
+    return (String(first) + last).uppercased()
+}

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -50,6 +50,7 @@ public struct SerenadaCallFlow: View {
         self.strings = strings
         self.onDismiss = onDismiss
         self.onCallEnded = nil
+        self._avatarCache = StateObject(wrappedValue: AvatarCache(provider: config.avatarProvider))
     }
 
     // MARK: - Session-first init
@@ -75,29 +76,35 @@ public struct SerenadaCallFlow: View {
         self.strings = strings
         self.onDismiss = onDismiss
         self.onCallEnded = nil
+        self._avatarCache = StateObject(wrappedValue: AvatarCache(provider: config.avatarProvider))
     }
 
-    public var body: some View {
-        switch mode {
-        case .urlFirst(let url, let serenadaConfig):
-            URLFirstCallFlow(
-                url: url,
-                serenadaConfig: serenadaConfig,
-                config: config,
-                strings: strings,
-                onDismiss: onDismiss,
-                onCallEnded: onCallEnded
-            )
+    @StateObject private var avatarCache: AvatarCache
 
-        case .sessionFirst(let params):
-            SessionFirstCallFlow(
-                params: params,
-                config: config,
-                strings: strings,
-                onDismiss: onDismiss,
-                onCallEnded: onCallEnded
-            )
+    public var body: some View {
+        Group {
+            switch mode {
+            case .urlFirst(let url, let serenadaConfig):
+                URLFirstCallFlow(
+                    url: url,
+                    serenadaConfig: serenadaConfig,
+                    config: config,
+                    strings: strings,
+                    onDismiss: onDismiss,
+                    onCallEnded: onCallEnded
+                )
+
+            case .sessionFirst(let params):
+                SessionFirstCallFlow(
+                    params: params,
+                    config: config,
+                    strings: strings,
+                    onDismiss: onDismiss,
+                    onCallEnded: onCallEnded
+                )
+            }
         }
+        .environment(\.avatarCache, avatarCache)
     }
 
     /// Callback for when the call ends.
@@ -322,6 +329,7 @@ private struct SessionFirstCallFlow: View {
             RemoteParticipant(
                 cid: rp.cid,
                 displayName: rp.displayName,
+                peerId: rp.peerId,
                 audioEnabled: rp.audioEnabled,
                 videoEnabled: rp.videoEnabled,
                 connectionState: rp.connectionState

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
@@ -17,15 +17,23 @@ public struct SerenadaCallFlowConfig {
     /// `false`, the controls are always visible and the idle timer never runs.
     public var autoHideControls: Bool
 
+    /// Optional resolver that returns an avatar for a remote participant's
+    /// host-supplied `peerId` (passed to `SerenadaCore.join`). When unset or
+    /// when `peerId` is absent on the participant, the call UI shows an
+    /// initials placeholder derived from their display name.
+    public var avatarProvider: AvatarProvider?
+
     public init(
         screenSharingEnabled: Bool = true,
         inviteControlsEnabled: Bool = true,
         debugOverlayEnabled: Bool = false,
-        autoHideControls: Bool = true
+        autoHideControls: Bool = true,
+        avatarProvider: AvatarProvider? = nil
     ) {
         self.screenSharingEnabled = screenSharingEnabled
         self.inviteControlsEnabled = inviteControlsEnabled
         self.debugOverlayEnabled = debugOverlayEnabled
         self.autoHideControls = autoHideControls
+        self.avatarProvider = avatarProvider
     }
 }

--- a/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
@@ -84,7 +84,7 @@ final class SignalingMessageRouter {
 
     func processJoinedEvent(_ event: JoinedEvent) {
         let participants = dedupeParticipants(
-            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
+            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, peerId: $0.appPeerId, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
             localPeerId: event.peerId,
             makeLocalParticipant: { Participant(cid: $0, joinedAt: nil) }
         )
@@ -107,7 +107,7 @@ final class SignalingMessageRouter {
     func processRoomStateEvent(_ event: RoomStateEvent) {
         let localPeerId = getClientId()
         let participants = dedupeParticipants(
-            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
+            participants: event.participants.map { Participant(cid: $0.peerId, joinedAt: $0.joinedAt, displayName: $0.displayName, peerId: $0.appPeerId, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus) },
             localPeerId: localPeerId,
             makeLocalParticipant: { Participant(cid: $0, joinedAt: nil) }
         )

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -24,6 +24,9 @@ public struct LocalParticipant: Equatable {
     public var cid: String?
     /// Display name shown to other participants.
     public var displayName: String?
+    /// Host-supplied stable identity passed via ``SerenadaCore/join(url:displayName:peerId:)``.
+    /// Distinct from ``cid`` (per-call, server-issued).
+    public var peerId: String?
     /// Whether local audio is enabled.
     public var audioEnabled: Bool = true
     /// Whether local video is enabled.
@@ -43,6 +46,7 @@ public struct LocalParticipant: Equatable {
     public init(
         cid: String?,
         displayName: String? = nil,
+        peerId: String? = nil,
         audioEnabled: Bool = true,
         videoEnabled: Bool = true,
         cameraMode: LocalCameraMode = .selfie,
@@ -51,6 +55,7 @@ public struct LocalParticipant: Equatable {
     ) {
         self.cid = cid
         self.displayName = displayName
+        self.peerId = peerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.cameraMode = cameraMode
@@ -65,6 +70,11 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
     public let cid: String
     /// Display name of the remote participant.
     public var displayName: String?
+    /// Host-supplied stable identity passed via the remote peer's
+    /// ``SerenadaCore/join(url:displayName:peerId:)``. Distinct from ``cid``
+    /// (per-call, server-issued) — call UIs use this to look up avatars or
+    /// correlate to host-side records.
+    public var peerId: String?
     /// Whether remote audio is enabled.
     public var audioEnabled: Bool
     /// Whether remote video is enabled.
@@ -83,6 +93,7 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
     public init(
         cid: String,
         displayName: String? = nil,
+        peerId: String? = nil,
         audioEnabled: Bool = true,
         videoEnabled: Bool = true,
         connectionState: SerenadaPeerConnectionState = .new,
@@ -90,6 +101,7 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
     ) {
         self.cid = cid
         self.displayName = displayName
+        self.peerId = peerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.connectionState = connectionState

--- a/client-ios/SerenadaCore/Sources/Models/Participant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/Participant.swift
@@ -15,6 +15,8 @@ public struct Participant: Codable, Equatable {
     public let cid: String
     public let joinedAt: Int64?
     public let displayName: String?
+    /// Host-supplied stable identity; opaque to the SDK, surfaced for avatar lookup.
+    public let peerId: String?
     public let audioEnabled: Bool?
     public let videoEnabled: Bool?
     public let signalingStatus: ParticipantSignalingStatus
@@ -23,6 +25,7 @@ public struct Participant: Codable, Equatable {
         cid: String,
         joinedAt: Int64?,
         displayName: String? = nil,
+        peerId: String? = nil,
         audioEnabled: Bool? = nil,
         videoEnabled: Bool? = nil,
         signalingStatus: ParticipantSignalingStatus = .active
@@ -30,6 +33,7 @@ public struct Participant: Codable, Equatable {
         self.cid = cid
         self.joinedAt = joinedAt
         self.displayName = displayName
+        self.peerId = peerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.signalingStatus = signalingStatus

--- a/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
@@ -3,15 +3,19 @@ import Foundation
 public struct RemoteParticipant: Identifiable, Equatable {
     public let cid: String
     public var displayName: String?
+    /// Host-supplied stable identity passed via the remote peer's
+    /// ``SerenadaCore/join(url:displayName:peerId:)``.
+    public var peerId: String?
     public var audioEnabled: Bool
     public var videoEnabled: Bool
     public var connectionState: SerenadaPeerConnectionState
 
     public var id: String { cid }
 
-    public init(cid: String, displayName: String? = nil, audioEnabled: Bool = true, videoEnabled: Bool, connectionState: SerenadaPeerConnectionState) {
+    public init(cid: String, displayName: String? = nil, peerId: String? = nil, audioEnabled: Bool = true, videoEnabled: Bool, connectionState: SerenadaPeerConnectionState) {
         self.cid = cid
         self.displayName = displayName
+        self.peerId = peerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.connectionState = connectionState

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -58,7 +58,11 @@ public final class SerenadaCore {
     }
 
     /// Join an existing call by URL. Returns a session that begins connecting immediately.
-    public func join(url: URL, displayName: String? = nil) -> SerenadaSession {
+    ///
+    /// - Parameter peerId: Optional host-supplied stable identity for this user
+    ///   (distinct from the per-call client ID). Surfaced on remote participants so
+    ///   the call UI can resolve avatars via `SerenadaCallFlowConfig.avatarProvider`.
+    public func join(url: URL, displayName: String? = nil, peerId: String? = nil) -> SerenadaSession {
         let roomId = DeepLinkParser.extractRoomId(from: url) ?? url.lastPathComponent
         let target = DeepLinkParser.parseTarget(from: url)
         let serverHost = target?.host
@@ -84,13 +88,16 @@ public final class SerenadaCore {
             delegateProvider: { [weak self] in self?.delegate },
             logger: logger,
             initialSignalingProvider: createSignalingProvider(for: sessionConfig),
-            displayName: displayName
+            displayName: displayName,
+            peerId: peerId
         )
         return session
     }
 
     /// Join an existing call by room ID. Returns a session that begins connecting immediately.
-    public func join(roomId: String, displayName: String? = nil) -> SerenadaSession {
+    ///
+    /// - Parameter peerId: Optional host-supplied stable identity — see the URL ``join(url:displayName:peerId:)`` overload.
+    public func join(roomId: String, displayName: String? = nil, peerId: String? = nil) -> SerenadaSession {
         let url = resolvedConfig.serverHost.flatMap { buildRoomURL(host: $0, roomId: roomId) }
 
         let session = SerenadaSession(
@@ -100,7 +107,8 @@ public final class SerenadaCore {
             delegateProvider: { [weak self] in self?.delegate },
             logger: logger,
             initialSignalingProvider: createSignalingProvider(for: config),
-            displayName: displayName
+            displayName: displayName,
+            peerId: peerId
         )
         return session
     }

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -17,6 +17,7 @@ internal final class SerenadaServerProvider: SignalingProvider {
     @MainActor private var currentMaxParticipants = 4
     @MainActor private var currentReconnectPeerId: String?
     @MainActor private var currentDisplayName: String?
+    @MainActor private var currentAppPeerId: String?
     @MainActor private var currentTurnToken: String?
     @MainActor private var reconnectToken: String?
     @MainActor private var clientId: String?
@@ -99,6 +100,9 @@ internal final class SerenadaServerProvider: SignalingProvider {
             currentReconnectPeerId = options.reconnectPeerId
             if options.displayName != nil {
                 currentDisplayName = options.displayName
+            }
+            if options.appPeerId != nil {
+                currentAppPeerId = options.appPeerId
             }
             if signaling.isConnected() {
                 pendingJoinRoomId = nil
@@ -240,7 +244,7 @@ private extension SerenadaServerProvider {
 
         let participants = dedupeProviderParticipants(
             participants: (payload.participants ?? []).map {
-                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
+                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, appPeerId: $0.peerId, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
             },
             localPeerId: peerId
         )
@@ -266,10 +270,10 @@ private extension SerenadaServerProvider {
     func emitParticipantDiffs(nextParticipants: [SignalingProviderParticipant]) {
         let nextMap = Dictionary(uniqueKeysWithValues: nextParticipants.map { ($0.peerId, $0) })
         for (peerId, participant) in nextMap where previousParticipants[peerId] == nil {
-            delegate?.signalingProviderDidJoinPeer(PeerEvent(peerId: peerId, joinedAt: participant.joinedAt, displayName: participant.displayName))
+            delegate?.signalingProviderDidJoinPeer(PeerEvent(peerId: peerId, joinedAt: participant.joinedAt, displayName: participant.displayName, appPeerId: participant.appPeerId))
         }
         for (peerId, participant) in previousParticipants where nextMap[peerId] == nil {
-            delegate?.signalingProviderDidLeavePeer(PeerEvent(peerId: peerId, joinedAt: participant.joinedAt, displayName: participant.displayName))
+            delegate?.signalingProviderDidLeavePeer(PeerEvent(peerId: peerId, joinedAt: participant.joinedAt, displayName: participant.displayName, appPeerId: participant.appPeerId))
         }
     }
 
@@ -291,7 +295,7 @@ private extension SerenadaServerProvider {
         guard let object = payload?.objectValue else { return nil }
         let participants = dedupeProviderParticipants(
             participants: (parseParticipants(from: object["participants"]?.arrayValue) ?? []).map {
-                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
+                SignalingProviderParticipant(peerId: $0.cid, joinedAt: $0.joinedAt, displayName: $0.displayName, appPeerId: $0.peerId, audioEnabled: $0.audioEnabled, videoEnabled: $0.videoEnabled, signalingStatus: $0.signalingStatus)
             },
             localPeerId: clientId
         )
@@ -328,6 +332,9 @@ private extension SerenadaServerProvider {
         }
         if let currentDisplayName {
             joinPayload["displayName"] = .string(currentDisplayName)
+        }
+        if let currentAppPeerId {
+            joinPayload["peerId"] = .string(currentAppPeerId)
         }
         sendRawMessage(type: "join", rid: roomId, payload: joinPayload)
     }

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -133,6 +133,7 @@ public final class SerenadaSession: ObservableObject {
     private let resolvedConfig: ResolvedSerenadaConfig
     private let availableCameraModes: [LocalCameraMode]
     private let displayName: String?
+    private let peerId: String?
     private let delegateProvider: (() -> SerenadaCoreDelegate?)?
     private let logger: SerenadaLogger?
 
@@ -178,7 +179,8 @@ public final class SerenadaSession: ObservableObject {
         config: SerenadaConfig,
         delegateProvider: (() -> SerenadaCoreDelegate?)? = nil,
         logger: SerenadaLogger? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        peerId: String? = nil
     ) {
         let sessionConfig = config.signalingProvider == nil
             ? SerenadaConfig(
@@ -195,7 +197,8 @@ public final class SerenadaSession: ObservableObject {
             roomId: roomId, roomUrl: roomUrl, config: sessionConfig,
             delegateProvider: delegateProvider, logger: logger,
             initialSignalingProvider: nil, signaling: nil, apiClient: nil, audioController: nil, mediaEngine: nil, clock: nil,
-            displayName: displayName
+            displayName: displayName,
+            peerId: peerId
         )
     }
 
@@ -211,13 +214,15 @@ public final class SerenadaSession: ObservableObject {
         audioController: SessionAudioController? = nil,
         mediaEngine: SessionMediaEngine? = nil,
         clock: SessionClock? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        peerId: String? = nil
     ) {
         self.roomId = roomId
         self.roomUrl = roomUrl
         self.config = config
         self.availableCameraModes = SerenadaSession.resolveAvailableCameraModes(config.cameraModes)
         self.displayName = displayName
+        self.peerId = peerId
         self.delegateProvider = delegateProvider
         self.logger = logger
         self.clock = clock ?? LiveSessionClock()
@@ -449,7 +454,7 @@ public final class SerenadaSession: ObservableObject {
         let initialCameraMode = self.availableCameraModes.first ?? .selfie
         commitSnapshot { s, d in
             s.localParticipant = LocalParticipant(
-                cid: nil, displayName: self.displayName,
+                cid: nil, displayName: self.displayName, peerId: self.peerId,
                 audioEnabled: self.config.defaultAudioEnabled,
                 videoEnabled: videoCaptureSupported && self.config.defaultVideoEnabled,
                 cameraMode: initialCameraMode,
@@ -519,7 +524,12 @@ public final class SerenadaSession: ObservableObject {
         }
         signalingProvider.joinRoom(
             roomId,
-            options: JoinOptions(reconnectPeerId: reconnectCid, maxParticipants: 4, displayName: self.displayName)
+            options: JoinOptions(
+                reconnectPeerId: reconnectCid,
+                maxParticipants: 4,
+                displayName: self.displayName,
+                appPeerId: self.peerId
+            )
         )
         joinFlowCoordinator?.scheduleJoinRecovery(for: roomId)
     }
@@ -721,7 +731,7 @@ public final class SerenadaSession: ObservableObject {
             let slot = peerSlots[p.cid]
             let peerState = remoteMediaStates[p.cid]
             return SerenadaRemoteParticipant(
-                cid: p.cid, displayName: p.displayName,
+                cid: p.cid, displayName: p.displayName, peerId: p.peerId,
                 audioEnabled: peerState?.audioEnabled ?? p.audioEnabled ?? true,
                 videoEnabled: peerState?.videoEnabled ?? p.videoEnabled ?? (slot?.isRemoteVideoTrackEnabled() ?? false),
                 connectionState: slot?.getConnectionState() ?? .new,
@@ -785,7 +795,12 @@ public final class SerenadaSession: ObservableObject {
         localPeerId: String?
     ) -> RoomState? {
         let participants = dedupeParticipants(
-            participants: (roomState?.participants ?? []) + [Participant(cid: event.peerId, joinedAt: event.joinedAt, displayName: event.displayName)],
+            participants: (roomState?.participants ?? []) + [Participant(
+                cid: event.peerId,
+                joinedAt: event.joinedAt,
+                displayName: event.displayName,
+                peerId: event.appPeerId
+            )],
             localPeerId: localPeerId,
             makeLocalParticipant: { Participant(cid: $0, joinedAt: nil) }
         )

--- a/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
@@ -11,6 +11,7 @@ func parseParticipants(from arrayValue: [JSONValue]?) -> [Participant]? {
         guard let cid = obj["cid"]?.stringValue, !cid.isEmpty else { continue }
         let joinedAt = obj["joinedAt"]?.intValue.map(Int64.init)
         let displayName = obj["displayName"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let peerId = obj["peerId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         let audioEnabled = obj["audioEnabled"]?.boolValue
         let videoEnabled = obj["videoEnabled"]?.boolValue
         // Unknown status values fall back to .active per protocol spec.
@@ -19,6 +20,7 @@ func parseParticipants(from arrayValue: [JSONValue]?) -> [Participant]? {
             cid: cid,
             joinedAt: joinedAt,
             displayName: displayName,
+            peerId: peerId,
             audioEnabled: audioEnabled,
             videoEnabled: videoEnabled,
             signalingStatus: signalingStatus

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -22,11 +22,21 @@ public struct JoinOptions: Equatable, Sendable {
     public var reconnectPeerId: String?
     public var maxParticipants: Int?
     public var displayName: String?
+    /// Host-supplied stable identity. Distinct from `peerId`/cid (per-call,
+    /// server-issued) — lets host applications correlate a participant to their
+    /// own user identity (avatar lookup, telemetry).
+    public var appPeerId: String?
 
-    public init(reconnectPeerId: String? = nil, maxParticipants: Int? = nil, displayName: String? = nil) {
+    public init(
+        reconnectPeerId: String? = nil,
+        maxParticipants: Int? = nil,
+        displayName: String? = nil,
+        appPeerId: String? = nil
+    ) {
         self.reconnectPeerId = reconnectPeerId
         self.maxParticipants = maxParticipants
         self.displayName = displayName
+        self.appPeerId = appPeerId
     }
 }
 
@@ -34,6 +44,8 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
     public let peerId: String
     public let joinedAt: Int64?
     public let displayName: String?
+    /// Host-supplied stable identity — see `JoinOptions.appPeerId`.
+    public let appPeerId: String?
     public let audioEnabled: Bool?
     public let videoEnabled: Bool?
     public let signalingStatus: ParticipantSignalingStatus
@@ -42,6 +54,7 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
         peerId: String,
         joinedAt: Int64? = nil,
         displayName: String? = nil,
+        appPeerId: String? = nil,
         audioEnabled: Bool? = nil,
         videoEnabled: Bool? = nil,
         signalingStatus: ParticipantSignalingStatus = .active
@@ -49,6 +62,7 @@ public struct SignalingProviderParticipant: Equatable, Sendable {
         self.peerId = peerId
         self.joinedAt = joinedAt
         self.displayName = displayName
+        self.appPeerId = appPeerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.signalingStatus = signalingStatus
@@ -94,11 +108,14 @@ public struct PeerEvent: Equatable, Sendable {
     public let peerId: String
     public let joinedAt: Int64?
     public let displayName: String?
+    /// Host-supplied stable identity — see `JoinOptions.appPeerId`.
+    public let appPeerId: String?
 
-    public init(peerId: String, joinedAt: Int64? = nil, displayName: String? = nil) {
+    public init(peerId: String, joinedAt: Int64? = nil, displayName: String? = nil, appPeerId: String? = nil) {
         self.peerId = peerId
         self.joinedAt = joinedAt
         self.displayName = displayName
+        self.appPeerId = appPeerId
     }
 }
 

--- a/client/packages/core/src/SerenadaCore.ts
+++ b/client/packages/core/src/SerenadaCore.ts
@@ -27,22 +27,31 @@ export class SerenadaCore {
     }
 
     /** Join an existing call by URL. Returns a session handle. */
-    join(url: string, options?: { displayName?: string }): SerenadaSessionHandle;
+    join(url: string, options?: { displayName?: string; peerId?: string }): SerenadaSessionHandle;
     /** Join an existing call by room ID. Returns a session handle. */
-    join(options: { roomId: string; displayName?: string }): SerenadaSessionHandle;
-    join(urlOrOptions: string | { roomId: string; displayName?: string }, extraOptions?: { displayName?: string }): SerenadaSessionHandle {
+    join(options: { roomId: string; displayName?: string; peerId?: string }): SerenadaSessionHandle;
+    join(
+        urlOrOptions: string | { roomId: string; displayName?: string; peerId?: string },
+        extraOptions?: { displayName?: string; peerId?: string },
+    ): SerenadaSessionHandle {
         if (!SerenadaCore.isSupported()) {
             return this.createUnsupportedSession();
         }
         const signalingProvider = this.createSignalingProvider();
         if (typeof urlOrOptions === 'string') {
             const roomId = this.parseRoomIdFromUrl(urlOrOptions);
-            return new SerenadaSession(this.config, roomId, urlOrOptions, signalingProvider, { displayName: extraOptions?.displayName });
+            return new SerenadaSession(this.config, roomId, urlOrOptions, signalingProvider, {
+                displayName: extraOptions?.displayName,
+                peerId: extraOptions?.peerId,
+            });
         }
         const roomUrl = this.resolvedConfig.serverHost
             ? buildRoomUrl(this.resolvedConfig.serverHost, urlOrOptions.roomId)
             : null;
-        return new SerenadaSession(this.config, urlOrOptions.roomId, roomUrl, signalingProvider, { displayName: urlOrOptions.displayName });
+        return new SerenadaSession(this.config, urlOrOptions.roomId, roomUrl, signalingProvider, {
+            displayName: urlOrOptions.displayName,
+            peerId: urlOrOptions.peerId,
+        });
     }
 
     /** Create a new room. Returns the room URL and ID. Call {@link join} to start the call. */

--- a/client/packages/core/src/SerenadaServerProvider.ts
+++ b/client/packages/core/src/SerenadaServerProvider.ts
@@ -75,6 +75,7 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
         this.signaling.joinRoom(roomId, {
             createMaxParticipants: options?.maxParticipants,
             displayName: options?.displayName,
+            peerId: options?.appPeerId,
         });
     }
 
@@ -308,6 +309,7 @@ function mapParticipant(participant: RoomParticipant): SignalingProviderParticip
         peerId: participant.cid,
         joinedAt: participant.joinedAt,
         displayName: participant.displayName,
+        appPeerId: participant.peerId,
         audioEnabled: participant.audioEnabled,
         videoEnabled: participant.videoEnabled,
         connectionStatus: participant.connectionStatus,

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -40,6 +40,7 @@ interface SessionDependencies {
     statsCollector?: CallStatsCollector;
     autoStart?: boolean;
     displayName?: string;
+    peerId?: string;
 }
 
 function mapErrorCode(serverCode: string): CallErrorCode {
@@ -74,6 +75,7 @@ function toRoomParticipant(participant: SignalingProviderParticipant): RoomParti
         cid: participant.peerId,
         joinedAt: participant.joinedAt,
         displayName: participant.displayName,
+        peerId: participant.appPeerId,
         audioEnabled: participant.audioEnabled,
         videoEnabled: participant.videoEnabled,
         connectionStatus: participant.connectionStatus,
@@ -136,7 +138,12 @@ function upsertParticipant(
     }
     const participants = dedupeParticipants([
         ...(roomState?.participants ?? []),
-        { cid: event.peerId, joinedAt: event.joinedAt, displayName: event.displayName },
+        {
+            cid: event.peerId,
+            joinedAt: event.joinedAt,
+            displayName: event.displayName,
+            peerId: event.appPeerId,
+        },
     ], localPeerId);
     return {
         hostCid: resolveHostCid(participants, roomState?.hostCid ?? null, localPeerId),
@@ -208,6 +215,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
     private readonly roomUrl: string | null;
     private readonly handlesReconnection: boolean;
     private readonly displayName?: string;
+    private readonly appPeerId?: string;
 
     private _state: CallState;
     private stateListeners: Array<(state: CallState) => void> = [];
@@ -256,6 +264,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.signaling = signaling;
         this.handlesReconnection = signaling.capabilities?.handlesReconnection === true;
         this.displayName = deps.displayName;
+        this.appPeerId = deps.peerId;
         this.availableCameraModes = Object.freeze(resolveCameraModes(config.cameraModes)) as ConfigurableCameraMode[];
         this.userPreferredVideoEnabled = this.availableCameraModes.length > 0 && config.defaultVideoEnabled !== false;
 
@@ -446,6 +455,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.started = true;
         this.pendingJoinOptions = {
             displayName: this.displayName,
+            appPeerId: this.appPeerId,
         };
         this.scheduleJoinTimeout();
         this.signaling.connect();
@@ -509,7 +519,11 @@ export class SerenadaSession implements SerenadaSessionHandle {
         if (this.handlesReconnection) {
             this.reconnectRecoveryPending = hadRoomState;
         } else {
-            this.pendingJoinOptions = { reconnectPeerId: this.clientId ?? undefined, displayName: this.displayName };
+            this.pendingJoinOptions = {
+                reconnectPeerId: this.clientId ?? undefined,
+                displayName: this.displayName,
+                appPeerId: this.appPeerId,
+            };
             this.scheduleReconnect();
         }
 
@@ -698,7 +712,11 @@ export class SerenadaSession implements SerenadaSessionHandle {
             if (this.isInactive) {
                 return;
             }
-            this.pendingJoinOptions = { reconnectPeerId: this.clientId ?? undefined, displayName: this.displayName };
+            this.pendingJoinOptions = {
+                reconnectPeerId: this.clientId ?? undefined,
+                displayName: this.displayName,
+                appPeerId: this.appPeerId,
+            };
             this.signaling.connect();
         }, delayMs);
     }
@@ -869,6 +887,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         const localParticipant = clientId ? {
             cid: clientId,
             displayName: this.displayName,
+            peerId: this.appPeerId,
             audioEnabled: audioTrack?.enabled ?? (this.config.defaultAudioEnabled !== false),
             // Mirror broadcast: derive from real track presence/state so the
             // local UI matches what peers see. Pre-media-start (no stream),
@@ -890,6 +909,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
                 return {
                     cid: participant.cid,
                     displayName: participant.displayName,
+                    peerId: participant.peerId,
                     audioEnabled: peerState?.audioEnabled ?? participant.audioEnabled ?? true,
                     videoEnabled: peerState?.videoEnabled ?? participant.videoEnabled ?? true,
                     connectionState: this.media.connectionState,

--- a/client/packages/core/src/SignalingProvider.ts
+++ b/client/packages/core/src/SignalingProvider.ts
@@ -12,12 +12,20 @@ export interface JoinOptions {
     reconnectPeerId?: string;
     maxParticipants?: number;
     displayName?: string;
+    /**
+     * Host-supplied stable identity. Distinct from `peerId`/cid (which is per-call
+     * and server-issued) — lets host applications correlate a participant to
+     * their own user identity (avatar lookup, telemetry).
+     */
+    appPeerId?: string;
 }
 
 export interface SignalingProviderParticipant {
     peerId: string;
     joinedAt?: number;
     displayName?: string;
+    /** Host-supplied stable identity — see {@link JoinOptions.appPeerId}. */
+    appPeerId?: string;
     audioEnabled?: boolean;
     videoEnabled?: boolean;
     // Wire-reported signaling transport status. Absent = active.
@@ -41,6 +49,8 @@ export interface PeerEvent {
     peerId: string;
     joinedAt?: number;
     displayName?: string;
+    /** Host-supplied stable identity — see {@link JoinOptions.appPeerId}. */
+    appPeerId?: string;
 }
 
 export interface PeerMessage {

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -72,6 +72,7 @@ export class SignalingEngine {
     private connecting = false;
     private lastCreateMaxParticipants: number | undefined = undefined;
     private lastDisplayName: string | undefined = undefined;
+    private lastPeerId: string | undefined = undefined;
 
     // Logger
     private logger?: SerenadaLogger;
@@ -123,7 +124,7 @@ export class SignalingEngine {
         }
     }
 
-    joinRoom(roomId: string, options?: { createMaxParticipants?: number; displayName?: string }): void {
+    joinRoom(roomId: string, options?: { createMaxParticipants?: number; displayName?: string; peerId?: string }): void {
         this.logger?.log('debug', 'Signaling', `joinRoom call for ${roomId}`);
         this.error = null;
         this.clearJoinTimers();
@@ -139,6 +140,9 @@ export class SignalingEngine {
         if (options?.displayName !== undefined) {
             this.lastDisplayName = options.displayName;
         }
+        if (options?.peerId !== undefined) {
+            this.lastPeerId = options.peerId;
+        }
 
         if (this.transport && this.transport.isOpen()) {
             const payload: Record<string, unknown> = {
@@ -148,6 +152,10 @@ export class SignalingEngine {
             const displayName = options?.displayName ?? this.lastDisplayName;
             if (displayName !== undefined) {
                 payload.displayName = displayName;
+            }
+            const peerId = options?.peerId ?? this.lastPeerId;
+            if (peerId !== undefined) {
+                payload.peerId = peerId;
             }
             const reconnectCid = this.clientId || this.lastClientId;
             if (reconnectCid) {

--- a/client/packages/core/src/signaling/payloads.ts
+++ b/client/packages/core/src/signaling/payloads.ts
@@ -46,6 +46,7 @@ function parseParticipants(raw: unknown): RoomParticipant[] | null {
             cid: rec.cid,
             joinedAt: typeof rec.joinedAt === 'number' ? rec.joinedAt : undefined,
             displayName: typeof rec.displayName === 'string' && rec.displayName.trim() !== '' ? rec.displayName : undefined,
+            peerId: typeof rec.peerId === 'string' && rec.peerId.trim() !== '' ? rec.peerId : undefined,
             audioEnabled: typeof rec.audioEnabled === 'boolean' ? rec.audioEnabled : undefined,
             videoEnabled: typeof rec.videoEnabled === 'boolean' ? rec.videoEnabled : undefined,
             // Only the recognized status value is forwarded; absent/unknown

--- a/client/packages/core/src/signaling/types.ts
+++ b/client/packages/core/src/signaling/types.ts
@@ -4,6 +4,8 @@ export type RoomParticipant = {
     cid: string;
     joinedAt?: number;
     displayName?: string;
+    /** Host-supplied stable identity — opaque to the SDK, surfaced for avatar lookup. */
+    peerId?: string;
     audioEnabled?: boolean;
     videoEnabled?: boolean;
     // Absent = active. 'suspended' means the server is holding the slot

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -40,6 +40,13 @@ export type ParticipantSignalingStatus = 'active' | 'suspended';
 export interface Participant {
     cid: string;
     displayName?: string;
+    /**
+     * Host-supplied stable identity passed via {@link SerenadaCore.join} (the
+     * `peerId` option). Distinct from {@link cid} (per-call, server-issued) —
+     * used by the call UI to look up avatars or correlate to host-side records.
+     * Absent when the remote peer didn't supply one.
+     */
+    peerId?: string;
     audioEnabled: boolean;
     videoEnabled: boolean;
     connectionState: PeerConnectionState;
@@ -50,6 +57,8 @@ export interface Participant {
 export interface LocalParticipant {
     cid: string;
     displayName?: string;
+    /** Host-supplied stable identity — see {@link Participant.peerId}. */
+    peerId?: string;
     audioEnabled: boolean;
     videoEnabled: boolean;
     cameraMode: CameraMode;

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -27,6 +27,8 @@ import {
     type SerenadaSessionHandle,
 } from '@serenada/core';
 import { DebugPanel } from './components/DebugPanel.js';
+import { RemoteAvatar } from './components/RemoteAvatar.js';
+import { useAvatarResolver, type AvatarResolver } from './hooks/useAvatarResolver.js';
 import { StatusOverlay } from './components/StatusOverlay.js';
 import { useCallState } from './hooks/useCallState.js';
 import { SerenadaPermissions } from './SerenadaPermissions.js';
@@ -88,6 +90,9 @@ const VideoTile: React.FC<{
     videoEnabled?: boolean;
     cameraOffLabel?: string;
     compact?: boolean;
+    peerId?: string;
+    displayName?: string;
+    resolveAvatar?: AvatarResolver;
     onAspectRatioChange?: (ratio: number) => void;
     onClick?: () => void;
 }> = ({
@@ -101,6 +106,9 @@ const VideoTile: React.FC<{
     videoEnabled,
     cameraOffLabel,
     compact = false,
+    peerId,
+    displayName,
+    resolveAvatar,
     onAspectRatioChange,
     onClick,
 }) => {
@@ -167,6 +175,14 @@ const VideoTile: React.FC<{
             />
             {videoEnabled === false && (
                 <div className={`video-camera-off-overlay${compact ? ' compact' : ''}`}>
+                    {resolveAvatar && (
+                        <RemoteAvatar
+                            peerId={peerId}
+                            displayName={displayName}
+                            resolveAvatar={resolveAvatar}
+                            compact={compact}
+                        />
+                    )}
                     <span className="video-camera-off-label">{cameraOffLabel}</span>
                 </div>
             )}
@@ -243,6 +259,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     const showScreenShareControl = config?.screenSharingEnabled !== false && canScreenShare;
     const autoHideControls = config?.autoHideControls !== false;
     const inviteControlsEnabled = config?.inviteControlsEnabled !== false;
+    const resolveAvatar = useAvatarResolver(config?.avatarProvider);
     const shareUrl = effectiveState.roomUrl ?? (typeof window !== 'undefined' ? window.location.href : '');
     const shouldMirrorLocalVideo = localParticipant?.cameraMode === 'selfie' && !isScreenSharing;
 
@@ -937,6 +954,9 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                                     videoFit={tile.fit === 'contain' ? 'contain' : 'cover'}
                                                     videoEnabled={tileVideoEnabled}
                                                     cameraOffLabel={tileDisplayName ?? resolveString('cameraOff', strings)}
+                                                    peerId={isContentTile || isLocalTile ? undefined : tileRemote?.peerId}
+                                                    displayName={isContentTile || isLocalTile ? undefined : tileRemote?.displayName}
+                                                    resolveAvatar={isContentTile || isLocalTile ? undefined : resolveAvatar}
                                                     onAspectRatioChange={
                                                         isLocalTile || isContentTile ? undefined : (ratio) => {
                                                             setRemoteStageAspectRatios((prev) => (
@@ -981,6 +1001,9 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                                             tileStyle={{ width: '100%', height: '100%' }}
                                                             videoEnabled={gridRemote?.videoEnabled}
                                                             cameraOffLabel={gridRemote?.displayName ?? resolveString('cameraOff', strings)}
+                                                            peerId={gridRemote?.peerId}
+                                                            displayName={gridRemote?.displayName}
+                                                            resolveAvatar={resolveAvatar}
                                                             onAspectRatioChange={(ratio) => {
                                                                 setRemoteStageAspectRatios((prev) => (
                                                                     prev[tile.cid] === ratio ? prev : { ...prev, [tile.cid]: ratio }
@@ -1060,6 +1083,11 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
 
                     {remoteParticipant0?.videoEnabled === false && (
                         <div className="video-camera-off-overlay">
+                            <RemoteAvatar
+                                peerId={remoteParticipant0.peerId}
+                                displayName={remoteParticipant0.displayName}
+                                resolveAvatar={resolveAvatar}
+                            />
                             <span className="video-camera-off-label">
                                 {remoteParticipant0.displayName ?? resolveString('cameraOff', strings)}
                             </span>

--- a/client/packages/react-ui/src/callFlowStyles.ts
+++ b/client/packages/react-ui/src/callFlowStyles.ts
@@ -187,8 +187,10 @@ const CALL_FLOW_CSS = `
   position: absolute;
   inset: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: clamp(8px, 2cqi, 24px);
   background: #111;
   border-radius: inherit;
   z-index: 1;
@@ -204,6 +206,37 @@ const CALL_FLOW_CSS = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+[data-serenada-callflow] .serenada-avatar-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(56px, 22cqi, 168px);
+  height: clamp(56px, 22cqi, 168px);
+  border-radius: 50%;
+  overflow: hidden;
+  background: #2a2a2a;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: clamp(20px, 8cqi, 64px);
+  font-weight: 600;
+  line-height: 1;
+  text-transform: uppercase;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+[data-serenada-callflow] .serenada-avatar-circle.compact {
+  width: clamp(40px, 16cqi, 96px);
+  height: clamp(40px, 16cqi, 96px);
+  font-size: clamp(14px, 6cqi, 36px);
+}
+
+[data-serenada-callflow] .serenada-avatar-circle img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
 [data-serenada-callflow] .video-stage-pin-indicator {

--- a/client/packages/react-ui/src/components/RemoteAvatar.tsx
+++ b/client/packages/react-ui/src/components/RemoteAvatar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { initialsFor, type AvatarResolver } from '../hooks/useAvatarResolver.js';
+
+export const RemoteAvatar: React.FC<{
+    peerId: string | undefined;
+    displayName: string | undefined;
+    resolveAvatar: AvatarResolver;
+    compact?: boolean;
+}> = ({ peerId, displayName, resolveAvatar, compact = false }) => {
+    const resolved = resolveAvatar(peerId);
+    const initials = initialsFor(displayName);
+    const className = `serenada-avatar-circle${compact ? ' compact' : ''}`;
+
+    if (resolved) {
+        return (
+            <div className={className} aria-hidden="true">
+                <img src={resolved.url} alt="" />
+            </div>
+        );
+    }
+
+    return (
+        <div className={`${className} initials`} aria-hidden="true">
+            {initials || '•'}
+        </div>
+    );
+};

--- a/client/packages/react-ui/src/hooks/useAvatarResolver.ts
+++ b/client/packages/react-ui/src/hooks/useAvatarResolver.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import type { AvatarProvider, AvatarSource } from '../types.js';
+
+type ResolvedAvatar = { url: string } | null;
+type CacheEntry = ResolvedAvatar | 'pending';
+
+export type AvatarResolver = (peerId: string | undefined) => ResolvedAvatar;
+
+/**
+ * Lazily resolves and caches avatars for the lifetime of the call UI.
+ * Each `peerId` is sent through the provider at most once. The returned
+ * resolver is synchronous: it returns `null` until the avatar is ready, then
+ * triggers a re-render with the resolved URL on the next call.
+ */
+export function useAvatarResolver(provider: AvatarProvider | undefined): AvatarResolver {
+    const cacheRef = useRef<Map<string, CacheEntry>>(new Map());
+    const objectUrlsRef = useRef<string[]>([]);
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+
+    useEffect(() => () => {
+        for (const url of objectUrlsRef.current) {
+            URL.revokeObjectURL(url);
+        }
+        objectUrlsRef.current = [];
+        cacheRef.current.clear();
+    }, []);
+
+    return useCallback((peerId: string | undefined): ResolvedAvatar => {
+        if (!provider || !peerId) {
+            return null;
+        }
+        const cached = cacheRef.current.get(peerId);
+        if (cached === 'pending') return null;
+        if (cached !== undefined) return cached;
+
+        cacheRef.current.set(peerId, 'pending');
+        provider(peerId).then(
+            (source) => {
+                cacheRef.current.set(peerId, materializeAvatar(source, objectUrlsRef.current));
+                forceUpdate();
+            },
+            (error) => {
+                console.warn('[serenada] avatarProvider rejected for', peerId, error);
+                cacheRef.current.set(peerId, null);
+                forceUpdate();
+            },
+        );
+        return null;
+    }, [provider]);
+}
+
+function materializeAvatar(source: AvatarSource | null, objectUrls: string[]): ResolvedAvatar {
+    if (!source) return null;
+    switch (source.kind) {
+        case 'url':
+            return source.url ? { url: source.url } : null;
+        case 'image':
+            return source.image.src ? { url: source.image.src } : null;
+        case 'bytes': {
+            const blob = new Blob([source.bytes as BlobPart]);
+            const url = URL.createObjectURL(blob);
+            objectUrls.push(url);
+            return { url };
+        }
+    }
+}
+
+export function initialsFor(displayName: string | undefined): string {
+    if (!displayName) return '';
+    const trimmed = displayName.trim();
+    if (!trimmed) return '';
+    const parts = trimmed.split(/\s+/);
+    if (parts.length === 1) {
+        return [...parts[0]][0]?.toUpperCase() ?? '';
+    }
+    const first = [...parts[0]][0] ?? '';
+    const last = [...parts[parts.length - 1]][0] ?? '';
+    return (first + last).toUpperCase();
+}

--- a/client/packages/react-ui/src/hooks/useAvatarResolver.ts
+++ b/client/packages/react-ui/src/hooks/useAvatarResolver.ts
@@ -67,13 +67,16 @@ function materializeAvatar(source: AvatarSource | null, objectUrls: string[]): R
 
 export function initialsFor(displayName: string | undefined): string {
     if (!displayName) return '';
-    const trimmed = displayName.trim();
-    if (!trimmed) return '';
-    const parts = trimmed.split(/\s+/);
-    if (parts.length === 1) {
-        return [...parts[0]][0]?.toUpperCase() ?? '';
+    const initials: string[] = [];
+    for (const part of displayName.trim().split(/\s+/)) {
+        for (const ch of part) {
+            if (/[\p{L}\p{N}]/u.test(ch)) {
+                initials.push(ch.toUpperCase());
+                break;
+            }
+        }
     }
-    const first = [...parts[0]][0] ?? '';
-    const last = [...parts[parts.length - 1]][0] ?? '';
-    return (first + last).toUpperCase();
+    if (initials.length === 0) return '';
+    if (initials.length === 1) return initials[0];
+    return initials[0] + initials[initials.length - 1];
 }

--- a/client/packages/react-ui/src/hooks/useAvatarResolver.ts
+++ b/client/packages/react-ui/src/hooks/useAvatarResolver.ts
@@ -15,9 +15,11 @@ export type AvatarResolver = (peerId: string | undefined) => ResolvedAvatar;
 export function useAvatarResolver(provider: AvatarProvider | undefined): AvatarResolver {
     const cacheRef = useRef<Map<string, CacheEntry>>(new Map());
     const objectUrlsRef = useRef<string[]>([]);
+    const mountedRef = useRef(true);
     const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
     useEffect(() => () => {
+        mountedRef.current = false;
         for (const url of objectUrlsRef.current) {
             URL.revokeObjectURL(url);
         }
@@ -34,12 +36,16 @@ export function useAvatarResolver(provider: AvatarProvider | undefined): AvatarR
         if (cached !== undefined) return cached;
 
         cacheRef.current.set(peerId, 'pending');
-        provider(peerId).then(
+        // Wrap in Promise.resolve so a sync throw inside a non-async provider
+        // becomes a rejection and never escapes the render path.
+        Promise.resolve().then(() => provider(peerId)).then(
             (source) => {
+                if (!mountedRef.current) return;
                 cacheRef.current.set(peerId, materializeAvatar(source, objectUrlsRef.current));
                 forceUpdate();
             },
             (error) => {
+                if (!mountedRef.current) return;
                 console.warn('[serenada] avatarProvider rejected for', peerId, error);
                 cacheRef.current.set(peerId, null);
                 forceUpdate();

--- a/client/packages/react-ui/src/index.ts
+++ b/client/packages/react-ui/src/index.ts
@@ -10,7 +10,14 @@ export { useCallState } from './hooks/useCallState.js';
 
 // Call Flow
 export { SerenadaCallFlow } from './SerenadaCallFlow.js';
-export type { SerenadaCallFlowConfig, SerenadaCallFlowTheme, SerenadaString, CallFlowProps } from './types.js';
+export type {
+    SerenadaCallFlowConfig,
+    SerenadaCallFlowTheme,
+    SerenadaString,
+    CallFlowProps,
+    AvatarProvider,
+    AvatarSource,
+} from './types.js';
 export { serenadaDefaultStrings, resolveString } from './types.js';
 
 export { StatusOverlay } from './components/StatusOverlay.js';

--- a/client/packages/react-ui/src/types.ts
+++ b/client/packages/react-ui/src/types.ts
@@ -2,6 +2,28 @@ import type { ReactNode } from 'react';
 import type { SerenadaSessionHandle, CallStats } from '@serenada/core';
 
 // ---------------------------------------------------------------------------
+// Avatar provider (host-supplied)
+// ---------------------------------------------------------------------------
+
+/**
+ * Avatar payload returned by an {@link AvatarProvider}. The image is rendered
+ * cover-fit, cropped to a circle above the participant's name when their
+ * remote video track is off.
+ */
+export type AvatarSource =
+    | { kind: 'url'; url: string }
+    | { kind: 'bytes'; bytes: Uint8Array }
+    | { kind: 'image'; image: HTMLImageElement };
+
+/**
+ * Resolves an avatar for a given host-supplied `peerId`. Returning `null` (or
+ * throwing) falls back to the initials placeholder. The call UI never blocks
+ * on the provider — it shows initials immediately and swaps in the avatar
+ * when the promise resolves. Each `peerId` is resolved at most once per call.
+ */
+export type AvatarProvider = (peerId: string) => Promise<AvatarSource | null>;
+
+// ---------------------------------------------------------------------------
 // Feature configuration
 // ---------------------------------------------------------------------------
 
@@ -15,6 +37,13 @@ export interface SerenadaCallFlowConfig {
      * `false`, the controls are always visible and the idle timer never runs.
      */
     autoHideControls?: boolean;
+    /**
+     * Optional resolver that returns an avatar for a remote participant's
+     * host-supplied `peerId` (passed to {@link SerenadaCore.join}). When
+     * unset or when `peerId` is absent on the participant, the call UI shows
+     * an initials placeholder derived from their display name.
+     */
+    avatarProvider?: AvatarProvider;
 }
 
 export interface SerenadaCallFlowTheme {

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -125,10 +125,18 @@ Join a room.
     },
     "createMaxParticipants": 4,
     "displayName": "optional display name",
+    "peerId": "optional host-supplied stable identity",
     "reconnectCid": "optionalPreviousClientId"
   }
 }
 ```
+
+**Notes**
+- `peerId` is opaque to the server and forwarded verbatim in `participants` entries
+  for `joined` and `room_state`. It lets host applications correlate a participant
+  to their own user identity (for avatar lookup, telemetry, etc.) — distinct from
+  `cid`, which is per-call and server-issued. Trimmed and truncated to 128
+  characters; an empty string clears the stored value (matching `displayName`).
 
 **Server behavior**
 - Validate `rid` as a signed 27-character room token (generated via `/api/room-id`).
@@ -170,7 +178,7 @@ Acknowledges join success and provides room state.
 **Fields in payload**
 - `hostCid` *(string)*: client ID of the current host.
 - `maxParticipants` *(number)*: current effective room capacity. For a newly created group-requested room, this is `2` until the second distinct participant joins and locks the final room capacity.
-- `participants` *(array)*: list of current participants. Each entry has `cid` *(string)*, `joinedAt` *(number, optional)*, `displayName` *(string, optional)*, `audioEnabled` *(boolean, optional)*, `videoEnabled` *(boolean, optional)*, and `connectionStatus` *(string, optional)*. See section 4.3 for the meaning of `connectionStatus`.
+- `participants` *(array)*: list of current participants. Each entry has `cid` *(string)*, `joinedAt` *(number, optional)*, `displayName` *(string, optional)*, `peerId` *(string, optional)*, `audioEnabled` *(boolean, optional)*, `videoEnabled` *(boolean, optional)*, and `connectionStatus` *(string, optional)*. See section 4.3 for the meaning of `connectionStatus`.
 - `turnToken` *(string, optional)*: temporary token for fetching TURN credentials from `/api/turn-credentials`. Only present on successful join.
 - `turnTokenExpiresAt` *(number, optional)*: unix timestamp (seconds) when the token expires.
 

--- a/server/multiparty_test.go
+++ b/server/multiparty_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -48,6 +49,7 @@ func drainMessages(c *Client) []Message {
 type joinPayloadOptions struct {
 	ReconnectCID string
 	DisplayName  *string
+	PeerID       *string
 }
 
 // joinPayload builds a raw JSON join message with optional capabilities.
@@ -64,11 +66,13 @@ func joinPayloadWithOptions(rid string, capMax int, createMax int, options joinP
 		CreateMaxParticipants int     `json:"createMaxParticipants,omitempty"`
 		ReconnectCID          string  `json:"reconnectCid,omitempty"`
 		DisplayName           *string `json:"displayName,omitempty"`
+		PeerID                *string `json:"peerId,omitempty"`
 	}{
 		Capabilities:          caps{MaxParticipants: capMax},
 		CreateMaxParticipants: createMax,
 		ReconnectCID:          options.ReconnectCID,
 		DisplayName:           options.DisplayName,
+		PeerID:                options.PeerID,
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
@@ -188,6 +192,88 @@ func TestReconnectJoinCanClearDisplayName(t *testing.T) {
 	}
 	if reattached.DisplayName != "" {
 		t.Fatalf("expected reconnect with empty displayName to clear the stored name, got %q", reattached.DisplayName)
+	}
+}
+
+func TestJoinPropagatesPeerIDInSnapshot(t *testing.T) {
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	c1 := fakeClient(hub)
+	hub.registerClient(c1)
+	alicePeer := "host-user-alice"
+	hub.handleMessage(c1, joinPayloadWithOptions(rid, 4, 4, joinPayloadOptions{
+		PeerID: &alicePeer,
+	}))
+	drainMessages(c1)
+
+	c2 := fakeClient(hub)
+	hub.registerClient(c2)
+	bobPeer := "host-user-bob"
+	hub.handleMessage(c2, joinPayloadWithOptions(rid, 4, 4, joinPayloadOptions{
+		PeerID: &bobPeer,
+	}))
+
+	msgs := drainMessages(c2)
+	var joined Message
+	for _, m := range msgs {
+		if m.Type == "joined" {
+			joined = m
+			break
+		}
+	}
+	if joined.Type == "" {
+		t.Fatal("expected joined message for c2")
+	}
+
+	var payload struct {
+		Participants []Participant `json:"participants"`
+	}
+	if err := json.Unmarshal(joined.Payload, &payload); err != nil {
+		t.Fatalf("failed to parse joined payload: %v", err)
+	}
+	gotByCID := map[string]string{}
+	for _, p := range payload.Participants {
+		gotByCID[p.CID] = p.PeerID
+	}
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	room.mu.Lock()
+	aliceCID := room.cidForClient(c1)
+	bobCID := room.cidForClient(c2)
+	room.mu.Unlock()
+	if gotByCID[aliceCID] != alicePeer {
+		t.Fatalf("expected alice peerId %q, got %q", alicePeer, gotByCID[aliceCID])
+	}
+	if gotByCID[bobCID] != bobPeer {
+		t.Fatalf("expected bob peerId %q, got %q", bobPeer, gotByCID[bobCID])
+	}
+}
+
+func TestJoinTruncatesOversizedPeerID(t *testing.T) {
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	c := fakeClient(hub)
+	hub.registerClient(c)
+	oversized := strings.Repeat("a", maxPeerIDLength+50)
+	hub.handleMessage(c, joinPayloadWithOptions(rid, 4, 4, joinPayloadOptions{
+		PeerID: &oversized,
+	}))
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	room.mu.Lock()
+	defer room.mu.Unlock()
+	cid := room.cidForClient(c)
+	p := room.participantByCID(cid)
+	if p == nil {
+		t.Fatal("expected participant record")
+	}
+	if len([]rune(p.PeerID)) != maxPeerIDLength {
+		t.Fatalf("expected peerId truncated to %d runes, got %d", maxPeerIDLength, len([]rune(p.PeerID)))
 	}
 }
 

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -18,6 +18,7 @@ import (
 
 const maxMessageSize = 65536 // 64KB
 const maxDisplayNameLength = 40
+const maxPeerIDLength = 128
 
 // TURN token TTL for call credentials: 15 minutes.
 // Clients proactively refresh at 80% of TTL (~12 min). Both Cloudflare and coturn
@@ -93,6 +94,7 @@ type Participant struct {
 	CID              string `json:"cid"`
 	JoinedAt         int64  `json:"joinedAt,omitempty"`
 	DisplayName      string `json:"displayName,omitempty"`
+	PeerID           string `json:"peerId,omitempty"` // host-supplied stable identity, distinct from CID; opaque to server
 	AudioEnabled     *bool  `json:"audioEnabled,omitempty"`
 	VideoEnabled     *bool  `json:"videoEnabled,omitempty"`
 	ConnectionStatus string `json:"connectionStatus,omitempty"` // "suspended" when transport detached; omitted (= "active") otherwise
@@ -107,6 +109,7 @@ type roomParticipant struct {
 	CID          string
 	JoinedAt     int64
 	DisplayName  string
+	PeerID       string
 	AudioEnabled *bool
 	VideoEnabled *bool
 	// Client is the currently attached transport. Nil when suspended.
@@ -239,6 +242,7 @@ func (r *Room) snapshotParticipants() []Participant {
 			CID:          p.CID,
 			JoinedAt:     p.JoinedAt,
 			DisplayName:  p.DisplayName,
+			PeerID:       p.PeerID,
 			AudioEnabled: p.AudioEnabled,
 			VideoEnabled: p.VideoEnabled,
 		}
@@ -495,6 +499,7 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 		ReconnectToken        string  `json:"reconnectToken"`
 		CreateMaxParticipants int     `json:"createMaxParticipants"`
 		DisplayName           *string `json:"displayName"`
+		PeerID                *string `json:"peerId"`
 		Capabilities          struct {
 			MaxParticipants int `json:"maxParticipants"`
 		} `json:"capabilities"`
@@ -686,6 +691,19 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 			trimmed = string(runes[:maxDisplayNameLength])
 		}
 		p.DisplayName = trimmed
+	}
+
+	// Update peer ID on every join. Empty string clears it (mirroring displayName).
+	// PeerID is host-supplied (e.g. host's user identifier) and opaque to the server —
+	// it is forwarded to other participants so call UIs can resolve avatars consistently
+	// even when displayName collides.
+	if joinPayload.PeerID != nil && p != nil {
+		trimmed := strings.TrimSpace(*joinPayload.PeerID)
+		runes := []rune(trimmed)
+		if len(runes) > maxPeerIDLength {
+			trimmed = string(runes[:maxPeerIDLength])
+		}
+		p.PeerID = trimmed
 	}
 
 	if room.HostCID == "" {


### PR DESCRIPTION
## Summary
- Adds an optional `peerId` parameter to `SerenadaCore.join` across web, Android, and iOS — distinct from the per-call cid, this is host-supplied stable identity that surfaces on the remote `Participant` model.
- Adds an `avatarProvider` to `SerenadaCallFlowConfig` (web React UI, Android Compose UI, iOS SwiftUI). When the remote video track is off, the call UI renders a circle avatar above the name; null/error/no provider falls back to initials.
- Server forwards `peerId` opaquely in `joined`/`room_state` participant entries (trimmed, max 128 chars). Wire-compatible — older clients ignore the new field per protocol forward-compat rules.

## Behavior
- Resolved once per `peerId` per call, cached for call lifetime — no re-fetch on every video-track transition.
- Lazy: only called on the first frame the placeholder is needed; silent peers don't trigger a fetch.
- Non-blocking: UI shows initials immediately, swaps in avatar when the suspend/async function returns.
- `AvatarSource` accepts URL, raw bytes, or pre-decoded image (`HTMLImageElement` / `Bitmap` / `UIImage`).

## Naming note
The web SDK's `SignalingProvider` abstraction already used `peerId` to mean cid. To avoid a collision, the new field is exposed at the abstraction layer as `appPeerId`, while the public API and wire JSON keep the proposed name `peerId`.

## Test plan
- [x] Server unit tests (existing + 2 new for peerId round-trip and oversized truncation)
- [x] Web: 288/288 vitest, `tsc --noEmit` clean, `vite build` OK
- [x] Android: `:serenada-core:test`, `:serenada-call-ui:assembleDebug`, `:app:assembleDebug` all pass
- [x] iOS: `xcodebuild test` on iPhone 17 simulator — all unit + UI tests pass
- [x] `check-resilience-constants.mjs` and `check-version-parity.mjs` green
- [ ] Manual smoke test on real devices (avatar render with URL/bytes/image sources, fallback to initials when provider returns null, lazy resolution timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)