### PR TITLE
Resilience #1: dispatch + consume negotiation_dirty / relay_failed

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"2a1e8903-08ff-4306-af3d-207716cb0439","pid":12128,"procStart":"Wed Apr 29 03:19:58 2026","acquiredAt":1777441942904}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2a1e8903-08ff-4306-af3d-207716cb0439","pid":12128,"procStart":"Wed Apr 29 03:19:58 2026","acquiredAt":1777441942904}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ secrets/
 /.webrtc-ios-build
 client-ios/Resources/GoogleService-Info.plist
 /.claude/worktrees
+/.claude/scheduled_tasks.lock
 /tools/smoke-test/artifacts
 
 # ralphex progress logs

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -9,6 +9,8 @@ import app.serenada.core.call.SignalingMessage
 import app.serenada.core.call.WebRtcResilienceConstants
 import app.serenada.core.call.toErrorPayload
 import app.serenada.core.call.toJoinedPayload
+import app.serenada.core.call.toNegotiationDirtyPayload
+import app.serenada.core.call.toRelayFailedPayload
 import app.serenada.core.call.toRoomStatePayload
 import app.serenada.core.network.CoreApiClient
 import app.serenada.core.network.SessionAPIClient
@@ -227,6 +229,20 @@ internal class SerenadaServerProvider(
                 }
             }
             "offer", "answer", "ice", "content_state", "participant_media_state" -> emitPeerMessage(message)
+            "negotiation_dirty" -> {
+                val payload = message.payload.toNegotiationDirtyPayload() ?: return
+                listener?.onNegotiationDirty(NegotiationDirtyEvent(withCid = payload.withCid))
+            }
+            "relay_failed" -> {
+                val payload = message.payload.toRelayFailedPayload() ?: return
+                listener?.onRelayFailed(
+                    RelayFailedEvent(
+                        reason = payload.reason,
+                        targets = payload.targets,
+                        of = payload.of,
+                    )
+                )
+            }
             "pong" -> signaling.recordPong()
         }
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -581,6 +581,26 @@ class SerenadaSession internal constructor(
                 applyIceServers(iceServers)
             }
         }
+
+        override fun onNegotiationDirty(event: NegotiationDirtyEvent) {
+            runOnMain {
+                logger?.log(SerenadaLogLevel.DEBUG, "Session", "RX negotiation_dirty with=${event.withCid}")
+                peerNegotiationEngine.scheduleIceRestart(event.withCid, "negotiation-dirty", 0)
+            }
+        }
+
+        override fun onRelayFailed(event: RelayFailedEvent) {
+            runOnMain {
+                // Server has the dirty-pair record; once the suspended target
+                // reattaches we'll get `negotiation_dirty` and renegotiate then.
+                // For now, just surface in logs so suppressed offers/ICE are visible.
+                logger?.log(
+                    SerenadaLogLevel.DEBUG,
+                    "Session",
+                    "RX relay_failed reason=${event.reason} of=${event.of ?: "n/a"} targets=${event.targets.joinToString(",")}",
+                )
+            }
+        }
     }
 
     // --- Public API ---

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
@@ -101,6 +101,27 @@ data class ErrorEvent(
 )
 
 /**
+ * Server tells an active peer that a previously-suspended peer has reattached
+ * AND there was pending negotiation traffic to it during the suspension. The
+ * SDK should perform glare-safe fresh negotiation / ICE restart for the named
+ * CID.
+ */
+data class NegotiationDirtyEvent(
+    /** The CID that needs fresh renegotiation. */
+    val withCid: String,
+)
+
+/** Server tells the sender it could not deliver a relay because the target had no transport. */
+data class RelayFailedEvent(
+    /** Server-assigned reason code, e.g. `"target_suspended"`. */
+    val reason: String,
+    /** Target CIDs the relay could not reach. */
+    val targets: List<String>,
+    /** Original signaling type that failed, e.g. `"offer" | "answer" | "ice"`. */
+    val of: String? = null,
+)
+
+/**
  * Transport-agnostic signaling contract for Android SDK sessions.
  *
  * Implementations may invoke [listener] callbacks from any thread. The session
@@ -153,5 +174,7 @@ interface SignalingProvider {
         fun onRoomEnded(event: RoomEndedEvent) {}
         fun onError(event: ErrorEvent) {}
         fun onIceServersChanged(iceServers: List<PeerConnection.IceServer>) {}
+        fun onNegotiationDirty(event: NegotiationDirtyEvent) {}
+        fun onRelayFailed(event: RelayFailedEvent) {}
     }
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionDirtyPairTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionDirtyPairTest.kt
@@ -1,0 +1,104 @@
+package app.serenada.core
+
+import app.serenada.core.fakes.TestSessionFactory
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Failure-mode #1 from `docs/resilience-failure-modes.md`: when the server
+ * sends `negotiation_dirty{with: cid}` after a previously-suspended peer
+ * reattaches, the SDK must schedule glare-safe ICE restart for that peer.
+ * `relay_failed` is informational — the SDK should not act on it directly
+ * (the same dirty-pair condition will surface as `negotiation_dirty` after
+ * the target reattaches).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SessionDirtyPairTest {
+
+    private lateinit var factory: TestSessionFactory
+
+    @Before fun setUp() { factory = TestSessionFactory(handlesReconnection = true) }
+    @After fun tearDown() { factory.tearDown() }
+
+    @Test
+    fun `negotiation_dirty schedules ICE restart for the named peer`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        val slot = factory.fakeMedia.fakeSlots.getValue("remote")
+        val baselineOffers = slot.createOfferCalls
+
+        factory.fakeProvider.simulateNegotiationDirty(withCid = "remote")
+        ShadowLooper.idleMainLooper()
+
+        // ICE restart machinery either fires a new offer immediately, or
+        // marks the slot pending (depending on slot ready state).
+        assertTrue(
+            "negotiation_dirty should trigger ICE restart for the named peer",
+            slot.createOfferCalls > baselineOffers || slot.pendingIceRestart || slot.iceRestartTask != null,
+        )
+    }
+
+    @Test
+    fun `negotiation_dirty for unknown peer is a no-op`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        val slot = factory.fakeMedia.fakeSlots.getValue("remote")
+        val baselineOffers = slot.createOfferCalls
+
+        factory.fakeProvider.simulateNegotiationDirty(withCid = "stranger")
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(
+            "Stranger CID should not affect known peer's slot",
+            baselineOffers,
+            slot.createOfferCalls,
+        )
+    }
+
+    @Test
+    fun `relay_failed is informational and does not schedule ICE restart`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        val slot = factory.fakeMedia.fakeSlots.getValue("remote")
+        val baselineOffers = slot.createOfferCalls
+        val baselinePending = slot.pendingIceRestart
+
+        factory.fakeProvider.simulateRelayFailed(
+            reason = "target_suspended",
+            targets = listOf("remote"),
+            of = "offer",
+        )
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(
+            "relay_failed should be logged only — no immediate ICE restart",
+            baselineOffers,
+            slot.createOfferCalls,
+        )
+        assertEquals(
+            "relay_failed should not mark the slot pending",
+            baselinePending,
+            slot.pendingIceRestart,
+        )
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeSignalingProvider.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeSignalingProvider.kt
@@ -4,9 +4,11 @@ import app.serenada.core.ConnectionInfo
 import app.serenada.core.ErrorEvent
 import app.serenada.core.JoinOptions
 import app.serenada.core.JoinedEvent
+import app.serenada.core.NegotiationDirtyEvent
 import app.serenada.core.PeerEvent
 import app.serenada.core.PeerMessage
 import app.serenada.core.ProviderCapabilities
+import app.serenada.core.RelayFailedEvent
 import app.serenada.core.RoomEndedEvent
 import app.serenada.core.RoomStateEvent
 import app.serenada.core.SignalingProvider
@@ -154,6 +156,14 @@ internal class FakeSignalingProvider(
 
     fun simulateIceServersChanged(iceServers: List<PeerConnection.IceServer>) {
         listener?.onIceServersChanged(iceServers)
+    }
+
+    fun simulateNegotiationDirty(withCid: String) {
+        listener?.onNegotiationDirty(NegotiationDirtyEvent(withCid = withCid))
+    }
+
+    fun simulateRelayFailed(reason: String, targets: List<String>, of: String? = null) {
+        listener?.onRelayFailed(RelayFailedEvent(reason = reason, targets = targets, of = of))
     }
 
     fun sentMessages(ofType: String): List<SentProviderMessage> {

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -227,6 +227,18 @@ extension SerenadaServerProvider: SignalingClientListener {
             turnManager?.handleTurnRefreshed(payload: message.payload)
         case "offer", "answer", "ice", "content_state", "participant_media_state":
             emitPeerMessage(message)
+        case "negotiation_dirty":
+            if let payload = NegotiationDirtyPayload(from: message.payload) {
+                delegate?.signalingProviderDidReceiveNegotiationDirty(
+                    NegotiationDirtyEvent(withCid: payload.withCid)
+                )
+            }
+        case "relay_failed":
+            if let payload = RelayFailedPayload(from: message.payload) {
+                delegate?.signalingProviderDidReceiveRelayFailed(
+                    RelayFailedEvent(reason: payload.reason, targets: payload.targets, of: payload.of)
+                )
+            }
         case "pong":
             signaling.recordPong()
         default:

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -88,6 +88,18 @@ private final class SignalingProviderDelegateProxy: SignalingProviderDelegate {
             session?.handleProviderIceServersChanged(iceServers)
         }
     }
+
+    func signalingProviderDidReceiveNegotiationDirty(_ event: NegotiationDirtyEvent) {
+        Task { @MainActor [weak session] in
+            session?.handleProviderNegotiationDirty(event)
+        }
+    }
+
+    func signalingProviderDidReceiveRelayFailed(_ event: RelayFailedEvent) {
+        Task { @MainActor [weak session] in
+            session?.handleProviderRelayFailed(event)
+        }
+    }
 }
 
 /// Represents an active call session. Created via ``SerenadaCore/join(url:)`` or ``SerenadaCore/createRoom()``.
@@ -719,6 +731,22 @@ public final class SerenadaSession: ObservableObject {
 
     fileprivate func handleProviderIceServersChanged(_ iceServers: [IceServerConfig]) {
         applyIceServers(iceServers)
+    }
+
+    fileprivate func handleProviderNegotiationDirty(_ event: NegotiationDirtyEvent) {
+        logger?.log(.debug, tag: "Session", "RX negotiation_dirty with=\(event.withCid)")
+        peerNegotiationEngine?.scheduleIceRestart(remoteCid: event.withCid, reason: "negotiation-dirty", delayMs: 0)
+    }
+
+    fileprivate func handleProviderRelayFailed(_ event: RelayFailedEvent) {
+        // Server has the dirty-pair record; once the suspended target reattaches
+        // we'll get `negotiation_dirty` and renegotiate then. For now, surface
+        // in logs so suppressed offers/ICE are visible.
+        logger?.log(
+            .debug,
+            tag: "Session",
+            "RX relay_failed reason=\(event.reason) of=\(event.of ?? "n/a") targets=\(event.targets.joined(separator: ","))"
+        )
     }
 
     // MARK: - Participants

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -195,6 +195,35 @@ public struct ErrorEvent: Equatable, Sendable {
     }
 }
 
+/// Server tells an active peer that a previously-suspended peer has reattached
+/// AND there was pending negotiation traffic to it during the suspension. The
+/// SDK should perform glare-safe fresh negotiation / ICE restart for the
+/// named CID.
+public struct NegotiationDirtyEvent: Equatable, Sendable {
+    /// The CID that needs fresh renegotiation.
+    public let withCid: String
+
+    public init(withCid: String) {
+        self.withCid = withCid
+    }
+}
+
+/// Server tells the sender it could not deliver a relay because the target had no transport.
+public struct RelayFailedEvent: Equatable, Sendable {
+    /// Server-assigned reason code, e.g. `"target_suspended"`.
+    public let reason: String
+    /// Target CIDs the relay could not reach.
+    public let targets: [String]
+    /// Original signaling type that failed, e.g. `"offer" | "answer" | "ice"`.
+    public let of: String?
+
+    public init(reason: String, targets: [String], of: String? = nil) {
+        self.reason = reason
+        self.targets = targets
+        self.of = of
+    }
+}
+
 /// Receives provider events. Implementations may invoke these callbacks from
 /// any thread; the SDK session layer hops back to the main actor before
 /// mutating observable SDK state.
@@ -209,6 +238,8 @@ public protocol SignalingProviderDelegate: AnyObject {
     func signalingProviderDidEndRoom(_ event: RoomEndedEvent)
     func signalingProviderDidReceiveError(_ event: ErrorEvent)
     func signalingProviderDidChangeIceServers(_ iceServers: [IceServerConfig])
+    func signalingProviderDidReceiveNegotiationDirty(_ event: NegotiationDirtyEvent)
+    func signalingProviderDidReceiveRelayFailed(_ event: RelayFailedEvent)
 }
 
 public extension SignalingProviderDelegate {
@@ -222,6 +253,8 @@ public extension SignalingProviderDelegate {
     func signalingProviderDidEndRoom(_ event: RoomEndedEvent) {}
     func signalingProviderDidReceiveError(_ event: ErrorEvent) {}
     func signalingProviderDidChangeIceServers(_ iceServers: [IceServerConfig]) {}
+    func signalingProviderDidReceiveNegotiationDirty(_ event: NegotiationDirtyEvent) {}
+    func signalingProviderDidReceiveRelayFailed(_ event: RelayFailedEvent) {}
 }
 
 /// Transport-agnostic signaling contract for iOS SDK sessions.

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSignalingProvider.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeSignalingProvider.swift
@@ -150,4 +150,12 @@ final class FakeSignalingProvider: SignalingProvider {
     func simulateIceServersChanged(_ iceServers: [IceServerConfig]) {
         delegate?.signalingProviderDidChangeIceServers(iceServers)
     }
+
+    func simulateNegotiationDirty(withCid: String) {
+        delegate?.signalingProviderDidReceiveNegotiationDirty(NegotiationDirtyEvent(withCid: withCid))
+    }
+
+    func simulateRelayFailed(reason: String, targets: [String], of: String? = nil) {
+        delegate?.signalingProviderDidReceiveRelayFailed(RelayFailedEvent(reason: reason, targets: targets, of: of))
+    }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionDirtyPairTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionDirtyPairTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import SerenadaCore
+
+/// Failure-mode #1 from `docs/resilience-failure-modes.md`: when the server
+/// sends `negotiation_dirty{with: cid}` after a previously-suspended peer
+/// reattaches, the SDK must schedule glare-safe ICE restart for that peer.
+/// `relay_failed` is informational — the SDK should not act on it directly
+/// (the same dirty-pair condition will surface as `negotiation_dirty` after
+/// the target reattaches).
+@MainActor
+final class SessionDirtyPairTests: XCTestCase {
+
+    private var harness: SessionTestHarness!
+
+    override func setUp() async throws {
+        harness = SessionTestHarness(handlesReconnection: true)
+    }
+
+    override func tearDown() async throws {
+        harness.tearDown()
+        harness = nil
+    }
+
+    func testNegotiationDirtySchedulesIceRestartForNamedPeer() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        let slot = harness.fakeMedia.fakeSlots["remote"]
+        XCTAssertNotNil(slot)
+        let baselineOffers = slot?.createOfferCalls ?? 0
+
+        harness.fakeProvider.simulateNegotiationDirty(withCid: "remote")
+        await harness.yieldToMainActor()
+
+        let didFire = (slot?.createOfferCalls ?? 0) > baselineOffers
+            || slot?.iceRestartTask != nil
+            || slot?.pendingIceRestart == true
+        XCTAssertTrue(didFire, "negotiation_dirty should trigger ICE restart for the named peer")
+    }
+
+    func testNegotiationDirtyForUnknownPeerIsNoOp() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        let slot = harness.fakeMedia.fakeSlots["remote"]
+        let baselineOffers = slot?.createOfferCalls ?? 0
+        let baselinePending = slot?.pendingIceRestart ?? false
+
+        harness.fakeProvider.simulateNegotiationDirty(withCid: "stranger")
+        await harness.yieldToMainActor()
+
+        XCTAssertEqual(slot?.createOfferCalls ?? 0, baselineOffers)
+        XCTAssertEqual(slot?.pendingIceRestart ?? false, baselinePending)
+    }
+
+    func testRelayFailedIsInformationalAndDoesNotScheduleIceRestart() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        let slot = harness.fakeMedia.fakeSlots["remote"]
+        let baselineOffers = slot?.createOfferCalls ?? 0
+        let baselinePending = slot?.pendingIceRestart ?? false
+
+        harness.fakeProvider.simulateRelayFailed(
+            reason: "target_suspended",
+            targets: ["remote"],
+            of: "offer"
+        )
+        await harness.yieldToMainActor()
+
+        XCTAssertEqual(slot?.createOfferCalls ?? 0, baselineOffers,
+                       "relay_failed should be logged only — no immediate ICE restart")
+        XCTAssertEqual(slot?.pendingIceRestart ?? false, baselinePending,
+                       "relay_failed should not mark the slot pending")
+    }
+}

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2689E7B3ED25607A90E268B7 /* FakeMediaEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461DCF4D9C695C2B6051BF91 /* FakeMediaEngine.swift */; };
 		2A96BF63C126AFE8CE2976D4 /* RecoveryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77004950192C89C56E76A8F /* RecoveryStorageTests.swift */; };
 		2B3986D47A857C11365A6D68 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5B216BB8A302914AB1CA5B /* NotificationService.swift */; };
+		2BF323F5A22C2952822DE96D /* SessionDirtyPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8815B032D4EFBB62BB976B66 /* SessionDirtyPairTests.swift */; };
 		2DC84097620992B43C52D59E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = ECFBB844D3428C53592F5F7B /* FirebaseMessaging */; };
 		3153C0E407E8DD601B43B97E /* RootViewRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD7296B4488661AE49A34BA /* RootViewRoutingTests.swift */; };
 		332B4061CA3CF448DBF766D6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8648687C9C97AD05ABC9AEB /* AppDelegate.swift */; };
@@ -185,6 +186,7 @@
 		801D5040B2102E7DFFFDC2B2 /* LoopbackSignalingProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopbackSignalingProviderTests.swift; sourceTree = "<group>"; };
 		8656DA5A095E572174461E96 /* L10nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10nTests.swift; sourceTree = "<group>"; };
 		8662332FB191C23A57DDBA4D /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
+		8815B032D4EFBB62BB976B66 /* SessionDirtyPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDirtyPairTests.swift; sourceTree = "<group>"; };
 		8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNegotiationTests.swift; sourceTree = "<group>"; };
 		96AD1035F89AEDD9E3B0F38C /* DiagnosticsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsScreen.swift; sourceTree = "<group>"; };
 		96CE1FC71083746A8D257448 /* DeepLinkParticipantCountUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkParticipantCountUITests.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */,
 				2A15CC6B14E97F4E2C37C573 /* SerenadaServerProviderTests.swift */,
 				7830FA5A71601737755C721D /* SerenadaSessionTests.swift */,
+				8815B032D4EFBB62BB976B66 /* SessionDirtyPairTests.swift */,
 				8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */,
 				09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */,
 				970E7AEDB3E705CBF2F03E95 /* SessionPostReconnectGateTests.swift */,
@@ -827,6 +830,7 @@
 				6D7CC8795CCE4899285777B4 /* SerenadaDiagnosticsTests.swift in Sources */,
 				838D89A84D60CC6245CB2EFC /* SerenadaServerProviderTests.swift in Sources */,
 				A281E4C5D7AE35EEF75A87A8 /* SerenadaSessionTests.swift in Sources */,
+				2BF323F5A22C2952822DE96D /* SessionDirtyPairTests.swift in Sources */,
 				6E8767096E3E70790EB1CEE5 /* SessionNegotiationTests.swift in Sources */,
 				CB94D71B6D37742D4EAAC565 /* SessionOrchestrationTests.swift in Sources */,
 				AFA7404C26B9F90435638F49 /* SessionPostReconnectGateTests.swift in Sources */,

--- a/client/packages/core/src/SerenadaServerProvider.ts
+++ b/client/packages/core/src/SerenadaServerProvider.ts
@@ -208,7 +208,7 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
             case 'negotiation_dirty': {
                 const dirty = parseNegotiationDirtyPayload(message.payload);
                 if (dirty) {
-                    this.emit('negotiationDirty', { with: dirty.with });
+                    this.emit('negotiationDirty', { withCid: dirty.with });
                 }
                 break;
             }

--- a/client/packages/core/src/SerenadaServerProvider.ts
+++ b/client/packages/core/src/SerenadaServerProvider.ts
@@ -1,7 +1,14 @@
 import { SignalingProviderEmitter, type JoinOptions, type RoomEndedEvent, type RoomStateEvent, type SignalingProviderParticipant } from './SignalingProvider.js';
 import type { SerenadaLogger } from './types.js';
 import { SignalingEngine } from './signaling/SignalingEngine.js';
-import { parseErrorPayload, parseJoinedPayload, parseRoomStatePayload, parseTurnRefreshedPayload } from './signaling/payloads.js';
+import {
+    parseErrorPayload,
+    parseJoinedPayload,
+    parseNegotiationDirtyPayload,
+    parseRelayFailedPayload,
+    parseRoomStatePayload,
+    parseTurnRefreshedPayload,
+} from './signaling/payloads.js';
 import type { RoomParticipant, SignalingMessage } from './signaling/types.js';
 import type { TransportKind } from './signaling/transports/types.js';
 import { TURN_FETCH_TIMEOUT_MS } from './constants.js';
@@ -198,6 +205,20 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
             case 'participant_media_state':
                 this.emitPeerMessage(message);
                 break;
+            case 'negotiation_dirty': {
+                const dirty = parseNegotiationDirtyPayload(message.payload);
+                if (dirty) {
+                    this.emit('negotiationDirty', { with: dirty.with });
+                }
+                break;
+            }
+            case 'relay_failed': {
+                const failed = parseRelayFailedPayload(message.payload);
+                if (failed) {
+                    this.emit('relayFailed', failed);
+                }
+                break;
+            }
         }
     }
 

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -633,7 +633,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         if (this.isInactive) {
             return;
         }
-        this.media.scheduleDirtyPairRestart(event.with);
+        this.media.scheduleDirtyPairRestart(event.withCid);
     };
 
     private readonly handleRelayFailed = (event: RelayFailedEvent): void => {

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -15,8 +15,10 @@ import type {
     ConnectionInfo,
     SignalingErrorEvent,
     JoinOptions,
+    NegotiationDirtyEvent,
     PeerEvent,
     PeerMessage,
+    RelayFailedEvent,
     RoomStateEvent,
     SignalingProvider,
     SignalingProviderEventMap,
@@ -478,6 +480,8 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.bindProviderEvent('roomEnded', this.handleRoomEnded);
         this.bindProviderEvent('error', this.handleError);
         this.bindProviderEvent('iceServersChanged', this.handleIceServersChanged);
+        this.bindProviderEvent('negotiationDirty', this.handleNegotiationDirty);
+        this.bindProviderEvent('relayFailed', this.handleRelayFailed);
     }
 
     private bindProviderEvent<K extends SignalingProviderEventName>(
@@ -623,6 +627,27 @@ export class SerenadaSession implements SerenadaSessionHandle {
             return;
         }
         this.media.setIceServers(iceServers);
+    };
+
+    private readonly handleNegotiationDirty = (event: NegotiationDirtyEvent): void => {
+        if (this.isInactive) {
+            return;
+        }
+        this.media.scheduleDirtyPairRestart(event.with);
+    };
+
+    private readonly handleRelayFailed = (event: RelayFailedEvent): void => {
+        if (this.isInactive) {
+            return;
+        }
+        // The server has the dirty-pair record; once the suspended target
+        // reattaches we'll get `negotiation_dirty` and renegotiate then.
+        // For now, just surface in logs so suppressed offers/ICE are visible.
+        this.config.logger?.log(
+            'debug',
+            'Session',
+            `relay_failed reason=${event.reason} of=${event.of ?? 'n/a'} targets=${event.targets.join(',')}`,
+        );
     };
 
     private async fetchInitialIceServers(): Promise<void> {

--- a/client/packages/core/src/SignalingProvider.ts
+++ b/client/packages/core/src/SignalingProvider.ts
@@ -69,6 +69,27 @@ export interface SignalingErrorEvent {
     message: string;
 }
 
+/**
+ * Server tells an active peer that a previously-suspended peer has reattached
+ * AND there was pending negotiation traffic to it during the suspension. The
+ * SDK should perform glare-safe fresh negotiation / ICE restart for the named
+ * CID.
+ */
+export interface NegotiationDirtyEvent {
+    /** The CID that needs fresh renegotiation. */
+    with: string;
+}
+
+/** Server tells the sender it could not deliver a relay because the target had no transport. */
+export interface RelayFailedEvent {
+    /** Server-assigned reason code, e.g. `"target_suspended"`. */
+    reason: string;
+    /** Target CIDs the relay could not reach. */
+    targets: string[];
+    /** Original signaling type that failed, e.g. `"offer" | "answer" | "ice"`. */
+    of?: string;
+}
+
 export interface SignalingProviderEventMap {
     connected: ConnectionInfo | undefined;
     disconnected: string | undefined;
@@ -80,6 +101,8 @@ export interface SignalingProviderEventMap {
     roomEnded: RoomEndedEvent;
     error: SignalingErrorEvent;
     iceServersChanged: RTCIceServer[];
+    negotiationDirty: NegotiationDirtyEvent;
+    relayFailed: RelayFailedEvent;
 }
 
 export type SignalingProviderEventName = keyof SignalingProviderEventMap;

--- a/client/packages/core/src/SignalingProvider.ts
+++ b/client/packages/core/src/SignalingProvider.ts
@@ -73,11 +73,13 @@ export interface SignalingErrorEvent {
  * Server tells an active peer that a previously-suspended peer has reattached
  * AND there was pending negotiation traffic to it during the suspension. The
  * SDK should perform glare-safe fresh negotiation / ICE restart for the named
- * CID.
+ * CID. The wire payload field `with` is mapped to the explicit `withCid` here
+ * to avoid the JavaScript reserved-word association and to match the Android
+ * / iOS event shapes.
  */
 export interface NegotiationDirtyEvent {
     /** The CID that needs fresh renegotiation. */
-    with: string;
+    withCid: string;
 }
 
 /** Server tells the sender it could not deliver a relay because the target had no transport. */

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -154,6 +154,21 @@ export class MediaEngine {
         }
     }
 
+    /**
+     * Schedule glare-safe ICE restart for a specific peer because the server
+     * told us the pair is dirty after the peer reattached (#1).
+     */
+    scheduleDirtyPairRestart(remoteCid: string): void {
+        if (!this.peers.has(remoteCid)) {
+            return;
+        }
+        if (this.shouldIOffer(remoteCid)) {
+            this.scheduleIceRestart(remoteCid, 'negotiation-dirty', 0);
+        } else {
+            this.scheduleNonHostFallback(remoteCid);
+        }
+    }
+
     processSignalingMessage(msg: SignalingMessage): void {
         const { type, payload } = msg;
         if (!payload) return;

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -812,7 +812,7 @@ describe('SerenadaSession', () => {
 
             expect(harness.media.scheduleDirtyPairRestartCalls).toEqual([]);
 
-            harness.signaling.emitNegotiationDirty({ with: 'peer-1' });
+            harness.signaling.emitNegotiationDirty({ withCid: 'peer-1' });
 
             expect(harness.media.scheduleDirtyPairRestartCalls).toEqual(['peer-1']);
         });

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -801,6 +801,40 @@ describe('SerenadaSession', () => {
             expect(harness.media.handleSignalingReconnectCalls).toBe(1);
         });
 
+        it('schedules per-CID ICE restart on negotiation_dirty', async () => {
+            harness = new TestSessionHarness();
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-1' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            await harness.session.resumeJoin();
+
+            expect(harness.media.scheduleDirtyPairRestartCalls).toEqual([]);
+
+            harness.signaling.emitNegotiationDirty({ with: 'peer-1' });
+
+            expect(harness.media.scheduleDirtyPairRestartCalls).toEqual(['peer-1']);
+        });
+
+        it('does not call dirty-pair restart for unrelated provider events', async () => {
+            harness = new TestSessionHarness();
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-1' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+
+            // relay_failed is informational only — no ICE restart should fire.
+            harness.signaling.emitRelayFailed({
+                reason: 'target_suspended',
+                targets: ['peer-1'],
+                of: 'offer',
+            });
+
+            expect(harness.media.scheduleDirtyPairRestartCalls).toEqual([]);
+        });
+
         it('retries reconnect and rejoins when the provider does not manage reconnection', async () => {
             harness = new TestSessionHarness({ handlesReconnection: false, autoStart: true });
 

--- a/client/packages/core/test/helpers/FakeMediaEngine.ts
+++ b/client/packages/core/test/helpers/FakeMediaEngine.ts
@@ -26,6 +26,7 @@ export class FakeMediaEngine {
     cleanupAllPeersCalls = 0;
     destroyCalls = 0;
     handleSignalingReconnectCalls = 0;
+    scheduleDirtyPairRestartCalls: string[] = [];
     processSignalingMessageCalls: SignalingMessage[] = [];
     setIceServersCalls: RTCIceServer[][] = [];
     updateRoomStateCalls: { state: RoomState | null; clientId: string | null }[] = [];
@@ -81,6 +82,10 @@ export class FakeMediaEngine {
 
     handleSignalingReconnect(): void {
         this.handleSignalingReconnectCalls++;
+    }
+
+    scheduleDirtyPairRestart(remoteCid: string): void {
+        this.scheduleDirtyPairRestartCalls.push(remoteCid);
     }
 
     allPathsDirect = false;

--- a/client/packages/core/test/helpers/FakeSignalingProvider.ts
+++ b/client/packages/core/test/helpers/FakeSignalingProvider.ts
@@ -1,4 +1,14 @@
-import { SignalingProviderEmitter, type JoinOptions, type PeerEvent, type PeerMessage, type ProviderCapabilities, type RoomEndedEvent, type RoomStateEvent } from '../../src/SignalingProvider.js';
+import {
+    SignalingProviderEmitter,
+    type JoinOptions,
+    type NegotiationDirtyEvent,
+    type PeerEvent,
+    type PeerMessage,
+    type ProviderCapabilities,
+    type RelayFailedEvent,
+    type RoomEndedEvent,
+    type RoomStateEvent,
+} from '../../src/SignalingProvider.js';
 
 export class FakeSignalingProvider extends SignalingProviderEmitter {
     readonly capabilities?: ProviderCapabilities;
@@ -105,5 +115,13 @@ export class FakeSignalingProvider extends SignalingProviderEmitter {
 
     emitIceServersChanged(iceServers: RTCIceServer[]): void {
         this.emit('iceServersChanged', iceServers);
+    }
+
+    emitNegotiationDirty(event: NegotiationDirtyEvent): void {
+        this.emit('negotiationDirty', event);
+    }
+
+    emitRelayFailed(event: RelayFailedEvent): void {
+        this.emit('relayFailed', event);
     }
 }

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -187,6 +187,84 @@ describe('MediaEngine', () => {
         });
     });
 
+    it('scheduleDirtyPairRestart is a no-op for an unknown CID', () => {
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({}, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+
+        const offerCountBefore = sentMessages.filter((m) => m.type === 'offer').length;
+
+        // Unknown CID — should not throw and should not produce any offers.
+        engine.scheduleDirtyPairRestart('stranger');
+
+        const offerCountAfter = sentMessages.filter((m) => m.type === 'offer').length;
+        expect(offerCountAfter).toBe(offerCountBefore);
+        expect(engine.getPeerConnectionsMap().has('stranger')).toBe(false);
+    });
+
+    it('scheduleDirtyPairRestart dispatches to scheduleIceRestart when local should offer', () => {
+        const engine = new MediaEngine({}, () => {});
+
+        engine.updateSignalingConnected(true);
+        // Local 'alpha' (host) sorts before 'zeta', so local should offer.
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+
+        // Spy on the private routing methods to verify dispatch without
+        // fighting the FakeRtcPeerConnection's signaling-state guards
+        // (the actual ICE-restart machinery is exercised by existing tests).
+        const internals = engine as unknown as {
+            scheduleIceRestart: (cid: string, reason: string, delay: number) => void;
+            scheduleNonHostFallback: (cid: string) => void;
+        };
+        const iceSpy = vi.spyOn(internals, 'scheduleIceRestart');
+        const fallbackSpy = vi.spyOn(internals, 'scheduleNonHostFallback');
+
+        engine.scheduleDirtyPairRestart('zeta');
+
+        expect(iceSpy).toHaveBeenCalledWith('zeta', 'negotiation-dirty', 0);
+        expect(fallbackSpy).not.toHaveBeenCalled();
+
+        iceSpy.mockRestore();
+        fallbackSpy.mockRestore();
+    });
+
+    it('scheduleDirtyPairRestart dispatches to non-host fallback when local should not offer', () => {
+        const engine = new MediaEngine({}, () => {});
+
+        engine.updateSignalingConnected(true);
+        // Local 'zeta' sorts after 'alpha', so 'alpha' (the remote) is the
+        // offerer; local takes the non-host fallback path.
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'zeta');
+
+        const internals = engine as unknown as {
+            scheduleIceRestart: (cid: string, reason: string, delay: number) => void;
+            scheduleNonHostFallback: (cid: string) => void;
+        };
+        const iceSpy = vi.spyOn(internals, 'scheduleIceRestart');
+        const fallbackSpy = vi.spyOn(internals, 'scheduleNonHostFallback');
+
+        engine.scheduleDirtyPairRestart('alpha');
+
+        expect(fallbackSpy).toHaveBeenCalledWith('alpha');
+        expect(iceSpy).not.toHaveBeenCalled();
+
+        iceSpy.mockRestore();
+        fallbackSpy.mockRestore();
+    });
+
     it('uses direct string ordering for offer ownership', async () => {
         const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
         const localeCompareSpy = vi.spyOn(String.prototype, 'localeCompare').mockImplementation(() => {

--- a/docs/resilience-failure-modes.md
+++ b/docs/resilience-failure-modes.md
@@ -1,7 +1,7 @@
 # Resilience Failure Modes — Audit & Fix Plan
 
-**Status:** Phase 1 implemented; Phase 2 partial (#4 SDK snapshot gate, #5 process-death recovery, and #8 foreground/Doze force-ping landed end-to-end; #1/#3/#6/#7/#10/#13 SDK pieces outstanding).
-**Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed) · 2026-04-26 (Phase 2 partial #5+#8 landed) · 2026-04-28 (#4 SDK snapshot gate landed)
+**Status:** Phase 1 implemented; Phase 2 partial (#1 dirty-pair renegotiation, #4 SDK snapshot gate, #5 process-death recovery, and #8 foreground/Doze force-ping landed end-to-end; #3/#6/#7/#10/#13 SDK pieces outstanding).
+**Date:** 2026-04-26 (audit) · 2026-04-25 (Phase 1 landed) · 2026-04-26 (Phase 2 partial #5+#8 landed) · 2026-04-28 (#4 SDK snapshot gate landed) · 2026-04-29 (#1 dirty-pair renegotiation landed)
 **Scope:** Web, Android, iOS SDKs and the Go signaling server
 
 ## Background
@@ -60,7 +60,7 @@ must preserve the core UX model:
 
 | # | Failure Mode                                              | User-visible Symptom                                      | Severity | Effort | Status |
 |---|-----------------------------------------------------------|-----------------------------------------------------------|----------|--------|--------|
-| 1 | Negotiation messages missed while peer is suspended       | Stuck call setup, missing media after reconnect           | Critical | M      | Phase 1 (server) · SDK glare-safe renegotiation pending |
+| 1 | Negotiation messages missed while peer is suspended       | Stuck call setup, missing media after reconnect           | Critical | M      | Phase 1 (server) · Phase 2 ✅ (SDK consumes `negotiation_dirty` for per-CID ICE restart; `relay_failed` informational) |
 | 2 | Reconnect creates a new CID instead of preserving identity | App thinks it rejoined; peers see duplicate/empty state   | Critical | S      | Phase 1 ✅ |
 | 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      | Phase 1 (server cleanup gate) · SDK presentation timer + emission pending |
 | 4 | ICE restart fires on stale peer map at reconnect          | Offers to ghost CIDs, missing offers to new peers         | High     | S      | Phase 1 (server) · Phase 2 ✅ (SDK snapshot gate landed end-to-end) |
@@ -89,13 +89,18 @@ follow-up; **Phase 2** / **Phase 3** = not started, see *Suggested ordering*.
 
 ## 1. Negotiation messages missed while a peer is suspended
 
-**Status (2026-04-25):** Server side landed. `handleRelay` now records a
-dirty pair on the room when an offer/answer/ice targets a CID without an
-attached transport, replies `relay_failed{target_suspended,targets,of}` to
-the sender, and emits `negotiation_dirty{with}` to active peers right after
-the reattach snapshot. SDKs parse both new messages but glare-safe
-renegotiation scheduling in `MediaEngine` / `WebRtcEngine` /
-`PeerNegotiationEngine` is the remaining piece.
+**Status (2026-04-29):** Landed end-to-end (server + all 3 SDKs). The
+server side from Phase 1 is unchanged: `handleRelay` records a dirty pair
+on the room when an offer/answer/ice targets a CID without an attached
+transport, replies `relay_failed{target_suspended,targets,of}` to the
+sender, and emits `negotiation_dirty{with}` to active peers right after
+the reattach snapshot. SDK side: each platform now surfaces both
+messages as typed provider events (`negotiationDirty`, `relayFailed`).
+On `negotiation_dirty`, `SerenadaSession` calls per-CID
+`scheduleIceRestart`/`scheduleDirtyPairRestart` against the existing
+glare-safe ICE-restart machinery. `relay_failed` is logged but not
+acted on directly — the same dirty-pair condition will surface as
+`negotiation_dirty` once the suspended target reattaches.
 
 ### Symptom
 
@@ -1423,6 +1428,57 @@ Out of scope for this document, listed for visibility:
   it deserves a fresh look.
 
 ## Change Log
+
+### 2026-04-29 — Phase 2 partial: SDK dirty-pair renegotiation (#1)
+
+- **Provider events**: Each SDK gains two new typed provider events
+  surfacing the Phase 1 server messages:
+  - `negotiationDirty { withCid: String }` — server tells an active peer
+    that a previously-suspended peer reattached and there was pending
+    negotiation traffic to it during the suspension.
+  - `relayFailed { reason, targets, of? }` — server tells a sender it
+    could not deliver a relay because the target had no transport.
+
+- **Web SDK** (`SignalingProvider.ts`, `SerenadaServerProvider.ts`,
+  `SerenadaSession.ts`, `MediaEngine.ts`): `SerenadaServerProvider` parses
+  both messages (parsers were already present from Phase 1, dropped
+  silently before) and emits the new events. `SerenadaSession` consumes
+  `negotiationDirty` to call `MediaEngine.scheduleDirtyPairRestart(cid)`,
+  which routes through the existing per-CID `scheduleIceRestart` (or
+  `scheduleNonHostFallback` when the local peer should not offer) so all
+  existing glare/cooldown guards apply.
+
+- **Android SDK** (`SignalingProvider.kt`, `SerenadaServerProvider.kt`,
+  `SerenadaSession.kt`): `Listener` gains `onNegotiationDirty` and
+  `onRelayFailed` (default no-op). `SerenadaServerProvider` dispatches
+  via the existing `toNegotiationDirtyPayload` / `toRelayFailedPayload`
+  parsers. `SerenadaSession.buildProviderListener` consumes
+  `onNegotiationDirty` by calling
+  `peerNegotiationEngine.scheduleIceRestart(cid, "negotiation-dirty", 0)`.
+
+- **iOS SDK** (`SignalingProvider.swift`, `SerenadaServerProvider.swift`,
+  `SerenadaSession.swift`): `SignalingProviderDelegate` gains
+  `signalingProviderDidReceiveNegotiationDirty` /
+  `signalingProviderDidReceiveRelayFailed` (default no-op extensions).
+  `SerenadaServerProvider` dispatches using the already-existing
+  `NegotiationDirtyPayload` / `RelayFailedPayload` parsers (previously
+  unreachable). `SerenadaSession.handleProviderNegotiationDirty` calls
+  `peerNegotiationEngine.scheduleIceRestart(remoteCid:reason:delayMs:)`.
+
+- **`relay_failed` behavior**: All three SDKs log it but do NOT
+  immediately act on it. The same dirty-pair condition will surface as
+  `negotiation_dirty` once the suspended target reattaches; acting on
+  `relay_failed` would duplicate the trigger. A future slice can
+  optimize the in-flight offer-timeout for suspended targets.
+
+- **Tests**:
+  - Web `SerenadaSession.test.ts` — 2 new tests: `negotiation_dirty`
+    schedules per-CID ICE restart; `relay_failed` does not.
+  - Android `SessionDirtyPairTest.kt` — 3 new tests covering both events
+    + unknown-CID no-op.
+  - iOS `SessionDirtyPairTests.swift` — 3 new tests mirroring Android.
+  - Web 312 (was 310), Android `:serenada-core:testDebugUnitTest` green,
+    iOS `xcodebuild test` green.
 
 ### 2026-04-28 — Phase 2 partial: SDK post-reconnect snapshot gate (#4)
 


### PR DESCRIPTION
## Summary

Activates the Phase 1 server-side dirty-pair protocol on all three SDKs. Closes failure-mode #1 in [docs/resilience-failure-modes.md](docs/resilience-failure-modes.md). Builds on the #4 snapshot gate that landed in [#79](https://github.com/agatx/serenada/pull/79) — the server emits \`negotiation_dirty{with: cid}\` to active peers right after the post-reconnect snapshot, telling them which specific peer needs fresh renegotiation.

- **Behavior change**: when a previously-suspended peer reattaches and the SDK had pending negotiation traffic to it during the suspension, the SDK now schedules a glare-safe ICE restart for *just that peer* (rather than waiting forever for an answer that will never come).
- **\`relay_failed\` is informational only**: surfaced as a logged event but not directly acted on. The same dirty-pair condition will surface as \`negotiation_dirty\` once the suspended target reattaches; acting on both would double-trigger ICE restart. A future slice can optimize the in-flight offer-timeout for suspended targets.

## Per-platform shape

| Platform | Provider event | Consumer | Test file |
|---|---|---|---|
| Web | \`negotiationDirty\` / \`relayFailed\` events on \`SignalingProvider\` | \`MediaEngine.scheduleDirtyPairRestart(cid)\` | [SerenadaSession.test.ts](client/packages/core/test/SerenadaSession.test.ts) |
| Android | \`Listener.onNegotiationDirty\` / \`onRelayFailed\` | \`peerNegotiationEngine.scheduleIceRestart(cid, ...)\` | [SessionDirtyPairTest.kt](client-android/serenada-core/src/test/java/app/serenada/core/SessionDirtyPairTest.kt) |
| iOS | \`signalingProviderDidReceiveNegotiationDirty\` / \`...RelayFailed\` | \`peerNegotiationEngine.scheduleIceRestart(remoteCid:...)\` | [SessionDirtyPairTests.swift](client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionDirtyPairTests.swift) |

Each platform covers three cases: \`negotiation_dirty\` schedules ICE restart for the named peer; unknown CID is a no-op; \`relay_failed\` is logged but does not trigger ICE restart.

## Why route through existing per-CID \`scheduleIceRestart\`

All three platforms already have a per-peer ICE-restart entry that goes through the canonical glare/cooldown guards:
- \`isMakingOffer\` glare protection (perfect-negotiation pattern)
- \`ICE_RESTART_COOLDOWN_MS = 10_000\` cooldown
- \`canOffer\` checks (signaling connected, slot ready, host arbitration)

Calling that path means \`negotiation_dirty\` gets the same robustness as every other ICE restart trigger today.

## Test plan

- [x] \`scripts/check-resilience-constants.mjs\` (20 constants ✓)
- [x] \`scripts/check-version-parity.mjs\` (8 sources @ 0.6.2 ✓)
- [x] \`server/go test ./...\` ✓
- [x] Web \`vitest run\` (312 tests, was 310) ✓
- [x] Android \`:serenada-core:testDebugUnitTest\` ✓
- [x] iOS \`xcodebuild test\` ✓
- [ ] Manual: A drops mid-call, B sends offer to A while A is suspended → server replies \`relay_failed\`; A reattaches → server sends \`negotiation_dirty\` to B → B's ICE restart converges in one round

🤖 Generated with [Claude Code](https://claude.com/claude-code)