### PR TITLE
Resilience #3 finishing: periodic media_liveness emission

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.OkHttpClient
+import org.json.JSONArray
 import org.json.JSONObject
 import org.webrtc.EglBase
 import org.webrtc.PeerConnection
@@ -352,6 +353,16 @@ class SerenadaSession internal constructor(
     // the peer goes back to active or is removed from the room.
     private val suspendedPresentationRunnables = mutableMapOf<String, Runnable>()
     private val presumedLostRemoteCids = mutableSetOf<String>()
+
+    // #3 — periodic `media_liveness` emission. Active across the in-call
+    // window so the server can defer hard-eviction of suspended peers whose
+    // media is still flowing locally. Ticks no-op while transport is
+    // disconnected (baseline samples preserved so the next post-reconnect
+    // tick can detect flow).
+    private val lastInboundBytesByCid = mutableMapOf<String, Long>()
+    private var mediaLivenessTickRunnable: Runnable? = null
+    private var mediaLivenessEmitInFlight = false
+    private var mediaLivenessEmitCount = 0
     private var iceFetchGeneration = 0
     private var cpuWakeLock: PowerManager.WakeLock? = null
     private val availableCameraModes: List<LocalCameraMode> = resolveAvailableCameraModes()
@@ -1142,6 +1153,9 @@ class SerenadaSession internal constructor(
         peerNegotiationEngine.syncPeers(roomState)
         refreshRemoteParticipants()
         updateConnectionStatusFromSignals()
+        // Start media-liveness emission only once we have remote peers — there's
+        // nothing to report when alone in the room.
+        if (phase == CallPhase.InCall) startMediaLivenessTimer()
     }
 
     private fun refreshRemoteParticipants() {
@@ -1287,6 +1301,76 @@ class SerenadaSession internal constructor(
     /** Test-only accessor for the local signaling-state surface. */
     internal fun currentSignalingState(): SignalingState = _state.value.signalingState
 
+    /** Test-only counter incremented on each `media_liveness` broadcast. */
+    internal fun mediaLivenessBroadcastCount(): Int = mediaLivenessEmitCount
+
+    // --- Internal: Media-liveness emission (#3) ---
+
+    /**
+     * Periodic `media_liveness{cids}` broadcast for #3. Started on a
+     * successful join; runs across reconnects (ticks no-op while
+     * disconnected but baseline samples persist so the next post-reconnect
+     * tick can detect flow). Stopped on session reset/destroy.
+     */
+    private fun startMediaLivenessTimer() {
+        if (mediaLivenessTickRunnable != null) return
+        val runnable = object : Runnable {
+            override fun run() {
+                emitMediaLiveness()
+                handler.postDelayed(this, WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS)
+            }
+        }
+        mediaLivenessTickRunnable = runnable
+        handler.postDelayed(runnable, WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS)
+    }
+
+    private fun stopMediaLivenessTimer() {
+        mediaLivenessTickRunnable?.let { handler.removeCallbacks(it) }
+        mediaLivenessTickRunnable = null
+    }
+
+    private fun emitMediaLiveness() {
+        if (_state.value.phase == CallPhase.Idle || _state.value.phase == CallPhase.Ending) return
+        if (mediaLivenessEmitInFlight) return
+        if (!_diagnostics.value.isSignalingConnected) return
+        if (currentRoomState == null) return
+        val slots = peerSlots.toMap()
+        if (slots.isEmpty()) return
+
+        mediaLivenessEmitInFlight = true
+        val newSamples = mutableMapOf<String, Long>()
+        var remaining = slots.size
+        for ((cid, slot) in slots) {
+            slot.collectInboundBytes { bytes ->
+                handler.post {
+                    newSamples[cid] = bytes
+                    remaining -= 1
+                    if (remaining == 0) finalizeMediaLivenessEmit(newSamples)
+                }
+            }
+        }
+    }
+
+    private fun finalizeMediaLivenessEmit(newSamples: Map<String, Long>) {
+        mediaLivenessEmitInFlight = false
+        val flowing = mutableListOf<String>()
+        for ((cid, bytes) in newSamples) {
+            val previous = lastInboundBytesByCid[cid]
+            if (previous != null && bytes > previous) flowing.add(cid)
+            lastInboundBytesByCid[cid] = bytes
+        }
+        // Drop tracking for peers that left the room.
+        val activeCids = peerSlots.keys
+        val stale = lastInboundBytesByCid.keys.filterNot { activeCids.contains(it) }
+        for (cid in stale) lastInboundBytesByCid.remove(cid)
+
+        if (flowing.isEmpty()) return
+        if (!_diagnostics.value.isSignalingConnected) return
+        val payload = JSONObject().apply { put("cids", JSONArray(flowing)) }
+        signalingProvider.broadcast("media_liveness", payload)
+        mediaLivenessEmitCount += 1
+    }
+
     // --- Internal: Local signaling-state computation ---
 
     private fun computeSignalingState(): SignalingState {
@@ -1367,6 +1451,9 @@ class SerenadaSession internal constructor(
         reconnectToken = null; reconnectRecoveryPending = false; hasInitialIceServers = false
         cancelPostReconnectResync()
         clearAllRemoteSuspensionTracking()
+        stopMediaLivenessTimer()
+        lastInboundBytesByCid.clear()
+        mediaLivenessEmitInFlight = false
         localSuspendedSinceMs = null
         sessionStartTs = null
         if (clearRecovery) recoveryStorage.clear()

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -419,6 +419,22 @@ internal class PeerConnectionSlot(
         }
     }
 
+    override fun collectInboundBytes(onComplete: (Long) -> Unit) {
+        val pc = peerConnection
+        if (pc == null) {
+            onComplete(0L)
+            return
+        }
+        pc.getStats { report ->
+            var bytes = 0L
+            for (stat in report.statsMap.values) {
+                if (stat.type != "inbound-rtp") continue
+                bytes += memberLong(stat, "bytesReceived") ?: 0L
+            }
+            onComplete(bytes)
+        }
+    }
+
     override fun isReady(): Boolean = peerConnection != null
 
     override fun isPathDirect(): Boolean? = lastPathIsDirect

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
@@ -73,6 +73,14 @@ internal interface PeerConnectionSlotProtocol {
     fun attachRemoteSink(sink: VideoSink)
     fun detachRemoteSink(sink: VideoSink)
     fun collectWebRtcStats(onComplete: (String, RealtimeCallStats?) -> Unit)
+    /**
+     * Asynchronously samples the cumulative inbound `bytesReceived` across all
+     * inbound-rtp stats for this peer. Used by the media-liveness emitter
+     * (see SerenadaSession.startMediaLivenessTimer); a CID is "flowing" when
+     * its sample advances over the previous one. Reports `0` when the peer
+     * connection is not yet established.
+     */
+    fun collectInboundBytes(onComplete: (Long) -> Unit)
     fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy)
 
     /**

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
@@ -59,4 +59,13 @@ object WebRtcResilienceConstants {
     // compute `estimatedHardEvictionAtMs` for the `SignalingState.Suspended`
     // surface so apps can render a countdown.
     const val SUSPEND_HARD_EVICTION_TIMEOUT_MS = 600_000L
+
+    // ── Media-liveness emission cadence ──────────────────────────────
+    // Active SDKs broadcast `media_liveness{cids:[..]}` every interval for
+    // remote CIDs whose inbound media is currently flowing. The server uses
+    // this hint to defer hard-eviction of suspended peers whose media is
+    // still being received. 10s leaves headroom under the server's 30s
+    // freshness window (`mediaLivenessFreshnessWindow`) for missed
+    // emissions.
+    const val MEDIA_LIVENESS_INTERVAL_MS = 10_000L
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionMediaLivenessTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionMediaLivenessTest.kt
@@ -1,0 +1,116 @@
+package app.serenada.core
+
+import app.serenada.core.call.WebRtcResilienceConstants
+import app.serenada.core.fakes.TestSessionFactory
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.TimeUnit
+
+/**
+ * Failure mode #3 from `docs/resilience-failure-modes.md` — periodic
+ * `media_liveness{cids}` emission so the server can defer hard-eviction of
+ * suspended peers whose media is still flowing locally. Verifies that:
+ *   - The SDK broadcasts `media_liveness` when inbound bytes advance for a
+ *     peer.
+ *   - Emission skips peers with no flow.
+ *   - Emission pauses while transport is disconnected and resumes after
+ *     reconnect.
+ *   - Emission stops on session reset.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SessionMediaLivenessTest {
+
+    private lateinit var factory: TestSessionFactory
+
+    @Before fun setUp() { factory = TestSessionFactory(handlesReconnection = true) }
+    @After fun tearDown() { factory.tearDown() }
+
+    private fun livenessBroadcasts() = factory.fakeProvider.sentProviderMessages
+        .filter { it.isBroadcast && it.type == "media_liveness" }
+
+    @Test
+    fun `broadcasts media_liveness with flowing CIDs after inbound bytes advance`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        // Baseline tick: bytes=0 → no flow.
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 0
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        val baseline = livenessBroadcasts().size
+
+        // Bytes advance → flow detected → broadcast.
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 5_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+
+        val broadcasts = livenessBroadcasts()
+        assertEquals(baseline + 1, broadcasts.size)
+        val payload = broadcasts.last().payload
+        val cids = payload?.optJSONArray("cids")
+        assertEquals(1, cids?.length() ?: 0)
+        assertEquals("remote", cids?.optString(0))
+    }
+
+    @Test
+    fun `skips broadcast when no peer is currently flowing`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 0
+        // Several ticks with no growth.
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS * 3, TimeUnit.MILLISECONDS)
+
+        assertEquals(0, livenessBroadcasts().size)
+        assertTrue(
+            "Slot should have been polled at least once",
+            (factory.fakeMedia.fakeSlots["remote"]?.collectInboundBytesCalls ?: 0) > 0,
+        )
+    }
+
+    @Test
+    fun `pauses while transport is disconnected and resumes after reconnect`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        // Establish a baseline so the first broadcast can fire.
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 1_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 5_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        val beforeDisconnect = livenessBroadcasts().size
+        assertTrue("Expected at least one broadcast before disconnect", beforeDisconnect >= 1)
+
+        // Transport drops — subsequent ticks must not broadcast.
+        factory.fakeProvider.simulateDisconnected()
+        ShadowLooper.idleMainLooper()
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 10_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS * 2, TimeUnit.MILLISECONDS)
+        assertEquals(beforeDisconnect, livenessBroadcasts().size)
+
+        // Reconnect — next tick should broadcast again.
+        factory.fakeProvider.simulateConnected("ws")
+        ShadowLooper.idleMainLooper()
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 20_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        assertTrue(
+            "Expected another broadcast after reconnect",
+            livenessBroadcasts().size > beforeDisconnect,
+        )
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionMediaLivenessTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionMediaLivenessTest.kt
@@ -20,9 +20,9 @@ import java.util.concurrent.TimeUnit
  *   - The SDK broadcasts `media_liveness` when inbound bytes advance for a
  *     peer.
  *   - Emission skips peers with no flow.
+ *   - Emission stops after `session.leave()` (terminal cleanup path).
  *   - Emission pauses while transport is disconnected and resumes after
  *     reconnect.
- *   - Emission stops on session reset.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -78,6 +78,29 @@ class SessionMediaLivenessTest {
             "Slot should have been polled at least once",
             (factory.fakeMedia.fakeSlots["remote"]?.collectInboundBytesCalls ?: 0) > 0,
         )
+    }
+
+    @Test
+    fun `stops emitting after session leave`() {
+        factory.advanceToInCallWithTurn(
+            localCid = "alpha",
+            remoteCid = "remote",
+            localJoinedAt = 1,
+            remoteJoinedAt = 2,
+        )
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 1_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        factory.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 5_000
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        val baseline = livenessBroadcasts().size
+        assertTrue("Expected at least one broadcast before leave", baseline >= 1)
+
+        factory.session.leave()
+        ShadowLooper.idleMainLooper()
+
+        // Advance well past several would-be tick intervals — no further emits.
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.MEDIA_LIVENESS_INTERVAL_MS * 3, TimeUnit.MILLISECONDS)
+        assertEquals(baseline, livenessBroadcasts().size)
     }
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -134,6 +134,13 @@ internal class FakePeerConnectionSlot(
     override fun attachRemoteSink(sink: VideoSink) {}
     override fun detachRemoteSink(sink: VideoSink) {}
     override fun collectWebRtcStats(onComplete: (String, RealtimeCallStats?) -> Unit) { onComplete("fake", null) }
+    /** Cumulative inbound bytes returned from the next `collectInboundBytes()` call. */
+    var inboundBytesSample: Long = 0L
+    var collectInboundBytesCalls = 0
+    override fun collectInboundBytes(onComplete: (Long) -> Unit) {
+        collectInboundBytesCalls += 1
+        onComplete(inboundBytesSample)
+    }
     override fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy) {}
 
     // Test drivers

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -544,9 +544,10 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
         peerConnection.statistics { report in
             var bytes: Int64 = 0
             for stat in report.statistics.values where stat.type == "inbound-rtp" {
-                if let value = stat.values["bytesReceived"] as? NSNumber {
-                    bytes += value.int64Value
-                }
+                // libwebrtc stat values can arrive as either NSNumber or String.
+                // memberInt64 handles both — using `as? NSNumber` alone would
+                // silently drop the string form and report 0 every tick.
+                bytes += memberInt64(stat, key: "bytesReceived") ?? 0
             }
             Task { @MainActor in onComplete(bytes) }
         }

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -535,6 +535,26 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
 #endif
     }
 
+    public func collectInboundBytes(onComplete: @escaping (Int64) -> Void) {
+#if canImport(WebRTC)
+        guard let peerConnection else {
+            onComplete(0)
+            return
+        }
+        peerConnection.statistics { report in
+            var bytes: Int64 = 0
+            for stat in report.statistics.values where stat.type == "inbound-rtp" {
+                if let value = stat.values["bytesReceived"] as? NSNumber {
+                    bytes += value.int64Value
+                }
+            }
+            Task { @MainActor in onComplete(bytes) }
+        }
+#else
+        onComplete(0)
+#endif
+    }
+
     public func isReady() -> Bool {
 #if canImport(WebRTC)
         peerConnection != nil

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
@@ -69,4 +69,11 @@ internal protocol PeerConnectionSlotProtocol: AnyObject {
     // Stats
     func collectRealtimeCallStats(onComplete: @escaping (RealtimeCallStats) -> Void)
     func collectRealtimeCallStatsAndSummary(onComplete: @escaping (RealtimeCallStats, String) -> Void)
+
+    /// Asynchronously samples cumulative inbound `bytesReceived` across all
+    /// inbound-rtp stats for this peer. Used by the media-liveness emitter
+    /// (see SerenadaSession.startMediaLivenessTimer); a CID is "flowing"
+    /// when its sample advances over the previous one. Reports `0` when
+    /// the peer connection is not yet established.
+    func collectInboundBytes(onComplete: @escaping (Int64) -> Void)
 }

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
@@ -66,6 +66,16 @@ public enum WebRtcResilience {
     /// to compute `estimatedHardEvictionAtMs` for the
     /// `SignalingState.suspended` surface so apps can render a countdown.
     public static let suspendHardEvictionTimeoutMs = 600_000
+
+    // MARK: - Media-liveness emission cadence
+
+    /// Active SDKs broadcast `media_liveness{cids:[..]}` every interval
+    /// for remote CIDs whose inbound media is currently flowing. The
+    /// server uses this hint to defer hard-eviction of suspended peers
+    /// whose media is still being received. 10s leaves headroom under the
+    /// server's 30s freshness window (`mediaLivenessFreshnessWindow`) for
+    /// missed emissions.
+    public static let mediaLivenessIntervalMs = 10_000
 }
 
 // MARK: - Nanosecond convenience accessors

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -212,6 +212,19 @@ public final class SerenadaSession: ObservableObject {
     /// Test-only count of remote CIDs currently flagged as `presumedLost`.
     internal var presumedLostRemoteCount: Int { presumedLostRemoteCids.count }
 
+    // #3 — periodic `media_liveness` emission. Active across the in-call
+    // window so the server can defer hard-eviction of suspended peers
+    // whose media is still flowing locally. Ticks no-op while transport
+    // is disconnected (baseline samples preserved so the next post-
+    // reconnect tick can detect flow).
+    private var lastInboundBytesByCid: [String: Int64] = [:]
+    private var mediaLivenessTask: Task<Void, Never>?
+    private var mediaLivenessEmitInFlight = false
+    private var mediaLivenessEmitCount = 0
+
+    /// Test-only counter incremented on each `media_liveness` broadcast.
+    internal var mediaLivenessBroadcastCount: Int { mediaLivenessEmitCount }
+
     private let recoveryStorage: RecoveryStorage
     private var sessionStartTs: Int64?
 
@@ -358,6 +371,7 @@ public final class SerenadaSession: ObservableObject {
         postReconnectResyncTask?.cancel()
         for task in suspendedPresentationTasks.values { task.cancel() }
         suspendedPresentationTasks.removeAll()
+        mediaLivenessTask?.cancel()
         if let foregroundObserver { NotificationCenter.default.removeObserver(foregroundObserver) }
         if let backgroundObserver { NotificationCenter.default.removeObserver(backgroundObserver) }
     }
@@ -788,6 +802,10 @@ public final class SerenadaSession: ObservableObject {
         peerNegotiationEngine?.syncPeers(roomState: roomState)
         refreshRemoteParticipants()
         connectionStatusTracker?.update()
+        // Start media-liveness emission only once we have remote peers — there's
+        // nothing to report when alone in the room, and the timer is otherwise
+        // a noisy no-op.
+        if phase == .inCall { startMediaLivenessTimer() }
     }
 
     /// True only when at least one peer exists and every slot's last observed
@@ -997,6 +1015,9 @@ public final class SerenadaSession: ObservableObject {
         reconnectTask?.cancel(); reconnectTask = nil
         cancelPostReconnectResync()
         clearAllRemoteSuspensionTracking()
+        stopMediaLivenessTimer()
+        lastInboundBytesByCid.removeAll()
+        mediaLivenessEmitInFlight = false
         localSuspendedSinceMs = nil
         joinFlowCoordinator?.clearAllTimers()
         connectionStatusTracker?.cancelTimer()
@@ -1174,6 +1195,71 @@ public final class SerenadaSession: ObservableObject {
         for task in suspendedPresentationTasks.values { task.cancel() }
         suspendedPresentationTasks.removeAll()
         presumedLostRemoteCids.removeAll()
+    }
+
+    // MARK: - Media-liveness emission (#3)
+
+    /// Periodic `media_liveness{cids}` broadcast for #3. Started on a
+    /// successful join; runs across reconnects (ticks no-op while
+    /// disconnected but baseline samples persist so the next post-reconnect
+    /// tick can detect flow). Stopped on session reset/destroy.
+    private func startMediaLivenessTimer() {
+        guard mediaLivenessTask == nil else { return }
+        mediaLivenessTask = Task { [weak self] in
+            guard let clock = self?.clock else { return }
+            let intervalNs = UInt64(WebRtcResilience.mediaLivenessIntervalMs) * 1_000_000
+            while !Task.isCancelled {
+                try? await clock.sleep(nanoseconds: intervalNs)
+                if Task.isCancelled { return }
+                guard let self else { return }
+                self.emitMediaLiveness()
+            }
+        }
+    }
+
+    private func stopMediaLivenessTimer() {
+        mediaLivenessTask?.cancel()
+        mediaLivenessTask = nil
+    }
+
+    private func emitMediaLiveness() {
+        if mediaLivenessEmitInFlight { return }
+        guard diagnostics.isSignalingConnected, currentRoomState != nil else { return }
+        let slots = peerSlots
+        if slots.isEmpty { return }
+
+        mediaLivenessEmitInFlight = true
+        var newSamples: [String: Int64] = [:]
+        var remaining = slots.count
+        for (cid, slot) in slots {
+            slot.collectInboundBytes { [weak self] bytes in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    newSamples[cid] = bytes
+                    remaining -= 1
+                    if remaining == 0 { self.finalizeMediaLivenessEmit(newSamples: newSamples) }
+                }
+            }
+        }
+    }
+
+    private func finalizeMediaLivenessEmit(newSamples: [String: Int64]) {
+        mediaLivenessEmitInFlight = false
+        var flowing: [String] = []
+        for (cid, bytes) in newSamples {
+            if let previous = lastInboundBytesByCid[cid], bytes > previous {
+                flowing.append(cid)
+            }
+            lastInboundBytesByCid[cid] = bytes
+        }
+        // Drop tracking for peers that left.
+        for cid in Array(lastInboundBytesByCid.keys) where peerSlots[cid] == nil {
+            lastInboundBytesByCid.removeValue(forKey: cid)
+        }
+        guard !flowing.isEmpty, diagnostics.isSignalingConnected else { return }
+        let cidsArray = JSONValue.array(flowing.map(JSONValue.string))
+        signalingProvider.broadcast(type: "media_liveness", payload: ["cids": cidsArray])
+        mediaLivenessEmitCount += 1
     }
 
     // MARK: - Local signaling state

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
@@ -194,6 +194,14 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
         onComplete(.empty, "fake")
     }
 
+    /// Cumulative inbound bytes returned from the next `collectInboundBytes()` call.
+    var inboundBytesSample: Int64 = 0
+    var collectInboundBytesCalls = 0
+    func collectInboundBytes(onComplete: @escaping (Int64) -> Void) {
+        collectInboundBytesCalls += 1
+        onComplete(inboundBytesSample)
+    }
+
     // MARK: - Test Drivers
 
     func simulateConnectionStateChange(_ state: SerenadaPeerConnectionState) {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionMediaLivenessTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionMediaLivenessTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import SerenadaCore
+
+/// Failure mode #3 — periodic `media_liveness{cids}` emission so the server
+/// can defer hard-eviction of suspended peers whose media is still flowing
+/// locally.
+@MainActor
+final class SessionMediaLivenessTests: XCTestCase {
+
+    private var harness: SessionTestHarness!
+
+    override func setUp() async throws {
+        harness = SessionTestHarness(handlesReconnection: true)
+    }
+
+    override func tearDown() async throws {
+        harness.tearDown()
+        harness = nil
+    }
+
+    private func livenessBroadcasts() -> [(type: String, payload: SignalingPayload?)] {
+        harness.fakeProvider.broadcasts.filter { $0.type == "media_liveness" }
+    }
+
+    private func tickInterval() async {
+        await harness.fakeClock.advance(byMs: Int64(WebRtcResilience.mediaLivenessIntervalMs) + 50)
+        // Allow async slot.collectInboundBytes callbacks to land back on MainActor.
+        await harness.yieldToMainActor()
+        await harness.yieldToMainActor()
+    }
+
+    func testBroadcastsMediaLivenessWhenInboundBytesAdvance() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        // Yield enough that startMediaLivenessTimer reaches its first sleep.
+        await harness.yieldToMainActor()
+        await harness.yieldToMainActor()
+
+        // Baseline tick: bytes still 0 → no flow.
+        let slot = harness.fakeMedia.fakeSlots["remote"]
+        slot?.inboundBytesSample = 0
+        await tickInterval()
+        let baseline = livenessBroadcasts().count
+
+        // Bytes advance → flow detected → broadcast.
+        slot?.inboundBytesSample = 5_000
+        await tickInterval()
+
+        let broadcasts = livenessBroadcasts()
+        XCTAssertEqual(broadcasts.count, baseline + 1)
+        if case let .array(items) = broadcasts.last?.payload?["cids"] {
+            XCTAssertEqual(items.count, 1)
+            if case let .string(cid) = items.first {
+                XCTAssertEqual(cid, "remote")
+            } else {
+                XCTFail("Expected first cid to be a string")
+            }
+        } else {
+            XCTFail("Expected `cids` array in payload")
+        }
+    }
+
+    func testSkipsBroadcastWhenNoPeerIsCurrentlyFlowing() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        await harness.yieldToMainActor()
+        await harness.yieldToMainActor()
+
+        harness.fakeMedia.fakeSlots["remote"]?.inboundBytesSample = 0
+        await tickInterval()
+        await tickInterval()
+        await tickInterval()
+
+        XCTAssertEqual(livenessBroadcasts().count, 0)
+        XCTAssertGreaterThan(harness.fakeMedia.fakeSlots["remote"]?.collectInboundBytesCalls ?? 0, 0)
+    }
+
+    func testPausesWhileTransportDisconnectedAndResumesAfterReconnect() async {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        await harness.yieldToMainActor()
+        await harness.yieldToMainActor()
+
+        // Establish a baseline so the first broadcast can fire.
+        let slot = harness.fakeMedia.fakeSlots["remote"]
+        slot?.inboundBytesSample = 1_000
+        await tickInterval()
+        slot?.inboundBytesSample = 5_000
+        await tickInterval()
+        let beforeDisconnect = livenessBroadcasts().count
+        XCTAssertGreaterThanOrEqual(beforeDisconnect, 1)
+
+        // Drop transport — subsequent ticks must not broadcast.
+        harness.fakeProvider.simulateDisconnected(reason: "test")
+        await harness.yieldToMainActor()
+        slot?.inboundBytesSample = 10_000
+        await tickInterval()
+        await tickInterval()
+        XCTAssertEqual(livenessBroadcasts().count, beforeDisconnect)
+
+        // Reconnect — next tick should broadcast again.
+        harness.fakeProvider.simulateConnected()
+        await harness.yieldToMainActor()
+        slot?.inboundBytesSample = 20_000
+        await tickInterval()
+        XCTAssertGreaterThan(livenessBroadcasts().count, beforeDisconnect)
+    }
+}

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		3A954265ACD7FADB9138DC1B /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8662332FB191C23A57DDBA4D /* AppConstants.swift */; };
 		3B240DC5B813D930328BDC99 /* SampleHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56B39E2A60D65FD1477B020 /* SampleHandler.swift */; };
 		3EEE808D7CBA63B2652C959F /* AppLaunchOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC78E56ECCCC36978DAE4FE /* AppLaunchOverrides.swift */; };
+		4137872C50BFF4B70C29DDED /* SessionMediaLivenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB457A612C7F7FCB2736B1F /* SessionMediaLivenessTests.swift */; };
 		46722D2E3EFC8D06D8B51355 /* DiagnosticsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AD1035F89AEDD9E3B0F38C /* DiagnosticsScreen.swift */; };
 		467581ED7FB87064203AA780 /* FakeSignalingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6EC0967F80C7CB8EB7E9E0 /* FakeSignalingProvider.swift */; };
 		5153383FD16DC779F8EBA4B3 /* JoinFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CA15C6609960E60FFBCD90 /* JoinFlowCoordinatorTests.swift */; };
@@ -167,6 +168,7 @@
 		3529A15EA2C43DB2F91F46FC /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		367DCC8F4EDC812C9FBA3F02 /* LiveRoomOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveRoomOverride.swift; sourceTree = "<group>"; };
 		3F0D033C8F77DC9925D9668A /* RoomStatusesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStatusesTests.swift; sourceTree = "<group>"; };
+		3FB457A612C7F7FCB2736B1F /* SessionMediaLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMediaLivenessTests.swift; sourceTree = "<group>"; };
 		4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaDiagnosticsTests.swift; sourceTree = "<group>"; };
 		41E34F50FDC1E2F064028B68 /* SessionTestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTestHarness.swift; sourceTree = "<group>"; };
 		43E2F0452DE65337073894BF /* RecentCallStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCallStore.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 				2A15CC6B14E97F4E2C37C573 /* SerenadaServerProviderTests.swift */,
 				7830FA5A71601737755C721D /* SerenadaSessionTests.swift */,
 				8815B032D4EFBB62BB976B66 /* SessionDirtyPairTests.swift */,
+				3FB457A612C7F7FCB2736B1F /* SessionMediaLivenessTests.swift */,
 				8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */,
 				09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */,
 				970E7AEDB3E705CBF2F03E95 /* SessionPostReconnectGateTests.swift */,
@@ -834,6 +837,7 @@
 				838D89A84D60CC6245CB2EFC /* SerenadaServerProviderTests.swift in Sources */,
 				A281E4C5D7AE35EEF75A87A8 /* SerenadaSessionTests.swift in Sources */,
 				2BF323F5A22C2952822DE96D /* SessionDirtyPairTests.swift in Sources */,
+				4137872C50BFF4B70C29DDED /* SessionMediaLivenessTests.swift in Sources */,
 				6E8767096E3E70790EB1CEE5 /* SessionNegotiationTests.swift in Sources */,
 				CB94D71B6D37742D4EAAC565 /* SessionOrchestrationTests.swift in Sources */,
 				AFA7404C26B9F90435638F49 /* SessionPostReconnectGateTests.swift in Sources */,

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -35,6 +35,7 @@ import {
     JOIN_HARD_TIMEOUT_MS,
     ENDING_SCREEN_MS,
     EPOCH_RESYNC_TIMEOUT_MS,
+    MEDIA_LIVENESS_INTERVAL_MS,
     PEER_SUSPENDED_UI_TIMEOUT_MS,
     SUSPEND_HARD_EVICTION_TIMEOUT_MS,
 } from './constants.js';
@@ -265,6 +266,14 @@ export class SerenadaSession implements SerenadaSessionHandle {
     // removed from the room.
     private readonly suspendedPresentationTimers = new Map<string, number>();
     private readonly presumedLostRemoteCids = new Set<string>();
+
+    // #3 — periodic `media_liveness` emission. Active across the in-call
+    // window so the server can defer hard-eviction of suspended peers whose
+    // media is still flowing locally. Emission skipped while transport is
+    // disconnected (ticks just no-op).
+    private mediaLivenessTimer: number | null = null;
+    private mediaLivenessEmitInFlight = false;
+    private mediaLivenessEmitCount = 0;
 
     private get isInactive(): boolean {
         return this._destroyed || this.terminated;
@@ -571,6 +580,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.clientId = event.peerId;
         this.roomState = buildRoomState(event, null, event.peerId);
         this.media.updateRoomState(this.roomState, this.clientId);
+        this.maybeStartMediaLivenessTimer();
         this.rebuildState();
         this.broadcastLocalMediaState();
         void this.fetchInitialIceServers();
@@ -583,6 +593,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.error = null;
         this.roomState = buildRoomState(event, this.roomState?.hostCid ?? null, this.clientId);
         this.media.updateRoomState(this.roomState, this.clientId);
+        this.maybeStartMediaLivenessTimer();
         this.flushPostReconnectResync('snapshot');
         this.rebuildState();
     };
@@ -594,6 +605,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.error = null;
         this.roomState = upsertParticipant(this.roomState, event, this.clientId);
         this.media.updateRoomState(this.roomState, this.clientId);
+        this.maybeStartMediaLivenessTimer();
         this.rebuildState();
         this.broadcastLocalMediaState();
     };
@@ -827,6 +839,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.clearEndingTimer();
         this.cancelPostReconnectResync();
         this.clearAllRemoteSuspensionTracking();
+        this.stopMediaLivenessTimer();
         this.invalidateIceFetches();
         this.statsCollector.stop();
 
@@ -1134,6 +1147,52 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.suspendedPresentationTimers.clear();
         this.presumedLostRemoteCids.clear();
     }
+
+    /**
+     * Periodic `media_liveness{cids}` emission for #3. Started once we have
+     * remote peers (i.e. the call reaches `inCall`); runs across reconnects
+     * (ticks no-op while disconnected but baseline samples persist so the
+     * next post-reconnect tick can detect flow). Stopped on session
+     * reset/destroy.
+     */
+    private maybeStartMediaLivenessTimer(): void {
+        if (this.mediaLivenessTimer !== null) return;
+        const remoteCount = (this.roomState?.participants?.length ?? 0) - (this.clientId ? 1 : 0);
+        if (remoteCount <= 0) return;
+        this.mediaLivenessTimer = window.setInterval(() => {
+            void this.emitMediaLiveness();
+        }, MEDIA_LIVENESS_INTERVAL_MS);
+    }
+
+    private stopMediaLivenessTimer(): void {
+        if (this.mediaLivenessTimer !== null) {
+            window.clearInterval(this.mediaLivenessTimer);
+            this.mediaLivenessTimer = null;
+        }
+    }
+
+    private async emitMediaLiveness(): Promise<void> {
+        if (this.isInactive || this.mediaLivenessEmitInFlight) return;
+        if (!this.isConnected || this.roomState === null) return;
+        this.mediaLivenessEmitInFlight = true;
+        try {
+            const flowing = await this.media.getInboundFlowingCids();
+            if (this.isInactive || flowing.length === 0) return;
+            this.signaling.broadcast('media_liveness', { cids: flowing });
+            this.mediaLivenessEmitCount += 1;
+        } catch (error) {
+            this.config.logger?.log(
+                'debug',
+                'Session',
+                `media_liveness emit failed: ${formatError(error)}`,
+            );
+        } finally {
+            this.mediaLivenessEmitInFlight = false;
+        }
+    }
+
+    /** Test-only counter incremented on each `media_liveness` broadcast. */
+    get mediaLivenessBroadcastCount(): number { return this.mediaLivenessEmitCount; }
 
     private async checkPermissionsAndStartMedia(): Promise<void> {
         if (this.permissionCheckDone || this.permissionCheckInFlight) return;

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -273,7 +273,6 @@ export class SerenadaSession implements SerenadaSessionHandle {
     // disconnected (ticks just no-op).
     private mediaLivenessTimer: number | null = null;
     private mediaLivenessEmitInFlight = false;
-    private mediaLivenessEmitCount = 0;
 
     private get isInactive(): boolean {
         return this._destroyed || this.terminated;
@@ -471,6 +470,8 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.clearEndingTimer();
         this.clearJoinTimeout();
         this.cancelPostReconnectResync();
+        this.clearAllRemoteSuspensionTracking();
+        this.stopMediaLivenessTimer();
         for (const unsubscribe of this.providerUnsubscribers) {
             unsubscribe();
         }
@@ -1179,7 +1180,6 @@ export class SerenadaSession implements SerenadaSessionHandle {
             const flowing = await this.media.getInboundFlowingCids();
             if (this.isInactive || flowing.length === 0) return;
             this.signaling.broadcast('media_liveness', { cids: flowing });
-            this.mediaLivenessEmitCount += 1;
         } catch (error) {
             this.config.logger?.log(
                 'debug',
@@ -1190,9 +1190,6 @@ export class SerenadaSession implements SerenadaSessionHandle {
             this.mediaLivenessEmitInFlight = false;
         }
     }
-
-    /** Test-only counter incremented on each `media_liveness` broadcast. */
-    get mediaLivenessBroadcastCount(): number { return this.mediaLivenessEmitCount; }
 
     private async checkPermissionsAndStartMedia(): Promise<void> {
         if (this.permissionCheckDone || this.permissionCheckInFlight) return;

--- a/client/packages/core/src/constants.ts
+++ b/client/packages/core/src/constants.ts
@@ -61,6 +61,14 @@ export const PEER_SUSPENDED_UI_TIMEOUT_MS = 30000;
 // surface so apps can render a countdown.
 export const SUSPEND_HARD_EVICTION_TIMEOUT_MS = 600000;
 
+// Media-liveness emission cadence
+// Active SDKs broadcast `media_liveness{cids:[..]}` every interval for
+// remote CIDs whose inbound media is currently flowing. The server uses
+// this hint to defer hard-eviction of suspended peers whose media is still
+// being received. 10s leaves headroom under the server's 30s freshness
+// window (`mediaLivenessFreshnessWindow`) for missed emissions.
+export const MEDIA_LIVENESS_INTERVAL_MS = 10000;
+
 // Connection Status
 export const CONNECTION_RETRYING_DELAY_MS = 10_000;
 

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -59,6 +59,11 @@ export class MediaEngine {
     connectionStatus: ConnectionStatus = 'connected';
 
     private peers = new Map<string, PeerState>();
+    // Per-remote-CID tally of cumulative `inbound-rtp.bytesReceived`. Sampled
+    // on every `getInboundFlowingCids()` call; a CID is "flowing" when its
+    // current sample exceeds the previous one. Drives #3's `media_liveness`
+    // emission (see SerenadaSession.startMediaLivenessTimer).
+    private lastInboundBytesByCid = new Map<string, number>();
     private rtcConfig: RTCConfiguration = DEFAULT_RTC_CONFIG;
     private screenShareTrack: MediaStreamTrack | null = null;
     private requestingMedia = false;
@@ -394,12 +399,50 @@ export class MediaEngine {
         }
         this.peers.clear();
         this.remoteStreams = new Map();
+        this.lastInboundBytesByCid.clear();
         if (this.retryingTimer) { window.clearTimeout(this.retryingTimer); this.retryingTimer = null; }
         this.iceConnectionState = 'closed';
         this.connectionState = 'closed';
         this.signalingState = 'closed';
         this.connectionStatus = 'connected';
         this.notifyChange();
+    }
+
+    /**
+     * Sample inbound RTP `bytesReceived` per remote peer and return the CIDs
+     * whose totals advanced since the previous sample. Drives #3's
+     * `media_liveness{cids}` emission so the server can defer hard-eviction
+     * of suspended peers whose media is still being received locally.
+     *
+     * Conservative on first call (no baseline → empty result). Cleans up
+     * tracking for peers that have left.
+     */
+    async getInboundFlowingCids(): Promise<string[]> {
+        const flowing: string[] = [];
+        const seen = new Set<string>();
+        for (const [cid, peer] of this.peers) {
+            seen.add(cid);
+            let bytes = 0;
+            try {
+                const report = await peer.pc.getStats();
+                report.forEach((stat) => {
+                    if (stat.type !== 'inbound-rtp') return;
+                    const value = (stat as unknown as Record<string, unknown>)['bytesReceived'];
+                    if (typeof value === 'number') bytes += value;
+                });
+            } catch {
+                continue;
+            }
+            const previous = this.lastInboundBytesByCid.get(cid);
+            if (previous !== undefined && bytes > previous) {
+                flowing.push(cid);
+            }
+            this.lastInboundBytesByCid.set(cid, bytes);
+        }
+        for (const cid of [...this.lastInboundBytesByCid.keys()]) {
+            if (!seen.has(cid)) this.lastInboundBytesByCid.delete(cid);
+        }
+        return flowing;
     }
 
     destroy(): void {

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
     JOIN_HARD_TIMEOUT_MS,
+    MEDIA_LIVENESS_INTERVAL_MS,
     PEER_SUSPENDED_UI_TIMEOUT_MS,
     SUSPEND_HARD_EVICTION_TIMEOUT_MS,
 } from '../src/constants.js';
@@ -1061,6 +1062,82 @@ describe('SerenadaSession', () => {
             if (sigState.kind === 'failed') {
                 expect(sigState.reason).toBe('roomEnded');
             }
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Media-liveness emission (#3)
+    // ---------------------------------------------------------------
+    describe('media-liveness emission', () => {
+        async function joinWithRemotes(remoteCids: string[]) {
+            harness = new TestSessionHarness();
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, ...remoteCids.map((cid) => ({ cid }))],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            await harness.session.resumeJoin();
+            return harness;
+        }
+
+        function livenessBroadcasts() {
+            return harness.signaling.broadcastCalls.filter((call) => call.type === 'media_liveness');
+        }
+
+        it('broadcasts media_liveness with flowing CIDs on each interval tick', async () => {
+            await joinWithRemotes(['peer-1']);
+            harness.media.inboundFlowingCids = ['peer-1'];
+
+            expect(livenessBroadcasts()).toHaveLength(0);
+
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS + 50);
+
+            const broadcasts = livenessBroadcasts();
+            expect(broadcasts).toHaveLength(1);
+            expect(broadcasts[0].payload).toEqual({ cids: ['peer-1'] });
+        });
+
+        it('skips broadcast when no peer is currently flowing', async () => {
+            await joinWithRemotes(['peer-1']);
+            harness.media.inboundFlowingCids = [];
+
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS * 3);
+
+            expect(livenessBroadcasts()).toHaveLength(0);
+            expect(harness.media.getInboundFlowingCidsCalls).toBeGreaterThan(0);
+        });
+
+        it('skips broadcast while transport is disconnected; resumes after reconnect', async () => {
+            await joinWithRemotes(['peer-1']);
+            harness.media.inboundFlowingCids = ['peer-1'];
+
+            // First tick — connected, broadcast happens.
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS + 50);
+            expect(livenessBroadcasts()).toHaveLength(1);
+
+            // Drop transport. Subsequent ticks must not broadcast.
+            harness.simulateDisconnect();
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS * 3);
+            expect(livenessBroadcasts()).toHaveLength(1);
+
+            // Reconnect — next tick should broadcast again.
+            harness.signaling.emitConnected('ws');
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS + 50);
+            expect(livenessBroadcasts().length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('stops emitting after the session is destroyed', async () => {
+            await joinWithRemotes(['peer-1']);
+            harness.media.inboundFlowingCids = ['peer-1'];
+
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS + 50);
+            const baseline = livenessBroadcasts().length;
+            expect(baseline).toBe(1);
+
+            harness.session.destroy();
+            await vi.advanceTimersByTimeAsync(MEDIA_LIVENESS_INTERVAL_MS * 3);
+
+            expect(livenessBroadcasts().length).toBe(baseline);
         });
     });
 

--- a/client/packages/core/test/helpers/FakeMediaEngine.ts
+++ b/client/packages/core/test/helpers/FakeMediaEngine.ts
@@ -93,6 +93,18 @@ export class FakeMediaEngine {
         return this.allPathsDirect;
     }
 
+    /**
+     * CIDs returned from the next `getInboundFlowingCids()` call. Tests can
+     * override to assert the periodic `media_liveness` emit picks up the
+     * right list.
+     */
+    inboundFlowingCids: string[] = [];
+    getInboundFlowingCidsCalls = 0;
+    async getInboundFlowingCids(): Promise<string[]> {
+        this.getInboundFlowingCidsCalls += 1;
+        return [...this.inboundFlowingCids];
+    }
+
     cleanupAllPeers(): void {
         this.cleanupAllPeersCalls++;
         this.remoteStreams = new Map();

--- a/docs/resilience-failure-modes.md
+++ b/docs/resilience-failure-modes.md
@@ -62,7 +62,7 @@ must preserve the core UX model:
 |---|-----------------------------------------------------------|-----------------------------------------------------------|----------|--------|--------|
 | 1 | Negotiation messages missed while peer is suspended       | Stuck call setup, missing media after reconnect           | Critical | M      | Phase 1 (server) · Phase 2 ✅ (SDK consumes `negotiation_dirty` for per-CID ICE restart; `relay_failed` informational) |
 | 2 | Reconnect creates a new CID instead of preserving identity | App thinks it rejoined; peers see duplicate/empty state   | Critical | S      | Phase 1 ✅ |
-| 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      | Phase 1 (server cleanup gate) · Phase 2 partial (SDK presentation timer landed; periodic media-liveness emission still pending) |
+| 3 | Suspension conflates signaling loss with media death      | Premature teardown risk, ghost UI for dead peers          | High     | M      | Phase 2 ✅ (SDK presentation timer + periodic `media_liveness` emission landed end-to-end) |
 | 4 | ICE restart fires on stale peer map at reconnect          | Offers to ghost CIDs, missing offers to new peers         | High     | S      | Phase 1 (server) · Phase 2 ✅ (SDK snapshot gate landed end-to-end) |
 | 5 | Process death without clean teardown                      | Server holds a slot for a participant that's gone         | High     | M      | Phase 2 ✅ (server `POST /api/leave` + per-platform recovery store + rejoin API) |
 | 6 | No explicit "you are suspended / about to be evicted"     | UI can't show countdown; apps can't make smart choices    | Medium   | S      | Phase 2 ✅ (SDK `signalingState` surface with `Suspended`/`Reconnecting`/`Failed` variants and hard-eviction estimate) |
@@ -301,20 +301,27 @@ the boundary.
 
 ## 3. Suspension conflates signaling loss with media death
 
-**Status (2026-04-29):** Phase 2 partial — SDK presentation timer landed
-end-to-end across Web, Android, and iOS. When a remote peer transitions to
-`signalingStatus="suspended"` in `room_state`, each SDK starts a per-CID
-timer of `peerSuspendedUiTimeoutMs = 30 s` (new shared constant). On
-expiry the SDK flips a new `presumedLost: boolean` field on the
-participant so call UIs can move them out of the active grid. The peer
-connection itself stays open so media can resume immediately if the peer
-reattaches. Cancellation is automatic when the peer reattaches as active
-or leaves the room. The remaining piece — periodic `media_liveness`
-emission from active peers so the server can keep the slot longer for
-peers whose media is still flowing — is still pending and will land in a
-follow-up slice. Server-side support from Phase 1 is unchanged
-(`mediaLivenessFreshnessWindow = 30s`,
-`hardEvictMediaActiveDeferral = 30s`).
+**Status (2026-04-29):** Landed end-to-end across server and all three
+SDKs. When a remote peer transitions to `signalingStatus="suspended"` in
+`room_state`, each SDK starts a per-CID timer of `peerSuspendedUiTimeoutMs
+= 30 s`; on expiry the SDK flips a new `presumedLost: boolean` field on
+the participant so call UIs can move them out of the active grid. The
+peer connection itself stays open so media can resume immediately if the
+peer reattaches. Cancellation is automatic when the peer reattaches as
+active or leaves the room.
+
+Active SDKs also broadcast `media_liveness{cids:[…]}` every
+`mediaLivenessIntervalMs = 10 s` for remote CIDs whose inbound RTP
+`bytesReceived` advanced since the previous sample. Web reads stats
+straight from each `RTCPeerConnection`; Android and iOS use a new
+`PeerConnectionSlot.collectInboundBytes` callback. Emission starts when
+the room transitions to `inCall` (i.e. there's at least one remote peer)
+and pauses while the local transport is disconnected — baseline samples
+are preserved so the next post-reconnect tick can detect flow. The
+server's existing `mediaLivenessFreshnessWindow = 30s` and
+`hardEvictMediaActiveDeferral = 30s` from Phase 1 do the rest of the
+work; a hard-eviction is now deferred whenever any active peer reports
+recent media from a suspended CID.
 
 ### Symptom
 
@@ -1441,6 +1448,46 @@ Out of scope for this document, listed for visibility:
   it deserves a fresh look.
 
 ## Change Log
+
+### 2026-04-29 — Phase 2: media-liveness emission completes #3
+
+- **New shared constant**: `mediaLivenessIntervalMs = 10_000` added to
+  Web, Android, and iOS (validated by
+  `scripts/check-resilience-constants.mjs` — 23 shared constants now
+  match). Mirrors the cadence under the server's 30s freshness window.
+
+- **Per-platform inbound-bytes detection**: Each SDK samples cumulative
+  `inbound-rtp.bytesReceived` per remote CID once per interval and
+  builds the list of "flowing" CIDs (current sample > previous):
+  - Web: `MediaEngine.getInboundFlowingCids()` reads each peer's
+    `RTCPeerConnection.getStats()` and aggregates inbound-rtp bytes.
+  - Android: new `PeerConnectionSlotProtocol.collectInboundBytes`
+    callback wraps `pc.getStats { ... }`.
+  - iOS: new `PeerConnectionSlotProtocol.collectInboundBytes` callback
+    wraps `peerConnection.statistics { ... }`.
+
+- **Periodic broadcast in `SerenadaSession`**: each SDK runs a
+  `mediaLivenessIntervalMs` tick that calls
+  `signalingProvider.broadcast("media_liveness", { cids })` whenever
+  the flowing list is non-empty AND the local transport is connected.
+  Timer starts when the call reaches `inCall` (at least one remote
+  peer); ticks no-op while disconnected (baseline samples are preserved
+  so the next post-reconnect tick can detect flow). Stopped on session
+  reset/destroy.
+
+- **Tests**:
+  - Web `SerenadaSession.test.ts` — 4 new tests covering: broadcasts
+    on flowing CIDs, skips when no flow, pauses while disconnected and
+    resumes after reconnect, stops after destroy. 326 total (was 322).
+  - Android `SessionMediaLivenessTest.kt` — 3 Robolectric tests
+    covering the same matrix.
+  - iOS `SessionMediaLivenessTests.swift` — 3 XCTest cases covering
+    the same matrix using `FakeSessionClock` advances.
+  - Server tests still green; resilience-constants and version-parity
+    checks green.
+
+- **Docs**: `docs/resilience-failure-modes.md` priority table for #3
+  flips to ✅, section status updated, change-log entry added.
 
 ### 2026-04-29 — Phase 2: suspended-state surface (#6) + remote presentation timer (#3 partial)
 


### PR DESCRIPTION
## Summary

Implements the remaining piece of failure mode **#3** from [docs/resilience-failure-modes.md](docs/resilience-failure-modes.md). Active SDKs now broadcast `media_liveness{cids:[..]}` every 10s for remote CIDs whose inbound RTP `bytesReceived` advanced since the previous sample. The server uses these hints (Phase 1 server side, already in place) to defer hard-eviction of suspended peers whose media is still flowing locally — completing the suspension-visibility theme started by the previous slice.

Stacks on top of [PR #81](https://github.com/agatx/serenada/pull/81) (suspension surface, now merged into the umbrella audit branch).

## Changes

**New shared constant** (Web/Android/iOS — `scripts/check-resilience-constants.mjs` validates 23 constants):
- `mediaLivenessIntervalMs = 10_000` — sits comfortably under the server's 30s `mediaLivenessFreshnessWindow`.

**Per-platform inbound-bytes detection:**
- Web: `MediaEngine.getInboundFlowingCids()` polls each peer's `RTCPeerConnection.getStats()` and aggregates `inbound-rtp.bytesReceived`.
- Android: new `PeerConnectionSlotProtocol.collectInboundBytes` callback wraps `pc.getStats { ... }`.
- iOS: new `PeerConnectionSlotProtocol.collectInboundBytes` callback wraps `peerConnection.statistics { ... }`.

**SerenadaSession periodic broadcast:**
- Each platform runs a `mediaLivenessIntervalMs` tick that calls `signalingProvider.broadcast("media_liveness", { cids })` whenever the flowing list is non-empty AND the local transport is connected.
- Timer starts when the call reaches `inCall` (at least one remote peer) — not on `joined`. Ticks no-op while disconnected (baseline samples preserved so the next post-reconnect tick can detect flow). Stopped on session reset/destroy.

## Test plan

- [x] Web `SerenadaSession.test.ts` — 4 new tests (326 total, was 322)
- [x] Android `SessionMediaLivenessTest.kt` — 3 Robolectric tests
- [x] iOS `SessionMediaLivenessTests.swift` — 3 XCTest cases
- [x] All 4 suites green (Web vitest, Android gradle, iOS xcodebuild, server Go)
- [x] `scripts/check-resilience-constants.mjs` — 23 constants match
- [x] `scripts/check-version-parity.mjs` — 8 sources match at 0.6.2

## Docs

`docs/resilience-failure-modes.md` priority table for #3 flips to Phase 2 ✅, section status updated, change-log entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)