### PR TITLE
SDK 0.6.3: resilience hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.3] — 2026-04-30
+
+Resilience hardening release. The SDK now degrades gracefully across long
+signaling drops, post-reconnect peer-set churn, and process death; suspended
+peers are surfaced explicitly to the UI with timing details, and active peers
+report media-liveness so the server can defer hard-eviction while media is
+still flowing locally. See `docs/resilience-failure-modes.md` for the full
+audit and per-failure-mode design notes.
+
+### Added
+- Web, Android, iOS: `CallState.signalingState` (richer transport state with
+  `connected | reconnecting{attempt, nextRetryAtMs} | suspended{suspendedSinceMs, estimatedHardEvictionAtMs} | failed{reason}`).
+  Mid-call transport drops produce `suspended` with a hard-eviction estimate
+  computed from the new shared `suspendHardEvictionTimeoutMs` constant
+  (mirrors the Go server's `suspendHardEvictionTimeout`). `connectionStatus`
+  remains the simpler tri-value summary for apps that don't need the detail.
+- Web, Android, iOS: `Participant.presumedLost: boolean` flag on remote
+  participants. Flipped to `true` after a peer has been
+  `signalingStatus="suspended"` for `peerSuspendedUiTimeoutMs = 30 s` so call
+  UIs can move them out of the active grid. The peer connection itself stays
+  open so media can resume immediately if the peer reattaches; the flag
+  clears when the peer transitions back to active or leaves the room.
+- Web, Android, iOS: periodic `media_liveness{cids}` broadcast every
+  `mediaLivenessIntervalMs = 10 s` for remote CIDs whose inbound RTP
+  `bytesReceived` advanced. Server uses these hints to defer hard-eviction
+  of suspended peers whose media is still being received locally.
+- Web, Android, iOS: `getRecoverableSession()` / `discardRecoverableSession()`
+  on `SerenadaCore` for app-relaunch recovery. Each SDK persists
+  `{roomId, cid, reconnectToken, lastEpoch, sessionStartTs, expiresAtMs}` —
+  Web uses `sessionStorage` (per-tab, survives reload), Android uses
+  app-private `SharedPreferences`, iOS uses an injectable `UserDefaults`
+  (defaults to `.standard`; host apps can pass an app-group store).
+- Server: new `POST /api/leave` endpoint for explicit terminal leave (skips
+  the suspension hold). Validates the reconnect token, idempotent,
+  rate-limited at 12 req/min/IP. Used by the recovery flow on relaunch and
+  by deliberate teardown paths.
+- Server: dirty-pair tracking. When a relay targets a suspended CID,
+  `relay_failed{reason: "target_suspended", targets, of}` is returned to the
+  sender and the pair is marked dirty. On the suspended target's reattach,
+  `negotiation_dirty{withCid}` notifies active peers to schedule glare-safe
+  ICE restart for that pair only. SDKs consume both messages.
+- Server: room-state epoch + post-reconnect snapshot. Every successful
+  `joined` is followed by an authoritative `room_state` snapshot on the new
+  transport regardless of whether membership changed, so SDKs can gate ICE
+  restart on a server-confirmed peer set.
+- Server: room tombstones (`ROOM_ENDED`) so peers reconnecting to an ended
+  room get a structured terminal error instead of a fresh-join attempt.
+  Reconnect tokens are now HMAC-bound to `(cid, rid, expiresAt)` and expire
+  with `suspendHardEvictionTimeout`; replay is rejected with
+  `INVALID_RECONNECT_TOKEN` (mapped to a new `sessionExpired` SDK error).
+- iOS, Android: foreground / Doze release force-ping. When the app returns
+  from background, the SDK issues a synthetic ping with a 2 s deadline
+  (`foregroundForcePingTimeoutMs`); on miss it force-closes the transport
+  and runs the normal reconnect path. Fixes the "still shows connected for
+  up to `pingIntervalMs` after suspension" gap on iOS background suspension
+  and Android Doze.
+
+### Changed
+- iOS: the WebRTC-mirror `SignalingState` enum (in `CallDiagnostics`) is now
+  `RtcSignalingState` so the new Phase 2 surface can take the unqualified
+  name (matches Web/Android naming). `CallDiagnostics.rtcSignalingState`
+  keeps its name.
+
 ## [0.6.2] — 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ audit and per-failure-mode design notes.
 - Server: dirty-pair tracking. When a relay targets a suspended CID,
   `relay_failed{reason: "target_suspended", targets, of}` is returned to the
   sender and the pair is marked dirty. On the suspended target's reattach,
-  `negotiation_dirty{withCid}` notifies active peers to schedule glare-safe
-  ICE restart for that pair only. SDKs consume both messages.
+  `negotiation_dirty{with}` notifies active peers to schedule glare-safe
+  ICE restart for that pair only (each SDK maps the wire `with` field into
+  an internal `withCid` event property). SDKs consume both messages.
 - Server: room-state epoch + post-reconnect snapshot. Every successful
   `joined` is followed by an authoritative `room_state` snapshot on the new
   transport regardless of whether membership changed, so SDKs can gate ICE

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7559_173-universal:0.6.2`
-- `app.serenada:core:0.6.2`
-- `app.serenada:call-ui:0.6.2`
+- `app.serenada:libwebrtc-7559_173-universal:0.6.3`
+- `app.serenada:core:0.6.3`
+- `app.serenada:call-ui:0.6.3`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.2"
+                version = "0.6.3"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.2"
+val sdkVersion = "0.6.3"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.2"
+val sdkVersion = "0.6.3"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.2"
+    public static let version = "0.6.3"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.6.2",
-    "@serenada/react-ui": "0.6.2",
+    "@serenada/core": "0.6.3",
+    "@serenada/react-ui": "0.6.3",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.2';
+export const SERENADA_CORE_VERSION = '0.6.3';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.2",
+    "@serenada/core": "^0.6.3",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.6.2"
+    "@serenada/core": "0.6.3"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.2")
-    implementation("app.serenada:call-ui:0.6.2")
+    implementation("app.serenada:core:0.6.3")
+    implementation("app.serenada:call-ui:0.6.3")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.6.2 @serenada/react-ui@0.6.2 lucide-react
+npm install @serenada/core@0.6.3 @serenada/react-ui@0.6.3 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.


### PR DESCRIPTION
## Summary

Bumps SDK version **0.6.2 → 0.6.3** across all 8 parity-checked sources, capturing the resilience improvements landed under the [docs/resilience-failure-modes.md](docs/resilience-failure-modes.md) audit (PRs #73, #74, #75, #79, #80, #81, #82).

Stacks on top of the resilience-audit branch.

## What's in 0.6.3

- **#1** — Server dirty-pair tracking + SDK `negotiation_dirty` consumption for glare-safe per-CID ICE restart after suspended-peer reattach.
- **#2** — Reconnect preserves identity (CID + reconnect token HMAC-bound to `(cid, rid, expiresAt)`).
- **#3** — Per-remote-CID `presumedLost` UI flag after 30s suspended; periodic `media_liveness{cids}` broadcast every 10s.
- **#4** — ICE restart on signaling reconnect waits for the authoritative post-reconnect `room_state` snapshot (or 5s fallback).
- **#5** — Process-death recovery via per-platform persisted state, `getRecoverableSession()` API, and `POST /api/leave`.
- **#6** — `CallState.signalingState` with `connected | reconnecting | suspended | failed` variants and hard-eviction estimate.
- **#8** — iOS / Android foreground / Doze release force-ping (`foregroundForcePingTimeoutMs = 2s`).
- **#11** — Server tombstones surface `ROOM_ENDED`; SDK clears persisted reconnect storage.
- **#15** — Reconnect-token replay rejected as `INVALID_RECONNECT_TOKEN` → new `sessionExpired` SDK error.
- **#16** — Content state persisted on participant record and replayed on reattach.

## Notable rename

iOS: `SignalingState` (the WebRTC mirror in `CallDiagnostics`) → `RtcSignalingState`, freeing the unqualified name for the new public Phase 2 surface. `CallDiagnostics.rtcSignalingState` keeps its name.

## Test plan

- [x] `scripts/check-version-parity.mjs` — 8/8 sources match at 0.6.3
- [x] `scripts/check-resilience-constants.mjs` — 23 constants match
- [x] Web 326 / Android `:serenada-core:testDebugUnitTest` / iOS `xcodebuild build` — all green

## Docs

- `CHANGELOG.md` — new `[0.6.3] — 2026-04-30` section with full Added/Changed list
- `docs/sdk/sdk-integration-android.md`, `docs/sdk/sdk-integration-web.md` — installation snippets bumped
- `client-android/README.md` — `publishSdkToMavenLocal` coords bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)