### PR TITLE
Add green audio activity indicator on web call UI

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -139,6 +139,10 @@ export {
 /** @internal Local video recovery utilities */
 export { shouldForceLocalVideoRefresh, shouldRecoverLocalVideo } from './media/localVideoRecovery.js';
 
+// Audio level monitoring (used by call UI for activity indicators)
+export { AudioLevelMonitor } from './media/AudioLevelMonitor.js';
+export type { AudioLevelMonitorOptions } from './media/AudioLevelMonitor.js';
+
 /** @internal */
 export { createRoomId } from './api/roomApi.js';
 /** @internal */

--- a/client/packages/core/src/media/AudioLevelMonitor.ts
+++ b/client/packages/core/src/media/AudioLevelMonitor.ts
@@ -15,9 +15,9 @@ const ATTACK_SMOOTHING = 0.4;
 const RELEASE_SMOOTHING = 0.7;
 
 export interface AudioLevelMonitorOptions {
-    /** AnalyserNode smoothingTimeConstant (0..1). Defaults to 0.7. */
+    /** AnalyserNode smoothingTimeConstant (0..1). Defaults to 0.5. */
     smoothing?: number;
-    /** AnalyserNode FFT size — power of two. Defaults to 256. */
+    /** AnalyserNode FFT size — power of two. Defaults to 1024. */
     fftSize?: number;
     /** Subscriber notification interval in ms. Defaults to 100. */
     updateIntervalMs?: number;
@@ -133,7 +133,6 @@ export class AudioLevelMonitor {
             : null;
         if (!setIntervalFn) return;
         this.timer = setIntervalFn(() => this.tick(), this.updateIntervalMs) as unknown as number;
-        this.tick();
     }
 
     private stopLoop(): void {
@@ -147,6 +146,9 @@ export class AudioLevelMonitor {
 
     private tick(): void {
         if (this.disposed || !this.analyser || !this.buffer) return;
+        if (this.context?.state === 'suspended') {
+            void this.context.resume().catch(() => {});
+        }
         this.analyser.getByteTimeDomainData(this.buffer);
         let sumSquares = 0;
         for (let i = 0; i < this.buffer.length; i++) {

--- a/client/packages/core/src/media/AudioLevelMonitor.ts
+++ b/client/packages/core/src/media/AudioLevelMonitor.ts
@@ -1,0 +1,188 @@
+import type { SerenadaLogger } from '../types.js';
+
+/** Update frequency for audio level subscribers. 10 Hz pairs well with 100 ms CSS transitions. */
+const DEFAULT_UPDATE_INTERVAL_MS = 100;
+/** Default FFT size — small for low CPU; we only need a coarse RMS. */
+const DEFAULT_FFT_SIZE = 1024;
+/** Default smoothing applied by the analyser node (0..1). */
+const DEFAULT_SMOOTHING = 0.5;
+/** dBFS at which the indicator reads zero. Quieter than this is treated as silence. */
+const NOISE_FLOOR_DB = -60;
+/** dBFS at which the indicator reads full. Normal speech peaks around -20 to -15 dBFS. */
+const SPEECH_PEAK_DB = -15;
+/** Attack/release smoothing across ticks (0..1). Higher = stickier; 0 = no smoothing. */
+const ATTACK_SMOOTHING = 0.4;
+const RELEASE_SMOOTHING = 0.7;
+
+export interface AudioLevelMonitorOptions {
+    /** AnalyserNode smoothingTimeConstant (0..1). Defaults to 0.7. */
+    smoothing?: number;
+    /** AnalyserNode FFT size — power of two. Defaults to 256. */
+    fftSize?: number;
+    /** Subscriber notification interval in ms. Defaults to 100. */
+    updateIntervalMs?: number;
+    /** Reuse an existing AudioContext (the monitor will not close it on dispose). */
+    audioContext?: AudioContext;
+    /** Optional logger for diagnostics. */
+    logger?: SerenadaLogger;
+}
+
+type LevelCallback = (level: number) => void;
+
+/**
+ * Computes a normalized speech audio level (0..1) from a MediaStream's audio
+ * track using the Web Audio API. Use it to drive UI activity indicators.
+ *
+ * The monitor is lazy: it only runs the analysis loop while at least one
+ * subscriber is attached. Call {@link dispose} when the stream is gone or
+ * the consumer goes away.
+ */
+export class AudioLevelMonitor {
+    private context: AudioContext | null = null;
+    private analyser: AnalyserNode | null = null;
+    private source: MediaStreamAudioSourceNode | null = null;
+    private buffer: Uint8Array<ArrayBuffer> | null = null;
+    private timer: number | null = null;
+    private subscribers = new Set<LevelCallback>();
+    private currentLevel = 0;
+    private disposed = false;
+    private readonly ownsContext: boolean;
+    private readonly updateIntervalMs: number;
+    private readonly logger?: SerenadaLogger;
+
+    constructor(stream: MediaStream, options: AudioLevelMonitorOptions = {}) {
+        this.updateIntervalMs = options.updateIntervalMs ?? DEFAULT_UPDATE_INTERVAL_MS;
+        this.logger = options.logger;
+        this.ownsContext = !options.audioContext;
+
+        const Ctx = typeof globalThis !== 'undefined'
+            ? ((globalThis as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext })
+                .AudioContext
+                ?? (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)
+            : undefined;
+
+        if (!Ctx && !options.audioContext) {
+            this.logger?.log('debug', 'AudioLevelMonitor', 'AudioContext unavailable; monitor will report zero level');
+            return;
+        }
+
+        if (stream.getAudioTracks().length === 0) {
+            this.logger?.log('debug', 'AudioLevelMonitor', 'Stream has no audio tracks');
+            return;
+        }
+
+        try {
+            this.context = options.audioContext ?? new (Ctx as typeof AudioContext)();
+            this.analyser = this.context.createAnalyser();
+            this.analyser.fftSize = options.fftSize ?? DEFAULT_FFT_SIZE;
+            this.analyser.smoothingTimeConstant = options.smoothing ?? DEFAULT_SMOOTHING;
+            this.source = this.context.createMediaStreamSource(stream);
+            this.source.connect(this.analyser);
+            this.buffer = new Uint8Array(new ArrayBuffer(this.analyser.fftSize));
+            // Browsers may create the context in a suspended state until a user gesture;
+            // resume it so analysis starts producing samples immediately.
+            if (this.context.state === 'suspended') {
+                void this.context.resume().catch((err) => {
+                    this.logger?.log('debug', 'AudioLevelMonitor', `resume() failed: ${err}`);
+                });
+            }
+        } catch (err) {
+            this.logger?.log('warning', 'AudioLevelMonitor', `Failed to attach to stream: ${err}`);
+            this.cleanup();
+        }
+    }
+
+    /** Returns the most recent level computed by the monitor (0..1). */
+    get level(): number {
+        return this.currentLevel;
+    }
+
+    /**
+     * Subscribe for level updates. The callback fires immediately with the
+     * current level, then at {@link AudioLevelMonitorOptions.updateIntervalMs}.
+     * Returns an unsubscribe function.
+     */
+    subscribe(callback: LevelCallback): () => void {
+        if (this.disposed) {
+            callback(0);
+            return () => { /* noop */ };
+        }
+        this.subscribers.add(callback);
+        callback(this.currentLevel);
+        if (this.analyser && this.subscribers.size === 1) {
+            this.startLoop();
+        }
+        return () => {
+            this.subscribers.delete(callback);
+            if (this.subscribers.size === 0) {
+                this.stopLoop();
+            }
+        };
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.cleanup();
+    }
+
+    private startLoop(): void {
+        if (this.timer !== null) return;
+        const setIntervalFn = typeof globalThis !== 'undefined' && typeof globalThis.setInterval === 'function'
+            ? globalThis.setInterval.bind(globalThis)
+            : null;
+        if (!setIntervalFn) return;
+        this.timer = setIntervalFn(() => this.tick(), this.updateIntervalMs) as unknown as number;
+        this.tick();
+    }
+
+    private stopLoop(): void {
+        if (this.timer === null) return;
+        const clearIntervalFn = typeof globalThis !== 'undefined' && typeof globalThis.clearInterval === 'function'
+            ? globalThis.clearInterval.bind(globalThis)
+            : null;
+        clearIntervalFn?.(this.timer as unknown as ReturnType<typeof setInterval>);
+        this.timer = null;
+    }
+
+    private tick(): void {
+        if (this.disposed || !this.analyser || !this.buffer) return;
+        this.analyser.getByteTimeDomainData(this.buffer);
+        let sumSquares = 0;
+        for (let i = 0; i < this.buffer.length; i++) {
+            const sample = (this.buffer[i] - 128) / 128;
+            sumSquares += sample * sample;
+        }
+        const rms = Math.sqrt(sumSquares / this.buffer.length);
+        // Map RMS to dBFS, then to a perceptual 0..1 between the noise floor and speech peak.
+        const dbfs = rms > 0 ? 20 * Math.log10(rms) : NOISE_FLOOR_DB;
+        const target = Math.max(0, Math.min(1, (dbfs - NOISE_FLOOR_DB) / (SPEECH_PEAK_DB - NOISE_FLOOR_DB)));
+        // Asymmetric smoothing: snap up quickly (attack), decay slowly (release).
+        const smoothing = target > this.currentLevel ? ATTACK_SMOOTHING : RELEASE_SMOOTHING;
+        const level = this.currentLevel * smoothing + target * (1 - smoothing);
+        this.currentLevel = level;
+        this.subscribers.forEach((cb) => {
+            try { cb(level); } catch (err) {
+                this.logger?.log('warning', 'AudioLevelMonitor', `Subscriber threw: ${err}`);
+            }
+        });
+    }
+
+    private cleanup(): void {
+        this.stopLoop();
+        if (this.source) {
+            try { this.source.disconnect(); } catch { /* ignore */ }
+            this.source = null;
+        }
+        if (this.analyser) {
+            try { this.analyser.disconnect(); } catch { /* ignore */ }
+            this.analyser = null;
+        }
+        if (this.context && this.ownsContext) {
+            try { void this.context.close(); } catch { /* ignore */ }
+        }
+        this.context = null;
+        this.buffer = null;
+        this.subscribers.clear();
+    }
+}

--- a/client/packages/core/test/media/AudioLevelMonitor.test.ts
+++ b/client/packages/core/test/media/AudioLevelMonitor.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AudioLevelMonitor } from '../../src/media/AudioLevelMonitor.js';
+
+interface FakeAnalyser {
+    fftSize: number;
+    smoothingTimeConstant: number;
+    frequencyBinCount: number;
+    getByteTimeDomainData: (buffer: Uint8Array) => void;
+    disconnect: () => void;
+}
+
+interface FakeSource {
+    connect: (target: unknown) => void;
+    disconnect: () => void;
+}
+
+class FakeAudioContext {
+    closed = false;
+    public lastSource: FakeSource | null = null;
+    public lastAnalyser: FakeAnalyser | null = null;
+    private waveform: Int8Array | null = null;
+
+    setWaveform(samples: number[] | null): void {
+        this.waveform = samples ? Int8Array.from(samples) : null;
+    }
+
+    createAnalyser(): FakeAnalyser {
+        const analyser: FakeAnalyser = {
+            fftSize: 2048,
+            smoothingTimeConstant: 0.8,
+            get frequencyBinCount() { return this.fftSize / 2; },
+            getByteTimeDomainData: (buffer: Uint8Array) => {
+                if (!this.waveform) {
+                    buffer.fill(128); // silence == 128 in u8 PCM
+                    return;
+                }
+                for (let i = 0; i < buffer.length; i++) {
+                    const sample = this.waveform[i % this.waveform.length] ?? 0;
+                    buffer[i] = Math.max(0, Math.min(255, 128 + sample));
+                }
+            },
+            disconnect: () => { /* noop */ },
+        };
+        this.lastAnalyser = analyser;
+        return analyser;
+    }
+
+    createMediaStreamSource(_stream: MediaStream): FakeSource {
+        const source: FakeSource = {
+            connect: () => { /* noop */ },
+            disconnect: () => { /* noop */ },
+        };
+        this.lastSource = source;
+        return source;
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+    }
+}
+
+function makeFakeStream(audioTracks: number): MediaStream {
+    const tracks = Array.from({ length: audioTracks }, () => ({}));
+    return {
+        getAudioTracks: () => tracks,
+        getVideoTracks: () => [],
+        getTracks: () => tracks,
+    } as unknown as MediaStream;
+}
+
+describe('AudioLevelMonitor', () => {
+    const originalAudioContext = (globalThis as Record<string, unknown>).AudioContext;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        if (originalAudioContext === undefined) {
+            delete (globalThis as Record<string, unknown>).AudioContext;
+        } else {
+            (globalThis as Record<string, unknown>).AudioContext = originalAudioContext;
+        }
+    });
+
+    it('reports zero level and noop unsubscribe when AudioContext is unavailable', () => {
+        delete (globalThis as Record<string, unknown>).AudioContext;
+        delete (globalThis as Record<string, unknown>).webkitAudioContext;
+
+        const monitor = new AudioLevelMonitor(makeFakeStream(1));
+        const samples: number[] = [];
+        const unsubscribe = monitor.subscribe((l) => samples.push(l));
+        unsubscribe();
+        monitor.dispose();
+
+        expect(samples).toEqual([0]);
+        expect(monitor.level).toBe(0);
+    });
+
+    it('reports zero level when stream has no audio tracks', () => {
+        (globalThis as Record<string, unknown>).AudioContext = FakeAudioContext;
+        const monitor = new AudioLevelMonitor(makeFakeStream(0));
+        const samples: number[] = [];
+        monitor.subscribe((l) => samples.push(l));
+
+        expect(samples).toEqual([0]);
+        monitor.dispose();
+    });
+
+    it('produces a non-zero level for a non-silent waveform', () => {
+        const ctx = new FakeAudioContext();
+        // Mid-level speech-like waveform (RMS ~ 50/128 ≈ 0.39, ~ -8 dBFS).
+        ctx.setWaveform([50, -50]);
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+
+        const samples: number[] = [];
+        monitor.subscribe((l) => samples.push(l));
+        // Initial sample is current level (0 before first tick)
+        expect(samples[0]).toBe(0);
+
+        // Advance through one tick (default 100 ms interval)
+        vi.advanceTimersByTime(100);
+        expect(samples.length).toBeGreaterThanOrEqual(2);
+        const after = samples[samples.length - 1];
+        expect(after).toBeGreaterThan(0);
+        expect(after).toBeLessThanOrEqual(1);
+
+        monitor.dispose();
+    });
+
+    it('converges toward 1 for very loud signals across multiple ticks', () => {
+        const ctx = new FakeAudioContext();
+        ctx.setWaveform([127, -127]); // RMS ≈ 0.99 (~0 dBFS)
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+
+        let last = 0;
+        monitor.subscribe((l) => { last = l; });
+        // EMA with attack 0.4 reaches ~0.99 after ~5 ticks
+        vi.advanceTimersByTime(600);
+        expect(last).toBeGreaterThan(0.95);
+        expect(last).toBeLessThanOrEqual(1);
+
+        monitor.dispose();
+    });
+
+    it('reports zero for silence (waveform pinned to 128)', () => {
+        const ctx = new FakeAudioContext();
+        ctx.setWaveform(null);
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+
+        let last = -1;
+        monitor.subscribe((l) => { last = l; });
+        vi.advanceTimersByTime(200);
+        expect(last).toBe(0);
+
+        monitor.dispose();
+    });
+
+    it('stops the loop when all subscribers unsubscribe', () => {
+        const ctx = new FakeAudioContext();
+        ctx.setWaveform([50, -50]);
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+
+        const samples: number[] = [];
+        const unsubscribe = monitor.subscribe((l) => samples.push(l));
+        vi.advanceTimersByTime(100);
+        const samplesBeforeUnsub = samples.length;
+        unsubscribe();
+        vi.advanceTimersByTime(500);
+
+        expect(samples.length).toBe(samplesBeforeUnsub);
+        monitor.dispose();
+    });
+
+    it('does not close an externally-supplied AudioContext on dispose', () => {
+        const ctx = new FakeAudioContext();
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+        monitor.dispose();
+        expect(ctx.closed).toBe(false);
+    });
+
+    it('subscribing after dispose returns a noop and zero', () => {
+        const ctx = new FakeAudioContext();
+        const monitor = new AudioLevelMonitor(makeFakeStream(1), { audioContext: ctx as unknown as AudioContext });
+        monitor.dispose();
+
+        const samples: number[] = [];
+        const unsubscribe = monitor.subscribe((l) => samples.push(l));
+        unsubscribe();
+
+        expect(samples).toEqual([0]);
+    });
+});

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -26,10 +26,12 @@ import {
     type LayoutResult,
     type SerenadaSessionHandle,
 } from '@serenada/core';
+import { AudioActivityIndicator } from './components/AudioActivityIndicator.js';
 import { DebugPanel } from './components/DebugPanel.js';
 import { RemoteAvatar } from './components/RemoteAvatar.js';
 import { useAvatarResolver, type AvatarResolver } from './hooks/useAvatarResolver.js';
 import { StatusOverlay } from './components/StatusOverlay.js';
+import { useAudioLevel } from './hooks/useAudioLevel.js';
 import { useCallState } from './hooks/useCallState.js';
 import { SerenadaPermissions } from './SerenadaPermissions.js';
 import type { CallFlowProps } from './types.js';
@@ -69,11 +71,16 @@ function isMobileBrowser(): boolean {
     return typeof navigator !== 'undefined' && MOBILE_BROWSER_RE.test(navigator.userAgent);
 }
 
-const ParticipantBadge: React.FC<{ muted?: boolean; displayName?: string }> = ({ muted, displayName }) => {
-    if (!muted && !displayName) return null;
+const ParticipantBadge: React.FC<{
+    muted?: boolean;
+    displayName?: string;
+    stream?: MediaStream | null;
+}> = ({ muted, displayName, stream }) => {
+    const level = useAudioLevel(stream ?? null, !muted);
+    if (!muted && !displayName && !stream) return null;
     return (
         <div className="participant-badge">
-            {muted && <MicOff size={14} />}
+            {muted ? <MicOff size={14} /> : stream ? <AudioActivityIndicator level={level} /> : null}
             {displayName && <span className="participant-badge-name">{displayName}</span>}
         </div>
     );
@@ -946,6 +953,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                         const tileAudioMuted = isContentTile ? false : isLocalTile ? isMuted : tileRemote?.audioEnabled === false;
                                         const tileDisplayName = isContentTile ? undefined : isLocalTile ? localParticipant?.displayName : tileRemote?.displayName;
                                         const tileVideoEnabled = isContentTile ? true : isLocalTile ? localParticipant?.videoEnabled !== false : tileRemote?.videoEnabled;
+                                        const tileAudioStream = isContentTile ? null : isLocalTile ? localStream : remoteStreams.get(tile.id) ?? null;
                                         return (
                                             <div key={tile.id} className="video-stage-tile" style={tileStyle}>
                                                 <VideoTile
@@ -981,7 +989,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                                         {remoteVideoFit === 'cover' ? <Minimize2 size={20} /> : <Maximize2 size={20} />}
                                                     </button>
                                                 )}
-                                                <ParticipantBadge muted={tileAudioMuted} displayName={tileDisplayName} />
+                                                <ParticipantBadge muted={tileAudioMuted} displayName={tileVideoEnabled === false ? undefined : tileDisplayName} stream={tileAudioStream} />
                                             </div>
                                         );
                                     })}
@@ -1011,7 +1019,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                                             }}
                                                             onClick={() => setPinnedParticipantId(tile.cid)}
                                                         />
-                                                        <ParticipantBadge muted={gridRemote?.audioEnabled === false} displayName={gridRemote?.displayName} />
+                                                        <ParticipantBadge muted={gridRemote?.audioEnabled === false} displayName={gridRemote?.videoEnabled === false ? undefined : gridRemote?.displayName} stream={stageTile.stream} />
                                                     </div>
                                                 );
                                             })}
@@ -1043,7 +1051,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                                     style={{ objectFit: isScreenSharing ? 'contain' : 'cover' }}
                                 />
                             )}
-                            <ParticipantBadge muted={isMuted} displayName={localParticipant?.displayName} />
+                            <ParticipantBadge muted={isMuted} displayName={localParticipant?.displayName} stream={localStream} />
                         </div>
                     )}
                 </div>
@@ -1105,7 +1113,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                         </button>
                     )}
 
-                    <ParticipantBadge muted={remoteParticipant0?.audioEnabled === false} displayName={remoteParticipant0?.displayName} />
+                    <ParticipantBadge muted={remoteParticipant0?.audioEnabled === false} displayName={remoteParticipant0?.videoEnabled === false ? undefined : remoteParticipant0?.displayName} stream={remoteStream} />
 
                     {waitingOverlay}
                 </div>
@@ -1132,7 +1140,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                             style={{ objectFit: isScreenSharing ? 'contain' : 'cover' }}
                         />
                     )}
-                    <ParticipantBadge muted={isMuted} displayName={localParticipant?.displayName} />
+                    <ParticipantBadge muted={isMuted} displayName={localParticipant?.displayName} stream={localStream} />
                 </div>
             </div>
             {controlsBar}

--- a/client/packages/react-ui/src/callFlowStyles.ts
+++ b/client/packages/react-ui/src/callFlowStyles.ts
@@ -420,6 +420,21 @@ const CALL_FLOW_CSS = `
   text-overflow: ellipsis;
 }
 
+[data-serenada-callflow] .audio-activity-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+[data-serenada-callflow] .audio-activity-bar {
+  width: 3px;
+  border-radius: 1.5px;
+  background: #22c55e;
+  transition: height 100ms ease-out;
+}
+
 [data-serenada-callflow] .debug-toggle-zone {
   position: absolute;
   top: 0;

--- a/client/packages/react-ui/src/components/AudioActivityIndicator.tsx
+++ b/client/packages/react-ui/src/components/AudioActivityIndicator.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface AudioActivityIndicatorProps {
+    /** Normalized speech level (0..1). */
+    level: number;
+    /** Pixel height of the indicator. Bars scale to fit. Defaults to 14. */
+    size?: number;
+}
+
+const BAR_GAINS = [0.7, 1.0, 0.55] as const;
+const MIN_HEIGHT_PCT = 14;
+const MAX_HEIGHT_PCT = 100;
+
+/**
+ * Three small green bars that pulse with the speaker's audio level — used
+ * in place of the muted mic icon when a participant is unmuted.
+ */
+export const AudioActivityIndicator: React.FC<AudioActivityIndicatorProps> = ({ level, size = 14 }) => {
+    const clamped = Math.max(0, Math.min(1, level));
+    return (
+        <div
+            className="audio-activity-indicator"
+            style={{ width: size, height: size }}
+            aria-hidden="true"
+        >
+            {BAR_GAINS.map((gain, index) => {
+                const heightPct = MIN_HEIGHT_PCT + (MAX_HEIGHT_PCT - MIN_HEIGHT_PCT) * Math.min(1, clamped * gain);
+                return (
+                    <span
+                        key={index}
+                        className="audio-activity-bar"
+                        style={{ height: `${heightPct}%` }}
+                    />
+                );
+            })}
+        </div>
+    );
+};

--- a/client/packages/react-ui/src/hooks/useAudioLevel.ts
+++ b/client/packages/react-ui/src/hooks/useAudioLevel.ts
@@ -1,19 +1,32 @@
 import { useEffect, useState } from 'react';
 import { AudioLevelMonitor } from '@serenada/core';
 
-/**
- * Returns a smoothed audio level (0..1) for the audio track of the given
- * stream. Returns 0 when `enabled` is false, when the stream has no audio
- * track, or when the Web Audio API is unavailable.
- *
- * Use to drive a voice-activity indicator next to a participant tile.
- */
+let sharedAudioContext: AudioContext | null = null;
+
+function getSharedAudioContext(): AudioContext | undefined {
+    if (sharedAudioContext && sharedAudioContext.state !== 'closed') {
+        return sharedAudioContext;
+    }
+    const Ctx = typeof globalThis !== 'undefined'
+        ? ((globalThis as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext })
+            .AudioContext
+            ?? (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)
+        : undefined;
+    if (!Ctx) return undefined;
+    try {
+        sharedAudioContext = new Ctx();
+        return sharedAudioContext;
+    } catch {
+        return undefined;
+    }
+}
+
 export function useAudioLevel(stream: MediaStream | null | undefined, enabled = true): number {
     const [level, setLevel] = useState(0);
 
     useEffect(() => {
         if (!enabled || !stream) return undefined;
-        const monitor = new AudioLevelMonitor(stream);
+        const monitor = new AudioLevelMonitor(stream, { audioContext: getSharedAudioContext() });
         const unsubscribe = monitor.subscribe(setLevel);
         return () => {
             unsubscribe();

--- a/client/packages/react-ui/src/hooks/useAudioLevel.ts
+++ b/client/packages/react-ui/src/hooks/useAudioLevel.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { AudioLevelMonitor } from '@serenada/core';
+
+/**
+ * Returns a smoothed audio level (0..1) for the audio track of the given
+ * stream. Returns 0 when `enabled` is false, when the stream has no audio
+ * track, or when the Web Audio API is unavailable.
+ *
+ * Use to drive a voice-activity indicator next to a participant tile.
+ */
+export function useAudioLevel(stream: MediaStream | null | undefined, enabled = true): number {
+    const [level, setLevel] = useState(0);
+
+    useEffect(() => {
+        if (!enabled || !stream) return undefined;
+        const monitor = new AudioLevelMonitor(stream);
+        const unsubscribe = monitor.subscribe(setLevel);
+        return () => {
+            unsubscribe();
+            monitor.dispose();
+        };
+    }, [stream, enabled]);
+
+    return enabled && stream ? level : 0;
+}


### PR DESCRIPTION
## Summary
- Replaces the empty space next to a participant's name with a small green 3-bar voice-activity meter (Google-Meet-style) when their mic is unmuted; muted state keeps the existing red mic-off icon.
- Adds `AudioLevelMonitor` to `@serenada/core` — a Web Audio API wrapper that yields a smoothed, dBFS-scaled `0..1` level at 10 Hz, with asymmetric attack/release smoothing and `AudioContext.resume()` when the browser hands one back suspended.
- Adds `useAudioLevel` hook + `AudioActivityIndicator` to `@serenada/react-ui` and wires them into all five `ParticipantBadge` call sites (1:1 and multi-party). Also fixes a small regression where the displayName double-rendered (in the badge and under the camera-off avatar) — the badge name now hides when video is disabled.

## Test plan
- [x] `npm test` (296 tests, 8 new for `AudioLevelMonitor`)
- [x] `npx tsc -b` clean
- [x] `npm run build` clean
- [x] Eyeballed live in dev server: bars react smoothly to normal speech (not just shouting/blowing); muted state still shows the red mic-off icon; no name duplication when peer's camera is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)