### PR TITLE
Add green audio activity indicator on Android call UI

### DIFF
--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AudioActivityIndicator.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AudioActivityIndicator.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AudioActivityIndicator.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/AudioActivityIndicator.kt
@@ -1,0 +1,65 @@
+package app.serenada.callui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Three small green bars that pulse with the speaker's audio level — used
+ * in place of the muted mic icon when a participant is unmuted.
+ *
+ * Mirrors the web SDK's `AudioActivityIndicator` 1:1 — same bar gains,
+ * 14% minimum height, animated transitions paced to the 100 ms update
+ * cadence of [app.serenada.core.call.AudioLevelMonitor].
+ */
+@Composable
+internal fun AudioActivityIndicator(
+    level: Float,
+    modifier: Modifier = Modifier,
+    size: Dp = 14.dp,
+) {
+    val clamped = level.coerceIn(0f, 1f)
+    Row(
+        modifier = modifier.size(size),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BAR_GAINS.forEach { gain ->
+            val targetFraction = MIN_HEIGHT_FRACTION +
+                (MAX_HEIGHT_FRACTION - MIN_HEIGHT_FRACTION) * (clamped * gain).coerceAtMost(1f)
+            val animatedFraction by animateFloatAsState(
+                targetValue = targetFraction,
+                animationSpec = tween(durationMillis = ANIMATION_DURATION_MS),
+                label = "audio-bar-height",
+            )
+            Box(
+                modifier = Modifier
+                    .width(BAR_WIDTH)
+                    .fillMaxHeight(animatedFraction)
+                    .background(BAR_COLOR, RoundedCornerShape(1.5.dp))
+            )
+        }
+    }
+}
+
+private val BAR_GAINS = listOf(0.7f, 1.0f, 0.55f)
+private const val MIN_HEIGHT_FRACTION = 0.14f
+private const val MAX_HEIGHT_FRACTION = 1.0f
+private val BAR_WIDTH = 3.dp
+private val BAR_COLOR = Color(0xFF22C55E)
+private const val ANIMATION_DURATION_MS = 100

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -562,17 +562,19 @@ internal fun CallScreen(
                     audioLevel = uiState.localAudioLevel,
                 )
             }
-            Box(modifier = remoteModifier) {
-                // Hide displayName from the badge when remote video is off — the
-                // remote placeholder already shows the participant's name.
-                val remoteNameForBadge =
-                    if (remoteP?.videoEnabled == false) null else remoteP?.displayName
-                ParticipantBadge(
-                    modifier = Modifier.align(Alignment.BottomStart),
-                    muted = remoteP?.audioEnabled == false,
-                    displayName = remoteNameForBadge,
-                    audioLevel = remoteP?.audioLevel ?: 0f,
-                )
+            if (remoteP != null) {
+                Box(modifier = remoteModifier) {
+                    // Hide displayName from the badge when remote video is off — the
+                    // remote placeholder already shows the participant's name.
+                    val remoteNameForBadge =
+                        if (!remoteP.videoEnabled) null else remoteP.displayName
+                    ParticipantBadge(
+                        modifier = Modifier.align(Alignment.BottomStart),
+                        muted = !remoteP.audioEnabled,
+                        displayName = remoteNameForBadge,
+                        audioLevel = remoteP.audioLevel,
+                    )
+                }
             }
         }
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -378,6 +378,7 @@ internal fun CallScreen(
                 localCid = uiState.localCid,
                 localVideoEnabled = uiState.localVideoEnabled,
                 localAudioEnabled = uiState.localAudioEnabled,
+                localAudioLevel = uiState.localAudioLevel,
                 localDisplayName = uiState.localDisplayName,
                 localMirror = uiState.isFrontCamera && !uiState.isScreenSharing,
                 localCameraMode = uiState.localCameraMode,
@@ -558,13 +559,19 @@ internal fun CallScreen(
                     modifier = Modifier.align(Alignment.BottomStart),
                     muted = !uiState.localAudioEnabled,
                     displayName = uiState.localDisplayName,
+                    audioLevel = uiState.localAudioLevel,
                 )
             }
             Box(modifier = remoteModifier) {
+                // Hide displayName from the badge when remote video is off — the
+                // remote placeholder already shows the participant's name.
+                val remoteNameForBadge =
+                    if (remoteP?.videoEnabled == false) null else remoteP?.displayName
                 ParticipantBadge(
                     modifier = Modifier.align(Alignment.BottomStart),
                     muted = remoteP?.audioEnabled == false,
-                    displayName = remoteP?.displayName,
+                    displayName = remoteNameForBadge,
+                    audioLevel = remoteP?.audioLevel ?: 0f,
                 )
             }
         }
@@ -1354,6 +1361,7 @@ private fun MultiPartyStage(
     localCid: String?,
     localVideoEnabled: Boolean,
     localAudioEnabled: Boolean,
+    localAudioLevel: Float,
     localDisplayName: String?,
     localMirror: Boolean,
     localCameraMode: LocalCameraMode,
@@ -1611,7 +1619,17 @@ private fun MultiPartyStage(
                                 val tileRemote = if (isLocal) null else remoteParticipants.find { it.cid == tile.id }
                                 val tileAudioMuted = if (isLocal) !localAudioEnabled else tileRemote?.audioEnabled == false
                                 val tileName = if (isLocal) localDisplayName else tileRemote?.displayName
-                                ParticipantBadge(modifier = Modifier.align(Alignment.BottomStart), muted = tileAudioMuted, displayName = tileName)
+                                // Remote tiles render their displayName inside the camera-off
+                                // placeholder, so hide it from the badge in that case.
+                                val tileNameForBadge =
+                                    if (!isLocal && tileRemote?.videoEnabled == false) null else tileName
+                                val tileAudioLevel = if (isLocal) localAudioLevel else tileRemote?.audioLevel ?: 0f
+                                ParticipantBadge(
+                                    modifier = Modifier.align(Alignment.BottomStart),
+                                    muted = tileAudioMuted,
+                                    displayName = tileNameForBadge,
+                                    audioLevel = tileAudioLevel,
+                                )
                             }
                             // Fit toggle on primary tile (bottom-end to avoid flashlight conflict)
                             if (tile.zOrder == 0) {
@@ -1704,7 +1722,14 @@ private fun MultiPartyStage(
                                         },
                                         strings = strings,
                                     )
-                                    ParticipantBadge(modifier = Modifier.align(Alignment.BottomStart), muted = participant.audioEnabled == false, displayName = participant.displayName)
+                                    val gridNameForBadge =
+                                        if (!participant.videoEnabled) null else participant.displayName
+                                    ParticipantBadge(
+                                        modifier = Modifier.align(Alignment.BottomStart),
+                                        muted = participant.audioEnabled == false,
+                                        displayName = gridNameForBadge,
+                                        audioLevel = participant.audioLevel,
+                                    )
                                 }
                             }
                         }
@@ -1739,7 +1764,12 @@ private fun MultiPartyStage(
                         fontSize = 10.sp
                     )
                 }
-                ParticipantBadge(modifier = Modifier.align(Alignment.BottomStart), muted = !localAudioEnabled, displayName = localDisplayName)
+                ParticipantBadge(
+                    modifier = Modifier.align(Alignment.BottomStart),
+                    muted = !localAudioEnabled,
+                    displayName = localDisplayName,
+                    audioLevel = localAudioLevel,
+                )
             }
         }
     }
@@ -2202,8 +2232,11 @@ private fun ParticipantBadge(
     modifier: Modifier = Modifier,
     muted: Boolean = false,
     displayName: String? = null,
+    audioLevel: Float = 0f,
+    showActivityIndicator: Boolean = true,
 ) {
-    if (!muted && displayName == null) return
+    val showIndicator = showActivityIndicator && !muted
+    if (!muted && !showIndicator && displayName == null) return
     Row(
         modifier = modifier
             .padding(6.dp)
@@ -2212,13 +2245,14 @@ private fun ParticipantBadge(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        if (muted) {
-            Icon(
+        when {
+            muted -> Icon(
                 imageVector = Icons.Default.MicOff,
                 contentDescription = null,
                 modifier = Modifier.size(14.dp),
                 tint = Color(0xFFEF4444)
             )
+            showIndicator -> AudioActivityIndicator(level = audioLevel)
         }
         if (displayName != null) {
             Text(

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallUiState.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallUiState.kt
@@ -18,6 +18,7 @@ data class CallUiState(
     val localAudioEnabled: Boolean = true,
     val localVideoEnabled: Boolean = true,
     val localDisplayName: String? = null,
+    val localAudioLevel: Float = 0f,
     val remoteParticipants: List<RemoteParticipant> = emptyList(),
     val connectionStatus: ConnectionStatus = ConnectionStatus.Connected,
     val isSignalingConnected: Boolean = false,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -315,6 +315,7 @@ private fun rememberCallUiState(
             localAudioEnabled = state.localAudioEnabled,
             localVideoEnabled = state.localVideoEnabled,
             localDisplayName = state.localDisplayName,
+            localAudioLevel = state.localAudioLevel,
             remoteParticipants = state.remoteParticipants,
             connectionStatus = state.connectionStatus,
             isSignalingConnected = diagnostics.isSignalingConnected,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
@@ -26,6 +26,12 @@ data class CallState(
     val localVideoEnabled: Boolean = true,
     /** Local participant display name, if set. */
     val localDisplayName: String? = null,
+    /**
+     * Smoothed voice activity level (0..1) for the locally captured mic.
+     * Updated at ~10 Hz while the call is active; intended to drive UI
+     * activity indicators. Always 0 when [localAudioEnabled] is false.
+     */
+    val localAudioLevel: Float = 0f,
     /** List of remote participants with their current state. */
     val remoteParticipants: List<RemoteParticipant> = emptyList(),
     /** Network connection status. */

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -1107,12 +1107,18 @@ class SerenadaSession internal constructor(
         val nextLocal = if (current.localAudioEnabled) localLevel else 0f
         var nextRemote: List<RemoteParticipant>? = null
         if (current.remoteParticipants.isNotEmpty()) {
+            var remoteChanged = false
             val updated = current.remoteParticipants.map { participant ->
                 val raw = remoteLevels[participant.cid] ?: 0f
                 val target = if (participant.audioEnabled) raw else 0f
-                if (participant.audioLevel == target) participant else participant.copy(audioLevel = target)
+                if (participant.audioLevel == target) {
+                    participant
+                } else {
+                    remoteChanged = true
+                    participant.copy(audioLevel = target)
+                }
             }
-            if (updated !== current.remoteParticipants) nextRemote = updated
+            if (remoteChanged) nextRemote = updated
         }
         if (nextLocal == current.localAudioLevel && nextRemote == null) return
         updateState(

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -19,6 +19,7 @@ import app.serenada.core.call.SessionClock
 import app.serenada.core.call.RemoteMediaState
 import app.serenada.core.call.resolveCameraModes
 import app.serenada.core.call.SignalingMessageRouter
+import app.serenada.core.call.AudioLevelPoller
 import app.serenada.core.call.StatsPoller
 import app.serenada.core.call.CallAudioSessionController
 import app.serenada.core.call.CallPhase
@@ -254,6 +255,13 @@ class SerenadaSession internal constructor(
             )
         },
         onRefreshRemoteParticipants = { refreshRemoteParticipants() },
+    )
+    private val audioLevelPoller = AudioLevelPoller(
+        handler = handler,
+        statsExecutorProvider = { webRtcStatsExecutor },
+        isActivePhase = { _state.value.phase == CallPhase.InCall },
+        getPeerSlots = { peerSlots.values.toList() },
+        onLevelsUpdated = { localLevel, remoteLevels -> applyAudioLevels(localLevel, remoteLevels) },
     )
     private val pendingMessages = java.util.ArrayDeque<SignalingMessage>()
     private val peerSlots = mutableMapOf<String, PeerConnectionSlotProtocol>()
@@ -1026,18 +1034,21 @@ class SerenadaSession internal constructor(
         val orderedRemoteCids = roomParticipants?.map { it.cid }?.filter { it != myCid }
             ?: peerSlots.keys.toList()
         val participantsByCid = roomParticipants?.associateBy { it.cid } ?: emptyMap()
+        val previousLevels = _state.value.remoteParticipants.associate { it.cid to it.audioLevel }
         val remoteParticipants = orderedRemoteCids.mapNotNull { cid ->
             val slot = peerSlots[cid] ?: return@mapNotNull null
             val participant = participantsByCid[cid]
             val peerState = remoteMediaStates[cid]
+            val audioEnabled = peerState?.audioEnabled ?: participant?.audioEnabled ?: true
             RemoteParticipant(
                 cid = cid,
                 displayName = participant?.displayName,
                 peerId = participant?.peerId,
-                audioEnabled = peerState?.audioEnabled ?: participant?.audioEnabled ?: true,
+                audioEnabled = audioEnabled,
                 videoEnabled = peerState?.videoEnabled ?: participant?.videoEnabled ?: slot.isRemoteVideoTrackEnabled(),
                 connectionState = SerenadaPeerConnectionState.fromRtcState(slot.getConnectionState()),
                 signalingStatus = participant?.signalingStatus ?: ParticipantSignalingStatus.ACTIVE,
+                audioLevel = if (audioEnabled) previousLevels[cid] ?: 0f else 0f,
             )
         }
         val currentState = _state.value
@@ -1082,8 +1093,35 @@ class SerenadaSession internal constructor(
 
     // --- Internal: Stats Polling ---
 
-    private fun startRemoteVideoStatePolling() { statsPoller.start() }
-    private fun stopRemoteVideoStatePolling() { statsPoller.stop() }
+    private fun startRemoteVideoStatePolling() {
+        statsPoller.start()
+        audioLevelPoller.start()
+    }
+    private fun stopRemoteVideoStatePolling() {
+        statsPoller.stop()
+        audioLevelPoller.stop()
+    }
+
+    private fun applyAudioLevels(localLevel: Float, remoteLevels: Map<String, Float>) {
+        val current = _state.value
+        val nextLocal = if (current.localAudioEnabled) localLevel else 0f
+        var nextRemote: List<RemoteParticipant>? = null
+        if (current.remoteParticipants.isNotEmpty()) {
+            val updated = current.remoteParticipants.map { participant ->
+                val raw = remoteLevels[participant.cid] ?: 0f
+                val target = if (participant.audioEnabled) raw else 0f
+                if (participant.audioLevel == target) participant else participant.copy(audioLevel = target)
+            }
+            if (updated !== current.remoteParticipants) nextRemote = updated
+        }
+        if (nextLocal == current.localAudioLevel && nextRemote == null) return
+        updateState(
+            current.copy(
+                localAudioLevel = nextLocal,
+                remoteParticipants = nextRemote ?: current.remoteParticipants,
+            )
+        )
+    }
 
     private fun broadcastLocalMediaState() {
         signalingMessageRouter.broadcastMediaState(

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelMonitor.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelMonitor.kt
@@ -1,0 +1,49 @@
+package app.serenada.core.call
+
+import kotlin.math.ln
+
+/**
+ * Stateful smoothing pipeline that turns a raw audio level (0..1, e.g. as
+ * reported by WebRTC's `audioLevel` stat) into a perceptual 0..1 value
+ * suitable for driving a voice-activity indicator.
+ *
+ * Mirrors the web SDK's `AudioLevelMonitor`:
+ *  - Map RMS to dBFS, then linearly map [-60, -15] dBFS → [0, 1].
+ *  - Apply asymmetric EMA: fast attack so bars react instantly to speech,
+ *    slow release so they don't twitch off between syllables.
+ *
+ * Not thread-safe. Call [update] from a single thread (the same one that
+ * reads [level]).
+ */
+internal class AudioLevelMonitor {
+    private var smoothedLevel: Float = 0f
+
+    val level: Float get() = smoothedLevel
+
+    /** Submit a raw 0..1 level and return the smoothed value. */
+    fun update(rawLevel: Float): Float {
+        val raw = rawLevel.coerceIn(0f, 1f)
+        val dbfs = if (raw > 0f) (20.0 * ln(raw.toDouble()) / LN_10).toFloat() else NOISE_FLOOR_DB
+        val target = ((dbfs - NOISE_FLOOR_DB) / (SPEECH_PEAK_DB - NOISE_FLOOR_DB))
+            .coerceIn(0f, 1f)
+        val smoothing = if (target > smoothedLevel) ATTACK_SMOOTHING else RELEASE_SMOOTHING
+        smoothedLevel = smoothedLevel * smoothing + target * (1f - smoothing)
+        return smoothedLevel
+    }
+
+    fun reset() { smoothedLevel = 0f }
+
+    companion object {
+        /** Update interval that pairs with the indicator's CSS-equivalent transition. */
+        const val UPDATE_INTERVAL_MS: Long = 100L
+        /** dBFS at or below which the indicator reads zero. */
+        const val NOISE_FLOOR_DB: Float = -60f
+        /** dBFS at which the indicator reads full. Speech peaks around -20 to -15 dBFS. */
+        const val SPEECH_PEAK_DB: Float = -15f
+        /** Smoothing factor when level is rising. Lower = snappier attack. */
+        const val ATTACK_SMOOTHING: Float = 0.4f
+        /** Smoothing factor when level is falling. Higher = slower release. */
+        const val RELEASE_SMOOTHING: Float = 0.7f
+        private val LN_10 = ln(10.0)
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelPoller.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelPoller.kt
@@ -1,0 +1,103 @@
+package app.serenada.core.call
+
+import android.os.Handler
+import java.util.concurrent.ExecutorService
+
+/**
+ * Polls WebRTC stats every [AudioLevelMonitor.UPDATE_INTERVAL_MS] for each
+ * peer connection's inbound audio level and the local media-source level,
+ * pushes them through per-cid [AudioLevelMonitor]s for dBFS+EMA smoothing,
+ * and reports the results on the main handler.
+ *
+ * Mirrors the web SDK's `AudioLevelMonitor`, but uses WebRTC stats instead
+ * of Web Audio API. The smoothed output range is identical (0..1) so the
+ * indicator visual is consistent across platforms.
+ */
+internal class AudioLevelPoller(
+    private val handler: Handler,
+    private val statsExecutorProvider: () -> ExecutorService?,
+    private val isActivePhase: () -> Boolean,
+    private val getPeerSlots: () -> List<PeerConnectionSlotProtocol>,
+    private val onLevelsUpdated: (localLevel: Float, remoteLevels: Map<String, Float>) -> Unit,
+) {
+    private val localMonitor = AudioLevelMonitor()
+    private val remoteMonitors = mutableMapOf<String, AudioLevelMonitor>()
+    private var pollRunnable: Runnable? = null
+    private var requestInFlight = false
+
+    fun start() {
+        if (pollRunnable != null) return
+        val runnable = object : Runnable {
+            override fun run() {
+                tick()
+                handler.postDelayed(this, AudioLevelMonitor.UPDATE_INTERVAL_MS)
+            }
+        }
+        pollRunnable = runnable
+        handler.post(runnable)
+    }
+
+    fun stop() {
+        pollRunnable?.let { handler.removeCallbacks(it) }
+        pollRunnable = null
+        requestInFlight = false
+        localMonitor.reset()
+        remoteMonitors.clear()
+    }
+
+    private fun tick() {
+        if (!isActivePhase()) return
+        if (requestInFlight) return
+        val slots = getPeerSlots()
+        val executor = statsExecutorProvider()?.takeIf { !it.isShutdown }
+        if (slots.isEmpty() || executor == null) {
+            // No peers (or executor torn down): emit a fully decayed sample so the
+            // indicator drops to silence rather than freezing on the last value.
+            val local = localMonitor.update(0f)
+            val remote = remoteMonitors.mapValues { (_, m) -> m.update(0f) }
+            onLevelsUpdated(local, remote)
+            return
+        }
+        requestInFlight = true
+        try {
+            executor.execute { collectAndReport(slots) }
+        } catch (_: java.util.concurrent.RejectedExecutionException) {
+            requestInFlight = false
+        }
+    }
+
+    private fun collectAndReport(slots: List<PeerConnectionSlotProtocol>) {
+        val rawLevels = mutableMapOf<String, Float?>()
+        var rawLocal: Float? = null
+        var remaining = slots.size
+        slots.forEach { slot ->
+            slot.collectAudioLevels { inbound, mediaSource ->
+                synchronized(rawLevels) {
+                    rawLevels[slot.remoteCid] = inbound
+                    // media-source is the same local mic across all peers; take the
+                    // first non-null value seen this round.
+                    if (rawLocal == null && mediaSource != null) rawLocal = mediaSource
+                    remaining -= 1
+                    if (remaining == 0) {
+                        val capturedLocal = rawLocal
+                        val capturedRemote = rawLevels.toMap()
+                        handler.post { applyAndEmit(capturedLocal, capturedRemote) }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun applyAndEmit(rawLocal: Float?, rawRemote: Map<String, Float?>) {
+        requestInFlight = false
+        val local = localMonitor.update(rawLocal ?: 0f)
+        // Drop monitors for peers no longer present.
+        val activeCids = rawRemote.keys
+        remoteMonitors.keys.retainAll(activeCids)
+        val remote = rawRemote.mapValues { (cid, raw) ->
+            val monitor = remoteMonitors.getOrPut(cid) { AudioLevelMonitor() }
+            monitor.update(raw ?: 0f)
+        }
+        onLevelsUpdated(local, remote)
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -419,6 +419,29 @@ internal class PeerConnectionSlot(
         }
     }
 
+    override fun collectAudioLevels(onComplete: (inboundLevel: Float?, mediaSourceLevel: Float?) -> Unit) {
+        val pc = peerConnection
+        if (pc == null) {
+            onComplete(null, null)
+            return
+        }
+        pc.getStats { report ->
+            var inbound: Float? = null
+            var mediaSource: Float? = null
+            report.statsMap.values.forEach { stat ->
+                when (stat.type) {
+                    "inbound-rtp" -> if (getMediaKind(stat) == "audio") {
+                        memberDouble(stat, "audioLevel")?.let { inbound = it.toFloat().coerceIn(0f, 1f) }
+                    }
+                    "media-source" -> if (getMediaKind(stat) == "audio") {
+                        memberDouble(stat, "audioLevel")?.let { mediaSource = it.toFloat().coerceIn(0f, 1f) }
+                    }
+                }
+            }
+            onComplete(inbound, mediaSource)
+        }
+    }
+
     override fun isReady(): Boolean = peerConnection != null
 
     override fun isPathDirect(): Boolean? = lastPathIsDirect

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
@@ -73,6 +73,15 @@ internal interface PeerConnectionSlotProtocol {
     fun attachRemoteSink(sink: VideoSink)
     fun detachRemoteSink(sink: VideoSink)
     fun collectWebRtcStats(onComplete: (String, RealtimeCallStats?) -> Unit)
+
+    /**
+     * Lightweight stats fetch that extracts only `audioLevel` (W3C webrtc-stats):
+     * the inbound-rtp audio level for the remote participant on this slot, and
+     * the media-source audio level for the locally captured mic. Either may
+     * be null if stats haven't populated yet. Callback runs on the executor
+     * thread (post to a handler if you need main-thread).
+     */
+    fun collectAudioLevels(onComplete: (inboundLevel: Float?, mediaSourceLevel: Float?) -> Unit)
     fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy)
 
     /**

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
@@ -78,8 +78,8 @@ internal interface PeerConnectionSlotProtocol {
      * Lightweight stats fetch that extracts only `audioLevel` (W3C webrtc-stats):
      * the inbound-rtp audio level for the remote participant on this slot, and
      * the media-source audio level for the locally captured mic. Either may
-     * be null if stats haven't populated yet. Callback runs on the executor
-     * thread (post to a handler if you need main-thread).
+     * be null if stats haven't populated yet. The callback thread is not
+     * guaranteed; post to the appropriate handler/executor if needed.
      */
     fun collectAudioLevels(onComplete: (inboundLevel: Float?, mediaSourceLevel: Float?) -> Unit)
     fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/RemoteParticipant.kt
@@ -15,4 +15,10 @@ data class RemoteParticipant(
     val videoEnabled: Boolean,
     val connectionState: SerenadaPeerConnectionState,
     val signalingStatus: ParticipantSignalingStatus = ParticipantSignalingStatus.ACTIVE,
+    /**
+     * Smoothed voice activity level (0..1) for this peer's inbound audio.
+     * Updated at ~10 Hz while the call is active; intended to drive UI
+     * activity indicators. Always 0 when [audioEnabled] is false.
+     */
+    val audioLevel: Float = 0f,
 )

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelMonitorTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelMonitorTest.kt
@@ -1,0 +1,70 @@
+package app.serenada.core.call
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioLevelMonitorTest {
+
+    @Test
+    fun reportsZeroForSilence() {
+        val monitor = AudioLevelMonitor()
+        repeat(10) { monitor.update(0f) }
+        assertEquals(0f, monitor.level, 0f)
+    }
+
+    @Test
+    fun convergesTowardOneForLoudSignals() {
+        // RMS ≈ 1.0 → ~0 dBFS → target 1.0. With attack 0.4, ~5 ticks gets close.
+        val monitor = AudioLevelMonitor()
+        repeat(8) { monitor.update(1.0f) }
+        assertTrue("expected level near 1, got ${monitor.level}", monitor.level > 0.95f)
+        assertTrue(monitor.level <= 1f)
+    }
+
+    @Test
+    fun producesNonZeroLevelForMidSpeech() {
+        // RMS = 0.39 → ~ -8 dBFS → target ≈ 1 (above SPEECH_PEAK_DB).
+        val monitor = AudioLevelMonitor()
+        val first = monitor.update(0.39f)
+        assertNotEquals(0f, first)
+        assertTrue(first > 0f && first <= 1f)
+    }
+
+    @Test
+    fun clampsRawInputToZeroOneRange() {
+        val monitor = AudioLevelMonitor()
+        // Negative + over-1 inputs are coerced; should not blow up.
+        monitor.update(-0.5f)
+        monitor.update(2.0f)
+        assertTrue(monitor.level in 0f..1f)
+    }
+
+    @Test
+    fun releasesSlowerThanItAttacks() {
+        val attack = AudioLevelMonitor()
+        attack.update(1.0f)
+        val afterAttackTick = attack.level
+
+        val release = AudioLevelMonitor()
+        repeat(20) { release.update(1.0f) }
+        val attackedFully = release.level
+        release.update(0f)
+        val afterReleaseTick = release.level
+
+        // After one tick of strong signal, attack should have moved a lot.
+        // After one tick of silence from full, release should still leave a substantial level.
+        assertTrue(afterAttackTick > 0.5f)
+        assertTrue("release left ${afterReleaseTick}, attacked to ${attackedFully}", afterReleaseTick > 0.5f * attackedFully)
+    }
+
+    @Test
+    fun resetReturnsToZero() {
+        val monitor = AudioLevelMonitor()
+        repeat(5) { monitor.update(1.0f) }
+        assertTrue(monitor.level > 0f)
+        monitor.reset()
+        assertEquals(0f, monitor.level, 0f)
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -134,6 +134,7 @@ internal class FakePeerConnectionSlot(
     override fun attachRemoteSink(sink: VideoSink) {}
     override fun detachRemoteSink(sink: VideoSink) {}
     override fun collectWebRtcStats(onComplete: (String, RealtimeCallStats?) -> Unit) { onComplete("fake", null) }
+    override fun collectAudioLevels(onComplete: (inboundLevel: Float?, mediaSourceLevel: Float?) -> Unit) { onComplete(null, null) }
     override fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy) {}
 
     // Test drivers


### PR DESCRIPTION
## Summary
Mirrors the web change in [#84](https://github.com/agatx/serenada/pull/84) for Android: replaces the empty space in `ParticipantBadge` with a small green 3-bar voice-activity meter when a participant's mic is unmuted. Muted state keeps the existing red mic-off icon. Also fixes the same name-duplication regression — the badge name is now hidden when video is off, since the camera-off placeholder already shows it.

### How the audio level reaches the UI

- **`AudioLevelMonitor`** (in `serenada-core`) — stateless dBFS + asymmetric EMA pipeline. Same constants as web (`NOISE_FLOOR_DB = -60`, `SPEECH_PEAK_DB = -15`, `ATTACK_SMOOTHING = 0.4`, `RELEASE_SMOOTHING = 0.7`), so the indicator behaves identically across platforms.
- **`AudioLevelPoller`** — polls each `PeerConnection`'s stats every 100 ms (cheaper variant of `getStats` that only reads `inbound-rtp.audioLevel` for the remote and `media-source.audioLevel` for the local mic), feeds raw 0..1 values through per-cid monitors, and emits smoothed levels on the main handler.
- **`audioLevel: Float`** added to `RemoteParticipant`; **`localAudioLevel: Float`** added to `CallState` and surfaced through `CallUiState`. `refreshRemoteParticipants` preserves audioLevel across rebuilds so the 500 ms participant refresh doesn't clobber it.
- **`AudioActivityIndicator`** Compose component — 3 bars with gains `[0.7, 1.0, 0.55]`, 14% minimum height, animated via `animateFloatAsState` with a 100 ms tween (the Compose analog of the web's CSS transition).

All 5 `ParticipantBadge` call sites updated (1:1 local + remote, multi-party stage tile, multi-party grid, multi-party local PIP).

## Test plan
- [x] `./gradlew assembleDebug` — clean
- [x] `./gradlew :serenada-core:testDebugUnitTest` — 6 new `AudioLevelMonitorTest` cases pass + existing tests
- [x] `./gradlew :serenada-core:lintDebug :serenada-call-ui:lintDebug` — clean
- [x] `node scripts/check-resilience-constants.mjs` — cross-platform parity intact
- [ ] Eyeball on a physical device: bars react smoothly to normal speech, muted shows red mic-off, no name duplication when peer's camera is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)