### PR TITLE
Add green audio activity indicator on iOS call UI

### DIFF
--- a/client-ios/SerenadaCallUI/Sources/AudioActivityIndicator.swift
+++ b/client-ios/SerenadaCallUI/Sources/AudioActivityIndicator.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Three small green bars that pulse with the speaker's audio level — used
+/// in place of the muted mic icon when a participant is unmuted.
+///
+/// Mirrors the web SDK's `AudioActivityIndicator` and Android's
+/// `AudioActivityIndicator.kt` 1:1 — same bar gains, 14% minimum height,
+/// animated transitions paced to the 100 ms update cadence of
+/// `AudioLevelMonitor`.
+struct AudioActivityIndicator: View {
+    let level: Float
+    var size: CGFloat = 14
+
+    private static let barGains: [Float] = [0.7, 1.0, 0.55]
+    private static let minHeightFraction: Float = 0.14
+    private static let maxHeightFraction: Float = 1.0
+    private static let barWidth: CGFloat = 3
+    private static let barColor = Color(red: 0x22 / 255, green: 0xC5 / 255, blue: 0x5E / 255)
+    private static let animationDuration: Double = 0.1
+
+    var body: some View {
+        let clamped = max(0, min(1, level))
+        HStack(alignment: .center, spacing: 2) {
+            ForEach(0..<Self.barGains.count, id: \.self) { index in
+                let gain = Self.barGains[index]
+                let target = Self.minHeightFraction +
+                    (Self.maxHeightFraction - Self.minHeightFraction) * min(1, clamped * gain)
+                Capsule()
+                    .fill(Self.barColor)
+                    .frame(width: Self.barWidth, height: size * CGFloat(target))
+                    .animation(.easeOut(duration: Self.animationDuration), value: clamped)
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -335,6 +335,7 @@ struct CallScreenView: View {
                     localCid: uiState.localCid,
                     localVideoEnabled: uiState.localVideoEnabled,
                     localAudioEnabled: uiState.localAudioEnabled,
+                    localAudioLevel: uiState.localAudioLevel,
                     localDisplayName: uiState.localDisplayName,
                     localMirror: uiState.isFrontCamera,
                     localCameraMode: uiState.localCameraMode,
@@ -370,7 +371,7 @@ struct CallScreenView: View {
                         showPlaceholder: shouldShowLocalVideoPlaceholder(localVideoEnabled: uiState.localVideoEnabled),
                         placeholderText: str(.callLocalCameraOff)
                     )
-                    ParticipantBadge(muted: !uiState.localAudioEnabled, displayName: uiState.localDisplayName)
+                    ParticipantBadge(muted: !uiState.localAudioEnabled, displayName: uiState.localDisplayName, audioLevel: uiState.localAudioLevel)
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
                 smallRemoteView
@@ -389,7 +390,11 @@ struct CallScreenView: View {
                         placeholderDisplayName: inCall ? firstRemote?.displayName : nil,
                         placeholderPeerId: inCall ? firstRemote?.peerId : nil
                     )
-                    ParticipantBadge(muted: firstRemote?.audioEnabled == false, displayName: firstRemote?.displayName)
+                    ParticipantBadge(
+                        muted: firstRemote?.audioEnabled == false,
+                        displayName: firstRemote?.videoEnabled == false ? nil : firstRemote?.displayName,
+                        audioLevel: firstRemote?.audioLevel ?? 0
+                    )
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
                 smallLocalView
@@ -539,7 +544,7 @@ struct CallScreenView: View {
                 VideoPlaceholderTile(text: str(.callCameraOff), compact: true)
             }
 
-            ParticipantBadge(muted: !uiState.localAudioEnabled, displayName: uiState.localDisplayName)
+            ParticipantBadge(muted: !uiState.localAudioEnabled, displayName: uiState.localDisplayName, audioLevel: uiState.localAudioLevel)
         }
             .frame(width: 110, height: 160)
             .clipShape(RoundedRectangle(cornerRadius: 14))
@@ -568,7 +573,11 @@ struct CallScreenView: View {
                 )
             }
 
-            ParticipantBadge(muted: uiState.remoteParticipants.first?.audioEnabled == false, displayName: uiState.remoteParticipants.first?.displayName)
+            ParticipantBadge(
+                muted: uiState.remoteParticipants.first?.audioEnabled == false,
+                displayName: uiState.remoteParticipants.first?.videoEnabled == false ? nil : uiState.remoteParticipants.first?.displayName,
+                audioLevel: uiState.remoteParticipants.first?.audioLevel ?? 0
+            )
         }
             .frame(width: 110, height: 160)
             .clipShape(RoundedRectangle(cornerRadius: 14))
@@ -887,6 +896,7 @@ private struct MultiPartyStage: View {
     let localCid: String?
     let localVideoEnabled: Bool
     let localAudioEnabled: Bool
+    let localAudioLevel: Float
     let localDisplayName: String?
     let localMirror: Bool
     let localCameraMode: LocalCameraMode
@@ -1063,7 +1073,14 @@ private struct MultiPartyStage: View {
                                 let tileRemote = isLocal ? nil : remoteParticipants.first(where: { $0.cid == tile.id })
                                 let tileAudioMuted = isLocal ? !localAudioEnabled : tileRemote?.audioEnabled == false
                                 let tileName = isLocal ? localDisplayName : tileRemote?.displayName
-                                ParticipantBadge(muted: tileAudioMuted, displayName: tileName)
+                                let tileNameForBadge: String? =
+                                    (!isLocal && tileRemote?.videoEnabled == false) ? nil : tileName
+                                let tileAudioLevel: Float = isLocal ? localAudioLevel : (tileRemote?.audioLevel ?? 0)
+                                ParticipantBadge(
+                                    muted: tileAudioMuted,
+                                    displayName: tileNameForBadge,
+                                    audioLevel: tileAudioLevel
+                                )
                                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
                             }
                         }
@@ -1148,6 +1165,7 @@ private struct MultiPartyStage: View {
                     MultiPartyLocalPip(
                         localVideoEnabled: localVideoEnabled,
                         localAudioEnabled: localAudioEnabled,
+                        localAudioLevel: localAudioLevel,
                         localDisplayName: localDisplayName,
                         localMirror: localMirror,
                         cornerRadius: pipCornerRadius,
@@ -1186,7 +1204,11 @@ private struct RemoteParticipantStageTile: View {
             if !participant.videoEnabled {
                 VideoPlaceholderTile(text: resolveString(.callVideoOff, overrides: strings), compact: false, displayName: participant.displayName, peerId: participant.peerId)
             }
-            ParticipantBadge(muted: participant.audioEnabled == false, displayName: participant.displayName)
+            ParticipantBadge(
+                muted: participant.audioEnabled == false,
+                displayName: participant.videoEnabled ? participant.displayName : nil,
+                audioLevel: participant.audioLevel
+            )
         }
         .frame(width: size.width, height: size.height)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
@@ -1200,6 +1222,7 @@ private struct RemoteParticipantStageTile: View {
 private struct MultiPartyLocalPip: View {
     let localVideoEnabled: Bool
     let localAudioEnabled: Bool
+    let localAudioLevel: Float
     let localDisplayName: String?
     let localMirror: Bool
     let cornerRadius: CGFloat
@@ -1219,7 +1242,7 @@ private struct MultiPartyLocalPip: View {
             } else {
                 VideoPlaceholderTile(text: resolveString(.callCameraOff, overrides: strings), compact: true)
             }
-            ParticipantBadge(muted: !localAudioEnabled, displayName: localDisplayName)
+            ParticipantBadge(muted: !localAudioEnabled, displayName: localDisplayName, audioLevel: localAudioLevel)
         }
         .frame(width: 100, height: 150)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
@@ -1282,14 +1305,19 @@ struct VideoPlaceholderTile: View {
 private struct ParticipantBadge: View {
     var muted: Bool = false
     var displayName: String? = nil
+    var audioLevel: Float = 0
+    var showActivityIndicator: Bool = true
 
     var body: some View {
-        if muted || displayName != nil {
+        let showIndicator = showActivityIndicator && !muted
+        if muted || showIndicator || displayName != nil {
             HStack(spacing: 4) {
                 if muted {
                     Image(systemName: "mic.slash.fill")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Color(red: 0.94, green: 0.27, blue: 0.27))
+                } else if showIndicator {
+                    AudioActivityIndicator(level: audioLevel)
                 }
                 if let name = displayName {
                     Text(name)

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -393,7 +393,7 @@ struct CallScreenView: View {
                     ParticipantBadge(
                         muted: firstRemote?.audioEnabled == false,
                         displayName: firstRemote?.videoEnabled == false ? nil : firstRemote?.displayName,
-                        audioLevel: firstRemote?.audioLevel ?? 0
+                        audioLevel: firstRemote?.audioLevel
                     )
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
@@ -576,7 +576,7 @@ struct CallScreenView: View {
             ParticipantBadge(
                 muted: uiState.remoteParticipants.first?.audioEnabled == false,
                 displayName: uiState.remoteParticipants.first?.videoEnabled == false ? nil : uiState.remoteParticipants.first?.displayName,
-                audioLevel: uiState.remoteParticipants.first?.audioLevel ?? 0
+                audioLevel: uiState.remoteParticipants.first?.audioLevel
             )
         }
             .frame(width: 110, height: 160)
@@ -1075,7 +1075,7 @@ private struct MultiPartyStage: View {
                                 let tileName = isLocal ? localDisplayName : tileRemote?.displayName
                                 let tileNameForBadge: String? =
                                     (!isLocal && tileRemote?.videoEnabled == false) ? nil : tileName
-                                let tileAudioLevel: Float = isLocal ? localAudioLevel : (tileRemote?.audioLevel ?? 0)
+                                let tileAudioLevel: Float? = isLocal ? localAudioLevel : tileRemote?.audioLevel
                                 ParticipantBadge(
                                     muted: tileAudioMuted,
                                     displayName: tileNameForBadge,
@@ -1305,18 +1305,21 @@ struct VideoPlaceholderTile: View {
 private struct ParticipantBadge: View {
     var muted: Bool = false
     var displayName: String? = nil
-    var audioLevel: Float = 0
-    var showActivityIndicator: Bool = true
+    /// When non-nil, drives the green activity indicator (and signals that a
+    /// real participant is bound to this badge). Pass `nil` for tiles without
+    /// a participant — e.g. the remote slot before a peer joins — to suppress
+    /// the badge entirely when there's nothing to show.
+    var audioLevel: Float? = nil
 
     var body: some View {
-        let showIndicator = showActivityIndicator && !muted
+        let showIndicator = !muted && audioLevel != nil
         if muted || showIndicator || displayName != nil {
             HStack(spacing: 4) {
                 if muted {
                     Image(systemName: "mic.slash.fill")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Color(red: 0.94, green: 0.27, blue: 0.27))
-                } else if showIndicator {
+                } else if let audioLevel {
                     AudioActivityIndicator(level: audioLevel)
                 }
                 if let name = displayName {

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -309,6 +309,7 @@ private struct SessionFirstCallFlow: View {
         uiState.localAudioEnabled = state.localParticipant.audioEnabled
         uiState.localVideoEnabled = state.localParticipant.videoEnabled
         uiState.localDisplayName = state.localParticipant.displayName
+        uiState.localAudioLevel = state.localParticipant.audioLevel
         uiState.localCameraMode = state.localParticipant.cameraMode
         uiState.connectionStatus = mapConnectionStatus(state.connectionStatus)
         uiState.activeTransport = diagnostics.activeTransport
@@ -332,7 +333,8 @@ private struct SessionFirstCallFlow: View {
                 peerId: rp.peerId,
                 audioEnabled: rp.audioEnabled,
                 videoEnabled: rp.videoEnabled,
-                connectionState: rp.connectionState
+                connectionState: rp.connectionState,
+                audioLevel: rp.audioLevel
             )
         }
         uiState.participantCount = 1 + state.remoteParticipants.count

--- a/client-ios/SerenadaCore/Sources/Call/AudioLevelMonitor.swift
+++ b/client-ios/SerenadaCore/Sources/Call/AudioLevelMonitor.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Stateful smoothing pipeline that turns a raw audio level (0..1, e.g. as
+/// reported by WebRTC's `audioLevel` stat) into a perceptual 0..1 value
+/// suitable for driving a voice-activity indicator.
+///
+/// Mirrors the web SDK's `AudioLevelMonitor` and the Android SDK's
+/// `AudioLevelMonitor.kt`:
+///  - Map RMS to dBFS, then linearly map [-60, -15] dBFS → [0, 1].
+///  - Apply asymmetric EMA: fast attack so bars react instantly to speech,
+///    slow release so they don't twitch off between syllables.
+///
+/// Not thread-safe. Use from a single thread (`@MainActor` in the SDK).
+final class AudioLevelMonitor {
+    /// Update interval that pairs with the indicator's animation duration.
+    static let updateIntervalSeconds: Double = 0.1
+    /// dBFS at or below which the indicator reads zero.
+    static let noiseFloorDb: Float = -60
+    /// dBFS at which the indicator reads full. Speech peaks around -20 to -15 dBFS.
+    static let speechPeakDb: Float = -15
+    /// Smoothing factor when level is rising. Lower = snappier attack.
+    static let attackSmoothing: Float = 0.4
+    /// Smoothing factor when level is falling. Higher = slower release.
+    static let releaseSmoothing: Float = 0.7
+
+    private(set) var level: Float = 0
+
+    /// Submit a raw 0..1 level and return the smoothed value.
+    @discardableResult
+    func update(rawLevel: Float) -> Float {
+        let raw = max(0, min(1, rawLevel))
+        let dbfs: Float = raw > 0 ? 20 * log10f(raw) : Self.noiseFloorDb
+        let span = Self.speechPeakDb - Self.noiseFloorDb
+        let target = max(0, min(1, (dbfs - Self.noiseFloorDb) / span))
+        let smoothing = target > level ? Self.attackSmoothing : Self.releaseSmoothing
+        level = level * smoothing + target * (1 - smoothing)
+        return level
+    }
+
+    func reset() { level = 0 }
+}

--- a/client-ios/SerenadaCore/Sources/Call/AudioLevelMonitor.swift
+++ b/client-ios/SerenadaCore/Sources/Call/AudioLevelMonitor.swift
@@ -28,7 +28,11 @@ final class AudioLevelMonitor {
     /// Submit a raw 0..1 level and return the smoothed value.
     @discardableResult
     func update(rawLevel: Float) -> Float {
-        let raw = max(0, min(1, rawLevel))
+        // `max`/`min` use `<` comparisons that propagate NaN unchanged, so a
+        // non-finite input would slip through the clamp and pin the indicator
+        // to a garbage value. Treat anything non-finite as silence.
+        let sanitized = rawLevel.isFinite ? rawLevel : 0
+        let raw = max(0, min(1, sanitized))
         let dbfs: Float = raw > 0 ? 20 * log10f(raw) : Self.noiseFloorDb
         let span = Self.speechPeakDb - Self.noiseFloorDb
         let target = max(0, min(1, (dbfs - Self.noiseFloorDb) / span))

--- a/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
+++ b/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
@@ -20,6 +20,9 @@ final class AudioLevelPoller {
     private var requestInFlight = false
     private let localMonitor = AudioLevelMonitor()
     private var remoteMonitors: [String: AudioLevelMonitor] = [:]
+    /// Bumped on each `start()`/`stop()` so any stats request started in a
+    /// previous run can be discarded when its async result returns.
+    private var generation: UInt64 = 0
 
     init(
         clock: SessionClock,
@@ -35,6 +38,7 @@ final class AudioLevelPoller {
 
     func start() {
         stop()
+        generation &+= 1
         pollTimerCancellable = clock.scheduleRepeating(intervalSeconds: AudioLevelMonitor.updateIntervalSeconds) { [weak self] in
             self?.tick()
         }
@@ -43,13 +47,17 @@ final class AudioLevelPoller {
     func stop() {
         pollTimerCancellable?.cancel()
         pollTimerCancellable = nil
+        // Bumping the generation invalidates any stats request kicked off by
+        // a previous tick — when its async completion fires, applyAndEmit
+        // will drop the result instead of emitting after teardown.
+        generation &+= 1
         requestInFlight = false
         localMonitor.reset()
         remoteMonitors.removeAll()
     }
 
     private func tick() {
-        guard isActivePhase() else { return }
+        guard pollTimerCancellable != nil, isActivePhase() else { return }
         if requestInFlight { return }
         let slots = getPeerSlots()
         guard !slots.isEmpty else {
@@ -62,6 +70,7 @@ final class AudioLevelPoller {
         }
 
         requestInFlight = true
+        let tickGeneration = generation
         let group = DispatchGroup()
         let lock = NSLock()
         var rawRemote: [String: Float?] = [:]
@@ -81,16 +90,22 @@ final class AudioLevelPoller {
 
         group.notify(queue: .main) { [weak self] in
             guard let self else { return }
-            Task { @MainActor in self.applyAndEmit(rawLocal: rawLocal, rawRemote: rawRemote) }
+            Task { @MainActor in self.applyAndEmit(rawLocal: rawLocal, rawRemote: rawRemote, tickGeneration: tickGeneration) }
         }
     }
 
-    private func applyAndEmit(rawLocal: Float?, rawRemote: [String: Float?]) {
+    private func applyAndEmit(rawLocal: Float?, rawRemote: [String: Float?], tickGeneration: UInt64) {
+        // Drop late results from a previous start()/stop() cycle.
+        guard tickGeneration == generation, pollTimerCancellable != nil else {
+            requestInFlight = false
+            return
+        }
         requestInFlight = false
         let local = localMonitor.update(rawLevel: rawLocal ?? 0)
-        // Drop monitors for peers no longer present.
+        // Drop monitors for peers no longer present. Snapshot the keys so we
+        // don't mutate the dictionary while iterating it.
         let activeCids = Set(rawRemote.keys)
-        for cid in remoteMonitors.keys where !activeCids.contains(cid) {
+        for cid in Array(remoteMonitors.keys) where !activeCids.contains(cid) {
             remoteMonitors.removeValue(forKey: cid)
         }
         var remote: [String: Float] = [:]

--- a/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
+++ b/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
@@ -1,0 +1,104 @@
+import Combine
+import Foundation
+
+/// Polls each peer's WebRTC stats every `AudioLevelMonitor.updateIntervalSeconds`
+/// for inbound audio level (remote) and media-source level (local mic),
+/// runs them through per-cid `AudioLevelMonitor`s for dBFS+EMA smoothing,
+/// and reports the smoothed values on the main actor.
+///
+/// Mirrors the Android `AudioLevelPoller.kt` and the web SDK's audio level
+/// machinery — output range is identical so the indicator visual is
+/// consistent across platforms.
+@MainActor
+final class AudioLevelPoller {
+    private let clock: SessionClock
+    private let isActivePhase: () -> Bool
+    private let getPeerSlots: () -> [any PeerConnectionSlotProtocol]
+    private let onLevelsUpdated: (_ localLevel: Float, _ remoteLevels: [String: Float]) -> Void
+
+    private var pollTimerCancellable: AnyCancellable?
+    private var requestInFlight = false
+    private let localMonitor = AudioLevelMonitor()
+    private var remoteMonitors: [String: AudioLevelMonitor] = [:]
+
+    init(
+        clock: SessionClock,
+        isActivePhase: @escaping () -> Bool,
+        getPeerSlots: @escaping () -> [any PeerConnectionSlotProtocol],
+        onLevelsUpdated: @escaping (_ localLevel: Float, _ remoteLevels: [String: Float]) -> Void
+    ) {
+        self.clock = clock
+        self.isActivePhase = isActivePhase
+        self.getPeerSlots = getPeerSlots
+        self.onLevelsUpdated = onLevelsUpdated
+    }
+
+    func start() {
+        stop()
+        pollTimerCancellable = clock.scheduleRepeating(intervalSeconds: AudioLevelMonitor.updateIntervalSeconds) { [weak self] in
+            self?.tick()
+        }
+    }
+
+    func stop() {
+        pollTimerCancellable?.cancel()
+        pollTimerCancellable = nil
+        requestInFlight = false
+        localMonitor.reset()
+        remoteMonitors.removeAll()
+    }
+
+    private func tick() {
+        guard isActivePhase() else { return }
+        if requestInFlight { return }
+        let slots = getPeerSlots()
+        guard !slots.isEmpty else {
+            // No peers: emit a fully decayed sample so the indicator drops to
+            // silence rather than freezing on the last value.
+            let local = localMonitor.update(rawLevel: 0)
+            let remote = remoteMonitors.mapValues { $0.update(rawLevel: 0) }
+            onLevelsUpdated(local, remote)
+            return
+        }
+
+        requestInFlight = true
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var rawRemote: [String: Float?] = [:]
+        var rawLocal: Float?
+
+        for slot in slots {
+            let cid = slot.remoteCid
+            group.enter()
+            slot.collectAudioLevels { inbound, mediaSource in
+                lock.lock()
+                rawRemote[cid] = inbound
+                if rawLocal == nil, let mediaSource { rawLocal = mediaSource }
+                lock.unlock()
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in self.applyAndEmit(rawLocal: rawLocal, rawRemote: rawRemote) }
+        }
+    }
+
+    private func applyAndEmit(rawLocal: Float?, rawRemote: [String: Float?]) {
+        requestInFlight = false
+        let local = localMonitor.update(rawLevel: rawLocal ?? 0)
+        // Drop monitors for peers no longer present.
+        let activeCids = Set(rawRemote.keys)
+        for cid in remoteMonitors.keys where !activeCids.contains(cid) {
+            remoteMonitors.removeValue(forKey: cid)
+        }
+        var remote: [String: Float] = [:]
+        for (cid, raw) in rawRemote {
+            let monitor = remoteMonitors[cid] ?? AudioLevelMonitor()
+            remoteMonitors[cid] = monitor
+            remote[cid] = monitor.update(rawLevel: raw ?? 0)
+        }
+        onLevelsUpdated(local, remote)
+    }
+}

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -535,6 +535,36 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
 #endif
     }
 
+    public func collectAudioLevels(onComplete: @escaping (_ inboundLevel: Float?, _ mediaSourceLevel: Float?) -> Void) {
+#if canImport(WebRTC)
+        guard let peerConnection else {
+            onComplete(nil, nil)
+            return
+        }
+        peerConnection.statistics { report in
+            var inbound: Float?
+            var mediaSource: Float?
+            for stat in report.statistics.values {
+                switch stat.type {
+                case "inbound-rtp":
+                    if mediaKind(for: stat) == "audio", let level = memberDouble(stat, key: "audioLevel") {
+                        inbound = max(0, min(1, Float(level)))
+                    }
+                case "media-source":
+                    if mediaKind(for: stat) == "audio", let level = memberDouble(stat, key: "audioLevel") {
+                        mediaSource = max(0, min(1, Float(level)))
+                    }
+                default:
+                    break
+                }
+            }
+            Task { @MainActor in onComplete(inbound, mediaSource) }
+        }
+#else
+        onComplete(nil, nil)
+#endif
+    }
+
     public func isReady() -> Bool {
 #if canImport(WebRTC)
         peerConnection != nil

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -547,12 +547,12 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
             for stat in report.statistics.values {
                 switch stat.type {
                 case "inbound-rtp":
-                    if mediaKind(for: stat) == "audio", let level = memberDouble(stat, key: "audioLevel") {
-                        inbound = max(0, min(1, Float(level)))
+                    if mediaKind(for: stat) == "audio" {
+                        inbound = clampedAudioLevel(memberDouble(stat, key: "audioLevel"))
                     }
                 case "media-source":
-                    if mediaKind(for: stat) == "audio", let level = memberDouble(stat, key: "audioLevel") {
-                        mediaSource = max(0, min(1, Float(level)))
+                    if mediaKind(for: stat) == "audio" {
+                        mediaSource = clampedAudioLevel(memberDouble(stat, key: "audioLevel"))
                     }
                 default:
                     break

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlotProtocol.swift
@@ -69,4 +69,10 @@ internal protocol PeerConnectionSlotProtocol: AnyObject {
     // Stats
     func collectRealtimeCallStats(onComplete: @escaping (RealtimeCallStats) -> Void)
     func collectRealtimeCallStatsAndSummary(onComplete: @escaping (RealtimeCallStats, String) -> Void)
+
+    /// Lightweight stats fetch for voice-activity indicators. Extracts only
+    /// `inbound-rtp.audioLevel` (the remote peer's audio) and
+    /// `media-source.audioLevel` (the locally captured mic). Either may be
+    /// `nil` if stats haven't populated yet. Callback fires on the main actor.
+    func collectAudioLevels(onComplete: @escaping (_ inboundLevel: Float?, _ mediaSourceLevel: Float?) -> Void)
 }

--- a/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
+++ b/client-ios/SerenadaCore/Sources/Call/RtcStatsHelpers.swift
@@ -33,6 +33,15 @@ func memberDouble(_ stat: RTCStatistics?, key: String) -> Double? {
     return nil
 }
 
+/// Clamps a raw `audioLevel` stat value to `[0, 1]`, returning `nil` for
+/// missing or non-finite inputs. `max`/`min` alone don't reject NaN (they use
+/// `<` comparisons that propagate NaN), so a stray non-finite value would
+/// otherwise pin the indicator to a garbage reading.
+func clampedAudioLevel(_ raw: Double?) -> Float? {
+    guard let raw, raw.isFinite else { return nil }
+    return Float(max(0, min(1, raw)))
+}
+
 func memberInt64(_ stat: RTCStatistics?, key: String) -> Int64? {
     guard let value = stat?.values[key] else { return nil }
     if let number = value as? NSNumber {

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -40,6 +40,10 @@ public struct LocalParticipant: Equatable {
     public var availableCameraModes: [LocalCameraMode] = defaultCameraModes
     /// Whether this participant is the room host.
     public var isHost: Bool = false
+    /// Smoothed voice activity level (0..1) for the locally captured mic.
+    /// Updated at ~10 Hz while the call is active; intended to drive UI
+    /// activity indicators. Always 0 when ``audioEnabled`` is false.
+    public var audioLevel: Float = 0
 
     public init() {}
 
@@ -51,7 +55,8 @@ public struct LocalParticipant: Equatable {
         videoEnabled: Bool = true,
         cameraMode: LocalCameraMode = .selfie,
         availableCameraModes: [LocalCameraMode] = defaultCameraModes,
-        isHost: Bool = false
+        isHost: Bool = false,
+        audioLevel: Float = 0
     ) {
         self.cid = cid
         self.displayName = displayName
@@ -61,6 +66,7 @@ public struct LocalParticipant: Equatable {
         self.cameraMode = cameraMode
         self.availableCameraModes = availableCameraModes
         self.isHost = isHost
+        self.audioLevel = audioLevel
     }
 }
 
@@ -87,6 +93,10 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
     /// them is intentionally kept alive. UIs should show a "reconnecting"
     /// indicator instead of rendering them as gone.
     public var signalingStatus: ParticipantSignalingStatus
+    /// Smoothed voice activity level (0..1) for this peer's inbound audio.
+    /// Updated at ~10 Hz while the call is active; intended to drive UI
+    /// activity indicators. Always 0 when ``audioEnabled`` is false.
+    public var audioLevel: Float = 0
 
     public var id: String { cid }
 
@@ -97,7 +107,8 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
         audioEnabled: Bool = true,
         videoEnabled: Bool = true,
         connectionState: SerenadaPeerConnectionState = .new,
-        signalingStatus: ParticipantSignalingStatus = .active
+        signalingStatus: ParticipantSignalingStatus = .active,
+        audioLevel: Float = 0
     ) {
         self.cid = cid
         self.displayName = displayName
@@ -106,6 +117,7 @@ public struct SerenadaRemoteParticipant: Identifiable, Equatable {
         self.videoEnabled = videoEnabled
         self.connectionState = connectionState
         self.signalingStatus = signalingStatus
+        self.audioLevel = audioLevel
     }
 }
 

--- a/client-ios/SerenadaCore/Sources/Models/CallUiState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallUiState.swift
@@ -17,6 +17,7 @@ public struct CallUiState: Equatable {
     public var localAudioEnabled: Bool = true
     public var localVideoEnabled: Bool = true
     public var localDisplayName: String?
+    public var localAudioLevel: Float = 0
     public var remoteParticipants: [RemoteParticipant] = []
     public var connectionStatus: ConnectionStatus = .connected
     public var isSignalingConnected: Bool = false

--- a/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/RemoteParticipant.swift
@@ -9,15 +9,20 @@ public struct RemoteParticipant: Identifiable, Equatable {
     public var audioEnabled: Bool
     public var videoEnabled: Bool
     public var connectionState: SerenadaPeerConnectionState
+    /// Smoothed voice activity level (0..1) for this peer's inbound audio.
+    /// Updated at ~10 Hz while the call is active. Always 0 when
+    /// ``audioEnabled`` is false.
+    public var audioLevel: Float
 
     public var id: String { cid }
 
-    public init(cid: String, displayName: String? = nil, peerId: String? = nil, audioEnabled: Bool = true, videoEnabled: Bool, connectionState: SerenadaPeerConnectionState) {
+    public init(cid: String, displayName: String? = nil, peerId: String? = nil, audioEnabled: Bool = true, videoEnabled: Bool, connectionState: SerenadaPeerConnectionState, audioLevel: Float = 0) {
         self.cid = cid
         self.displayName = displayName
         self.peerId = peerId
         self.audioEnabled = audioEnabled
         self.videoEnabled = videoEnabled
         self.connectionState = connectionState
+        self.audioLevel = audioLevel
     }
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -752,18 +752,32 @@ public final class SerenadaSession: ObservableObject {
     }
 
     private func applyAudioLevels(localLevel: Float, remoteLevels: [String: Float]) {
+        // Compute updates without touching state so we can skip commitSnapshot
+        // entirely when nothing changed. Otherwise this fires the SDK
+        // delegate's `sessionDidChangeState` 10×/sec during sustained silence.
         let nextLocal: Float = state.localParticipant.audioEnabled ? localLevel : 0
-        commitSnapshot { s, _ in
-            if s.localParticipant.audioLevel != nextLocal {
-                s.localParticipant.audioLevel = nextLocal
-            }
-            for index in s.remoteParticipants.indices {
-                let raw = remoteLevels[s.remoteParticipants[index].cid] ?? 0
-                let target: Float = s.remoteParticipants[index].audioEnabled ? raw : 0
-                if s.remoteParticipants[index].audioLevel != target {
-                    s.remoteParticipants[index].audioLevel = target
+        let localChanged = nextLocal != state.localParticipant.audioLevel
+
+        var updatedRemote: [SerenadaRemoteParticipant]?
+        if !state.remoteParticipants.isEmpty {
+            var draft = state.remoteParticipants
+            var anyChanged = false
+            for index in draft.indices {
+                let raw = remoteLevels[draft[index].cid] ?? 0
+                let target: Float = draft[index].audioEnabled ? raw : 0
+                if draft[index].audioLevel != target {
+                    draft[index].audioLevel = target
+                    anyChanged = true
                 }
             }
+            if anyChanged { updatedRemote = draft }
+        }
+
+        guard localChanged || updatedRemote != nil else { return }
+
+        commitSnapshot { s, _ in
+            if localChanged { s.localParticipant.audioLevel = nextLocal }
+            if let updatedRemote { s.remoteParticipants = updatedRemote }
         }
     }
 

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -143,6 +143,7 @@ public final class SerenadaSession: ObservableObject {
     private var peerNegotiationEngine: PeerNegotiationEngine?
     private var connectionStatusTracker: ConnectionStatusTracker?
     private var statsPoller: StatsPoller?
+    private var audioLevelPoller: AudioLevelPoller?
 
     // Network
     private let pathMonitor = NWPathMonitor()
@@ -498,6 +499,7 @@ public final class SerenadaSession: ObservableObject {
         userPreferredVideoEnabled = shouldEnableVideo
         applyLocalVideoPreference()
         statsPoller?.start()
+        audioLevelPoller?.start()
 
         joinFlowCoordinator?.clearJoinConnectKickstart()
         joinFlowCoordinator?.scheduleJoinTimeout(roomId: roomId, joinAttempt: joinAttemptSerial)
@@ -727,15 +729,18 @@ public final class SerenadaSession: ObservableObject {
             commitSnapshot { s, _ in s.remoteParticipants = [] }
             return
         }
+        let previousLevels = Dictionary(uniqueKeysWithValues: state.remoteParticipants.map { ($0.cid, $0.audioLevel) })
         let participants = roomState.participants.filter { $0.cid != clientId }.map { p in
             let slot = peerSlots[p.cid]
             let peerState = remoteMediaStates[p.cid]
+            let audioEnabled = peerState?.audioEnabled ?? p.audioEnabled ?? true
             return SerenadaRemoteParticipant(
                 cid: p.cid, displayName: p.displayName, peerId: p.peerId,
-                audioEnabled: peerState?.audioEnabled ?? p.audioEnabled ?? true,
+                audioEnabled: audioEnabled,
                 videoEnabled: peerState?.videoEnabled ?? p.videoEnabled ?? (slot?.isRemoteVideoTrackEnabled() ?? false),
                 connectionState: slot?.getConnectionState() ?? .new,
-                signalingStatus: p.signalingStatus
+                signalingStatus: p.signalingStatus,
+                audioLevel: audioEnabled ? (previousLevels[p.cid] ?? 0) : 0
             )
         }
         let activeCids = Set(participants.map(\.cid))
@@ -743,6 +748,22 @@ public final class SerenadaSession: ObservableObject {
         commitSnapshot { s, d in
             s.remoteParticipants = participants
             if clearContent { d.remoteContentParticipantId = nil; d.remoteContentType = nil }
+        }
+    }
+
+    private func applyAudioLevels(localLevel: Float, remoteLevels: [String: Float]) {
+        let nextLocal: Float = state.localParticipant.audioEnabled ? localLevel : 0
+        commitSnapshot { s, _ in
+            if s.localParticipant.audioLevel != nextLocal {
+                s.localParticipant.audioLevel = nextLocal
+            }
+            for index in s.remoteParticipants.indices {
+                let raw = remoteLevels[s.remoteParticipants[index].cid] ?? 0
+                let target: Float = s.remoteParticipants[index].audioEnabled ? raw : 0
+                if s.remoteParticipants[index].audioLevel != target {
+                    s.remoteParticipants[index].audioLevel = target
+                }
+            }
         }
     }
 
@@ -901,6 +922,7 @@ public final class SerenadaSession: ObservableObject {
 
     private func resetResources() {
         statsPoller?.stop()
+        audioLevelPoller?.stop()
         peerNegotiationEngine?.resetAll()
         signalingProvider.disconnect()
         peerSlots.values.forEach { $0.closePeerConnection() }
@@ -1069,6 +1091,18 @@ public final class SerenadaSession: ObservableObject {
             },
             onStatsUpdated: { [weak self] merged in self?.commitSnapshot { _, d in d.realtimeStats = merged } },
             onRefreshRemoteParticipants: { [weak self] in self?.refreshRemoteParticipants() }
+        )
+
+        audioLevelPoller = AudioLevelPoller(
+            clock: clock,
+            isActivePhase: { [weak self] in self?.internalPhase == .inCall },
+            getPeerSlots: { [weak self] in
+                guard let self else { return [] }
+                return Array(self.peerSlots.values)
+            },
+            onLevelsUpdated: { [weak self] localLevel, remoteLevels in
+                self?.applyAudioLevels(localLevel: localLevel, remoteLevels: remoteLevels)
+            }
         )
 
         peerNegotiationEngine = PeerNegotiationEngine(

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelMonitorTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelMonitorTests.swift
@@ -1,0 +1,57 @@
+@testable import SerenadaCore
+import XCTest
+
+final class AudioLevelMonitorTests: XCTestCase {
+    func testReportsZeroForSilence() {
+        let monitor = AudioLevelMonitor()
+        for _ in 0..<10 { _ = monitor.update(rawLevel: 0) }
+        XCTAssertEqual(monitor.level, 0, accuracy: 1e-6)
+    }
+
+    func testConvergesTowardOneForLoudSignals() {
+        // RMS = 1.0 → ~0 dBFS → target 1.0. With attack 0.4, ~5 ticks gets close.
+        let monitor = AudioLevelMonitor()
+        for _ in 0..<8 { _ = monitor.update(rawLevel: 1.0) }
+        XCTAssertGreaterThan(monitor.level, 0.95)
+        XCTAssertLessThanOrEqual(monitor.level, 1.0)
+    }
+
+    func testProducesNonZeroLevelForMidSpeech() {
+        // RMS = 0.39 → ~ -8 dBFS → above SPEECH_PEAK_DB → target ≈ 1.
+        let monitor = AudioLevelMonitor()
+        let first = monitor.update(rawLevel: 0.39)
+        XCTAssertGreaterThan(first, 0)
+        XCTAssertLessThanOrEqual(first, 1)
+    }
+
+    func testClampsRawInputToZeroOneRange() {
+        let monitor = AudioLevelMonitor()
+        _ = monitor.update(rawLevel: -0.5)
+        _ = monitor.update(rawLevel: 2.0)
+        XCTAssertGreaterThanOrEqual(monitor.level, 0)
+        XCTAssertLessThanOrEqual(monitor.level, 1)
+    }
+
+    func testReleasesSlowerThanItAttacks() {
+        let attack = AudioLevelMonitor()
+        _ = attack.update(rawLevel: 1.0)
+        let afterAttackTick = attack.level
+
+        let release = AudioLevelMonitor()
+        for _ in 0..<20 { _ = release.update(rawLevel: 1.0) }
+        let attackedFully = release.level
+        _ = release.update(rawLevel: 0)
+        let afterReleaseTick = release.level
+
+        XCTAssertGreaterThan(afterAttackTick, 0.5)
+        XCTAssertGreaterThan(afterReleaseTick, 0.5 * attackedFully)
+    }
+
+    func testResetReturnsToZero() {
+        let monitor = AudioLevelMonitor()
+        for _ in 0..<5 { _ = monitor.update(rawLevel: 1.0) }
+        XCTAssertGreaterThan(monitor.level, 0)
+        monitor.reset()
+        XCTAssertEqual(monitor.level, 0, accuracy: 1e-6)
+    }
+}

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelMonitorTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelMonitorTests.swift
@@ -32,6 +32,16 @@ final class AudioLevelMonitorTests: XCTestCase {
         XCTAssertLessThanOrEqual(monitor.level, 1)
     }
 
+    func testTreatsNonFiniteInputAsSilence() {
+        let monitor = AudioLevelMonitor()
+        // NaN/inf would otherwise slip through the clamp (min/max use `<`
+        // comparisons that propagate NaN) and pin the indicator to garbage.
+        _ = monitor.update(rawLevel: .nan)
+        XCTAssertEqual(monitor.level, 0, accuracy: 1e-6)
+        _ = monitor.update(rawLevel: .infinity)
+        XCTAssertEqual(monitor.level, 0, accuracy: 1e-6)
+    }
+
     func testReleasesSlowerThanItAttacks() {
         let attack = AudioLevelMonitor()
         _ = attack.update(rawLevel: 1.0)

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
@@ -194,6 +194,10 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
         onComplete(.empty, "fake")
     }
 
+    func collectAudioLevels(onComplete: @escaping (_ inboundLevel: Float?, _ mediaSourceLevel: Float?) -> Void) {
+        onComplete(nil, nil)
+    }
+
     // MARK: - Test Drivers
 
     func simulateConnectionStateChange(_ state: SerenadaPeerConnectionState) {

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		1B3764EC96FDD478F4ADD4C4 /* BroadcastUpload.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BroadcastUpload.entitlements; sourceTree = "<group>"; };
 		1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingMessageTests.swift; sourceTree = "<group>"; };
 		23CA15C6609960E60FFBCD90 /* JoinFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinFlowCoordinatorTests.swift; sourceTree = "<group>"; };
-		265E1C5C61144DD8395C627C /* SerenadaCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SerenadaCore; path = SerenadaCore; sourceTree = SOURCE_ROOT; };
+		265E1C5C61144DD8395C627C /* SerenadaCore */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SerenadaCore; sourceTree = SOURCE_ROOT; };
 		28D54CC01458DA4FCF58D271 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2A15CC6B14E97F4E2C37C573 /* SerenadaServerProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaServerProviderTests.swift; sourceTree = "<group>"; };
 		2D7AA70D76623801E762E2DB /* ErrorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreen.swift; sourceTree = "<group>"; };
@@ -168,11 +168,11 @@
 		43E2F0452DE65337073894BF /* RecentCallStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCallStore.swift; sourceTree = "<group>"; };
 		461DCF4D9C695C2B6051BF91 /* FakeMediaEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMediaEngine.swift; sourceTree = "<group>"; };
 		47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackScreen.swift; sourceTree = "<group>"; };
-		4D4E0E538F82CE87BE4FDB24 /* SerenadaCallUI */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SerenadaCallUI; path = SerenadaCallUI; sourceTree = SOURCE_ROOT; };
+		4D4E0E538F82CE87BE4FDB24 /* SerenadaCallUI */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SerenadaCallUI; sourceTree = SOURCE_ROOT; };
 		4ECD8A5FB8E492716B9681E3 /* SavedRoomStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRoomStoreTests.swift; sourceTree = "<group>"; };
 		53E3B13DA44022026D9F605D /* SavedRoomStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRoomStore.swift; sourceTree = "<group>"; };
 		6625E5E013BB38E369F98188 /* JoinWithCodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinWithCodeScreen.swift; sourceTree = "<group>"; };
-		68ABF3375C20336F82397BA3 /* SerenadaBroadcast.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SerenadaBroadcast.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		68ABF3375C20336F82397BA3 /* SerenadaBroadcast.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SerenadaBroadcast.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A7E704E0AE11C565FB076AE /* SerenadaiOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SerenadaiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelMonitorTests.swift; sourceTree = "<group>"; };
 		6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushKeyStore.swift; sourceTree = "<group>"; };
@@ -664,7 +664,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					8983470B9AA32DF7F4E2428C = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					952AC02A226F3D3E300DA6FF = {
@@ -1140,6 +1139,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = BroadcastUpload/BroadcastUpload.entitlements;
+				DEVELOPMENT_TEAM = U5TBRZ56DZ;
 				INFOPLIST_FILE = BroadcastUpload/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1175,6 +1175,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = BroadcastUpload/BroadcastUpload.entitlements;
+				DEVELOPMENT_TEAM = U5TBRZ56DZ;
 				INFOPLIST_FILE = BroadcastUpload/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		5B73BDA93B3B03BE10F8F3DC /* DeepLinkParticipantCountUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE1FC71083746A8D257448 /* DeepLinkParticipantCountUITests.swift */; };
 		60DD419576BB73E40DC4D993 /* SignalingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */; };
 		6198802831401A13687DDCA9 /* FeedbackScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */; };
+		64A7BCD5402B626283D5F7A7 /* AudioLevelMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */; };
 		6D7CC8795CCE4899285777B4 /* SerenadaDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */; };
 		6E8767096E3E70790EB1CEE5 /* SessionNegotiationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */; };
 		6E92E404B6B3E0A636F21C56 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529A15EA2C43DB2F91F46FC /* RootView.swift */; };
@@ -173,6 +174,7 @@
 		6625E5E013BB38E369F98188 /* JoinWithCodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinWithCodeScreen.swift; sourceTree = "<group>"; };
 		68ABF3375C20336F82397BA3 /* SerenadaBroadcast.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SerenadaBroadcast.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A7E704E0AE11C565FB076AE /* SerenadaiOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SerenadaiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelMonitorTests.swift; sourceTree = "<group>"; };
 		6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushKeyStore.swift; sourceTree = "<group>"; };
 		70D055EA10214AFAD5F76FFE /* layout_conformance_v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = layout_conformance_v1.json; sourceTree = "<group>"; };
 		7830FA5A71601737755C721D /* SerenadaSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaSessionTests.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 		A2D3D0A29FF7773DB01D20A5 /* SerenadaCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */,
 				9FC9E71EE9415390DBBFC4A7 /* BackoffTests.swift */,
 				9F052EA0D1D083D292B3CF0E /* CameraModeFlowTests.swift */,
 				D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */,
@@ -789,6 +792,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				64A7BCD5402B626283D5F7A7 /* AudioLevelMonitorTests.swift in Sources */,
 				932FE0F4C5B2A808073B537A /* BackoffTests.swift in Sources */,
 				85B89222838ED1AA3AF9F938 /* CallScreenStateTests.swift in Sources */,
 				9ADDE9F64E5B64AB5128AF50 /* CameraModeFlowTests.swift in Sources */,


### PR DESCRIPTION
## Summary
Mirrors the web ([#84](https://github.com/agatx/serenada/pull/84)) and Android ([#85](https://github.com/agatx/serenada/pull/85)) implementations for iOS: replaces the empty space in `ParticipantBadge` with a small green 3-bar voice-activity meter when a participant's mic is unmuted. Muted state keeps the existing red mic-off icon. Also fixes the same name-duplication regression — the badge name is now hidden when video is off, since the camera-off placeholder already shows it.

### How the audio level reaches the UI

- **`AudioLevelMonitor`** (in `SerenadaCore`) — stateless dBFS + asymmetric EMA pipeline. Same constants as web/Android (`noiseFloorDb = -60`, `speechPeakDb = -15`, `attackSmoothing = 0.4`, `releaseSmoothing = 0.7`).
- **`AudioLevelPoller`** — runs on `SessionClock.scheduleRepeating(0.1)`. New lightweight `PeerConnectionSlot.collectAudioLevels` fetches `inbound-rtp.audioLevel` (remote) and `media-source.audioLevel` (local) without parsing the rest of the stats report. Levels go through per-cid monitors and emit on the main actor.
- **`audioLevel: Float`** added to `LocalParticipant`, `SerenadaRemoteParticipant`, and the UI-side `RemoteParticipant`. `localAudioLevel` added to `CallUiState`. `refreshRemoteParticipants` preserves audioLevel across rebuilds.
- **`AudioActivityIndicator`** SwiftUI view — 3 bars with gains `[0.7, 1.0, 0.55]`, 14% minimum height, animated via `.animation(.easeOut(duration: 0.1), value:)` (matches the 100 ms web CSS transition + Android tween).

All 7 `ParticipantBadge` call sites updated (1:1 primary local + remote, 1:1 small PIPs, multi-party computed-layout tile, multi-party grid stage tile, multi-party local PIP).

## Test plan
- [x] `xcodebuild ... build` (iOS Simulator) — clean
- [x] `xcodebuild ... test` — all suites pass, 6 new `AudioLevelMonitorTests` cases included
- [x] `node scripts/check-resilience-constants.mjs` — cross-platform parity intact
- [ ] Eyeball on a physical iPhone: bars react smoothly to normal speech, muted shows red mic-off, no name duplication when peer's camera is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)