### PR TITLE
fix: harden cert auto-renewal for webroot + coturn

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -115,7 +115,7 @@ Serenada expects Let's Encrypt certificates to be located at `/etc/letsencrypt/l
     sudo certbot certonly --standalone -d your-domain.com
     ```
 3.  The certificates are mounted into the containers via `docker-compose.prod.yml`.
-4.  Run `./deploy.sh` from your local machine. It converts the cert's renewal config to webroot mode (zero-downtime renewals against the live containerized nginx) and registers the deploy-hook to reload nginx after each renewal. **Do not skip this step** — without it, certbot keeps trying to bind ports 80/443 itself, which Docker already owns, and renewals fail silently until the cert expires.
+4.  Run `./deploy.sh` from your local machine. It converts the cert's renewal config to webroot mode (zero-downtime renewals against the live containerized nginx) and installs a post-renewal hook at `/etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh` that reloads nginx (`nginx -s reload`) and signals coturn (`SIGUSR2` to re-read the TLS files) after every successful renewal. **Do not skip this step** — without it, certbot keeps trying to bind ports 80/443 itself, which Docker already owns, and renewals fail silently until the cert expires; coturn would also continue serving the old cert on TURNS:5349 until the next container restart.
 
 ### 4. Deploying the Stack
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -115,6 +115,7 @@ Serenada expects Let's Encrypt certificates to be located at `/etc/letsencrypt/l
     sudo certbot certonly --standalone -d your-domain.com
     ```
 3.  The certificates are mounted into the containers via `docker-compose.prod.yml`.
+4.  Run `./deploy.sh` from your local machine. It converts the cert's renewal config to webroot mode (zero-downtime renewals against the live containerized nginx) and registers the deploy-hook to reload nginx after each renewal. **Do not skip this step** — without it, certbot keeps trying to bind ports 80/443 itself, which Docker already owns, and renewals fail silently until the cert expires.
 
 ### 4. Deploying the Stack
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -159,8 +159,14 @@ COMPOSE_PROJECT=$(basename "$REMOTE_DIR")
 ssh "$VPS_HOST" <<RENEWAL_EOF
 set -e
 
+if [ "\$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
 CERT_CONF="/etc/letsencrypt/renewal/${DOMAIN}.conf"
-if [ ! -f "\$CERT_CONF" ]; then
+if ! \$SUDO test -f "\$CERT_CONF"; then
     echo "⚠️  No certbot renewal config at \$CERT_CONF — bootstrap the cert first (see DEPLOY.md)"
     exit 0
 fi
@@ -177,14 +183,14 @@ fi
 # (SIGUSR2 = re-read TLS certs) so both pick up the new cert without
 # dropping in-flight connections. coturn must be signaled explicitly —
 # it loads certs once at startup and won't notice file changes otherwise.
-mkdir -p /etc/letsencrypt/renewal-hooks/deploy
-cat > /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh <<'HOOK_EOF'
+\$SUDO mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+\$SUDO tee /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh >/dev/null <<'HOOK_EOF'
 #!/bin/bash
 set -e
 docker exec serenada-nginx nginx -s reload || true
 docker kill -s USR2 serenada-coturn || true
 HOOK_EOF
-chmod +x /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh
+\$SUDO chmod +x /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh
 
 # Force renewal to use webroot for zero-downtime. Covers fresh deploys AND any
 # prior config using authenticator=standalone or authenticator=nginx — both of
@@ -192,32 +198,43 @@ chmod +x /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh
 # Re-run certbot (instead of sed-editing the conf) so certbot writes a valid
 # renewal config itself. Reload hooks come from renewal-hooks/deploy/ above,
 # not --deploy-hook, so all renewals fire the same hook script.
-AUTH=\$(awk -F' = ' '/^authenticator/{print \$2; exit}' "\$CERT_CONF")
+#
+# Use --force-renewal (not --keep-until-expiring): the latter can early-exit
+# when the cert isn't due, leaving the renewal config still pointing at
+# standalone/nginx. Force-renewal guarantees certbot rewrites the lineage
+# config with authenticator=webroot. This block only runs once per VPS (the
+# AUTH check skips it on subsequent deploys), so the extra issuance is a
+# one-time cost during migration.
+AUTH=\$(\$SUDO awk -F' = ' '/^authenticator/{print \$2; exit}' "\$CERT_CONF")
 if [ "\$AUTH" != "webroot" ]; then
     echo "🔧 Cert was using authenticator=\$AUTH; reconfiguring to webroot..."
-    DOMAINS=\$(certbot certificates --cert-name "${DOMAIN}" 2>/dev/null \\
+    DOMAINS=\$(\$SUDO certbot certificates --cert-name "${DOMAIN}" 2>/dev/null \\
         | awk -F': ' '/Domains:/{print \$2; exit}')
     [ -z "\$DOMAINS" ] && DOMAINS="${DOMAIN}"
     DOMAIN_ARGS=""
     for d in \$DOMAINS; do DOMAIN_ARGS="\$DOMAIN_ARGS -d \$d"; done
-    certbot certonly --non-interactive \\
+    \$SUDO certbot certonly --non-interactive \\
         --webroot -w "\$WEBROOT_PATH" \\
         --cert-name "${DOMAIN}" \\
         \$DOMAIN_ARGS \\
-        --keep-until-expiring
+        --force-renewal
     echo "✅ Cert renewal switched to webroot"
 fi
 
 # Drop any legacy renew_hook from the cert config (now handled by
 # renewal-hooks/deploy/) to avoid double-running on each renewal.
-sed -i '/^renew_hook = /d' "\$CERT_CONF"
+\$SUDO sed -i '/^renew_hook = /d' "\$CERT_CONF"
 
 # Install weekly cron (Sun 3am), replacing any old certbot entry. The renewal
 # config stores webroot_path; reload hooks live in renewal-hooks/deploy/.
 # Plain 'certbot renew' is enough — no flags belong in the cron line.
+# We use a dedicated cron entry (not the system certbot.timer) so the schedule
+# and command are explicit and visible to operators alongside the rest of the
+# deploy. 'certbot renew' is idempotent, so co-existence with the system timer
+# is harmless if both are enabled.
 if command -v crontab >/dev/null 2>&1; then
     CRON_CMD="0 3 * * 0 certbot renew --quiet"
-    ( crontab -l 2>/dev/null | grep -v 'certbot renew'; echo "\$CRON_CMD" ) | crontab -
+    ( \$SUDO crontab -l 2>/dev/null | grep -v 'certbot renew'; echo "\$CRON_CMD" ) | \$SUDO crontab -
     echo "✅ SSL auto-renewal cron job is configured (weekly, zero-downtime)"
 else
     echo "⚠️  crontab not found — install cron (apt install cron) to enable SSL auto-renewal"

--- a/deploy.sh
+++ b/deploy.sh
@@ -153,7 +153,7 @@ ssh "$VPS_HOST" "cd $REMOTE_DIR && \
     docker compose -f docker-compose.yml -f docker-compose.prod.yml down && \
     docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build"
 
-# 6. Ensure SSL auto-renewal cron job exists
+# 6. Ensure SSL auto-renewal is configured for webroot (zero-downtime)
 echo "🔒 Checking SSL auto-renewal cron job..."
 COMPOSE_PROJECT=$(basename "$REMOTE_DIR")
 ssh "$VPS_HOST" <<RENEWAL_EOF
@@ -161,27 +161,62 @@ set -e
 
 CERT_CONF="/etc/letsencrypt/renewal/${DOMAIN}.conf"
 if [ ! -f "\$CERT_CONF" ]; then
-    echo "⚠️  No certbot renewal config at \$CERT_CONF — skipping auto-renewal setup"
+    echo "⚠️  No certbot renewal config at \$CERT_CONF — bootstrap the cert first (see DEPLOY.md)"
     exit 0
 fi
 
-# If certbot uses standalone (requires stopping nginx), switch to webroot for zero-downtime
-AUTH=\$(grep '^authenticator' "\$CERT_CONF" | awk '{print \$3}')
-if [ "\$AUTH" = "standalone" ]; then
-    sed -i 's/^authenticator = standalone/authenticator = webroot/' "\$CERT_CONF"
-    if ! grep -q '^\[webroot\]' "\$CERT_CONF"; then
-        printf '\n[webroot]\n${DOMAIN} = /var/www/certbot\n' >> "\$CERT_CONF"
-    fi
-    WEBROOT_PATH=\$(docker volume inspect ${COMPOSE_PROJECT}_certbot-webroot -f '{{.Mountpoint}}')
-    RENEW_FLAGS="--webroot-path \$WEBROOT_PATH"
-    echo "Switched certbot from standalone to webroot"
-else
-    RENEW_FLAGS=""
+WEBROOT_VOL="${COMPOSE_PROJECT}_certbot-webroot"
+WEBROOT_PATH=\$(docker volume inspect "\$WEBROOT_VOL" -f '{{.Mountpoint}}' 2>/dev/null || true)
+if [ -z "\$WEBROOT_PATH" ]; then
+    echo "⚠️  Docker volume \$WEBROOT_VOL not found — is the stack running? Skipping renewal config."
+    exit 0
 fi
 
-# Install weekly cron (Sunday 3am), replacing any old certbot entry
+# Install (or refresh) the post-renewal hook. Runs after every successful
+# 'certbot renew' to reload nginx (graceful) and signal coturn
+# (SIGUSR2 = re-read TLS certs) so both pick up the new cert without
+# dropping in-flight connections. coturn must be signaled explicitly —
+# it loads certs once at startup and won't notice file changes otherwise.
+mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+cat > /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh <<'HOOK_EOF'
+#!/bin/bash
+set -e
+docker exec serenada-nginx nginx -s reload || true
+docker kill -s USR2 serenada-coturn || true
+HOOK_EOF
+chmod +x /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh
+
+# Force renewal to use webroot for zero-downtime. Covers fresh deploys AND any
+# prior config using authenticator=standalone or authenticator=nginx — both of
+# which fail silently when the live nginx runs in Docker on ports 80/443.
+# Re-run certbot (instead of sed-editing the conf) so certbot writes a valid
+# renewal config itself. Reload hooks come from renewal-hooks/deploy/ above,
+# not --deploy-hook, so all renewals fire the same hook script.
+AUTH=\$(awk -F' = ' '/^authenticator/{print \$2; exit}' "\$CERT_CONF")
+if [ "\$AUTH" != "webroot" ]; then
+    echo "🔧 Cert was using authenticator=\$AUTH; reconfiguring to webroot..."
+    DOMAINS=\$(certbot certificates --cert-name "${DOMAIN}" 2>/dev/null \\
+        | awk -F': ' '/Domains:/{print \$2; exit}')
+    [ -z "\$DOMAINS" ] && DOMAINS="${DOMAIN}"
+    DOMAIN_ARGS=""
+    for d in \$DOMAINS; do DOMAIN_ARGS="\$DOMAIN_ARGS -d \$d"; done
+    certbot certonly --non-interactive \\
+        --webroot -w "\$WEBROOT_PATH" \\
+        --cert-name "${DOMAIN}" \\
+        \$DOMAIN_ARGS \\
+        --keep-until-expiring
+    echo "✅ Cert renewal switched to webroot"
+fi
+
+# Drop any legacy renew_hook from the cert config (now handled by
+# renewal-hooks/deploy/) to avoid double-running on each renewal.
+sed -i '/^renew_hook = /d' "\$CERT_CONF"
+
+# Install weekly cron (Sun 3am), replacing any old certbot entry. The renewal
+# config stores webroot_path; reload hooks live in renewal-hooks/deploy/.
+# Plain 'certbot renew' is enough — no flags belong in the cron line.
 if command -v crontab >/dev/null 2>&1; then
-    CRON_CMD="0 3 * * 0 certbot renew --quiet \$RENEW_FLAGS --deploy-hook 'docker exec serenada-nginx nginx -s reload'"
+    CRON_CMD="0 3 * * 0 certbot renew --quiet"
     ( crontab -l 2>/dev/null | grep -v 'certbot renew'; echo "\$CRON_CMD" ) | crontab -
     echo "✅ SSL auto-renewal cron job is configured (weekly, zero-downtime)"
 else


### PR DESCRIPTION
## Summary

Production cert for `serenada-app.ru` expired silently on Apr 28, 2026. Root cause was twofold — the renewal authenticator was set to `nginx` (which the previous fix in [dd32236](https://github.com/agatx/serenada/commit/dd32236) only converted from `standalone`, not `nginx`), and the deploy-hook didn't signal coturn so even successful renewals would have left TURNS:5349 stale.

## Changes

- **deploy.sh** — convert *any* non-webroot authenticator to webroot (not just `standalone`). Re-run `certbot certonly --webroot --force-renewal` so certbot writes its own renewal config; drop the brittle sed-editing approach (which was also writing a malformed `[webroot]` section instead of `[[webroot_map]]`). `--force-renewal` (not `--keep-until-expiring`) guarantees the lineage config is rewritten even when the cert isn't due — this block only runs once per VPS, so the extra issuance is a one-time migration cost.
- **deploy.sh** — install `/etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh`. Reloads nginx (`-s reload`) AND signals coturn (`SIGUSR2` → re-read TLS files without dropping sessions). Idempotent; rewritten every deploy.
- **deploy.sh** — strip any legacy `renew_hook` from the cert config so we don't double-run with the dir-based hook.
- **deploy.sh** — install/refresh a weekly cron entry (Sun 3am) that runs `certbot renew --quiet`. Explicit cron (rather than relying on the system `certbot.timer`) keeps the schedule visible to operators alongside the rest of the deploy. `certbot renew` is idempotent so coexistence with the system timer is harmless.
- **deploy.sh** — apply the same `id -u` / `$SUDO` root-detection pattern (used by the sysctl block) to the renewal block, so it works under non-root SSH users.
- **DEPLOY.md** — call out that running `./deploy.sh` after the standalone cert bootstrap is mandatory (it switches the cert to webroot mode and installs the post-renewal hook that reloads nginx + signals coturn).

## Verification (production, already applied)

- `certbot certonly --webroot` issued a fresh cert for `serenada-app.ru` + `www.serenada-app.ru`, valid until **2026-07-30**.
- Renewal config rewritten: `authenticator = webroot`, `webroot_path = /var/lib/docker/volumes/serenada_certbot-webroot/_data`, both domains in `[[webroot_map]]`.
- HTTPS handshake (`https://serenada-app.ru`) returns 200 with the new cert.
- TURNS handshake on `serenada-app.ru:5349` returns the new cert (coturn picked it up via `SIGUSR2` — zero dropped sessions).
- `certbot renew --dry-run` simulates renewal end-to-end successfully.

## Why this happened twice

[dd32236](https://github.com/agatx/serenada/commit/dd32236) (Jan 2026) added auto-renewal logic that only handled `authenticator = standalone`. The live cert was bootstrapped with `certbot --nginx`, so the conversion branch was never entered, and the system `certbot.timer` had been failing every 12h with `bind() to 0.0.0.0:80 failed (98: Address already in use)` — which goes to journal logs that nobody was watching. The new logic detects any non-webroot authenticator and converts it.

## Test plan

- [x] Live `certbot renew --dry-run` succeeds against the new config
- [x] HTTPS test pass: `curl -sI https://serenada-app.ru` returns 200
- [x] TURNS test pass: `openssl s_client -connect serenada-app.ru:5349` shows new cert dates
- [x] User re-ran the diagnostics page TURNS test and confirmed it now passes
- [ ] Next renewal (~30 days before 2026-07-30) succeeds via the weekly cron entry — visible in cron mail / `journalctl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)