### PR TITLE
v0.6.7: animate audio indicator while alone in the room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.7] — 2026-05-01
+
+Audio activity indicator now animates while the user is alone in the room
+(Android and iOS), not just after a peer joins. Sensitivity matches the
+in-call behavior because the same WebRTC `media-source.audioLevel` stat
+drives both phases.
+
+### Added
+- Android, iOS: `LocalAudioPipelinePrimer` — a self-loopback peer-connection
+  pair that holds the local audio track so WebRTC's audio capture, AEC/NS/AGC,
+  and `media-source` stat stay active continuously while the user is in a
+  room. The receiver PC's incoming audio is silenced (volume 0 + disabled)
+  so the loopback doesn't echo through the speaker.
+- `SessionMediaEngine.collectLocalAudioLevel(onComplete)` (Android + iOS) —
+  async fetch of the primer's `media-source.audioLevel` stat for the
+  audio-level poller.
+
+### Changed
+- Android, iOS: `AudioLevelPoller` now sources the local mic level from the
+  primer's `media-source` stat (via `collectLocalLevel`) and only consumes
+  inbound levels from peer slots. This unifies the local-level path across
+  Waiting and InCall — the indicator no longer freezes while alone, and
+  resumes immediately after a peer leaves and we're back to alone.
+- Android, iOS: `AudioLevelPoller`'s `isActivePhase` widened from `InCall`
+  only to `InCall || Waiting` so the poller runs during both phases.
+
+### Fixed
+- iOS: audio activity indicator stayed frozen at zero after a peer left the
+  call and the user returned to the Waiting phase.
+
 ## [0.6.6] — 2026-04-30
 
 Resilience hardening release. The SDK now degrades gracefully across long

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.6"
+                version = "0.6.7"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.6"
+val sdkVersion = "0.6.7"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -326,8 +326,12 @@ class SerenadaSession internal constructor(
     private val audioLevelPoller = AudioLevelPoller(
         handler = handler,
         statsExecutorProvider = { webRtcStatsExecutor },
-        isActivePhase = { _state.value.phase == CallPhase.InCall },
+        // Run while local media is live, including the Waiting phase before
+        // a peer joins. The primer peer connection keeps `media-source` stat
+        // available throughout, so sensitivity matches InCall.
+        isActivePhase = { _state.value.phase == CallPhase.Waiting || _state.value.phase == CallPhase.InCall },
         getPeerSlots = { peerSlots.values.toList() },
+        collectLocalLevel = { onComplete -> webRtcEngine.collectLocalAudioLevel(onComplete) },
         onLevelsUpdated = { localLevel, remoteLevels -> applyAudioLevels(localLevel, remoteLevels) },
     )
     private val pendingMessages = java.util.ArrayDeque<SignalingMessage>()

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelMonitor.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelMonitor.kt
@@ -22,7 +22,11 @@ internal class AudioLevelMonitor {
 
     /** Submit a raw 0..1 level and return the smoothed value. */
     fun update(rawLevel: Float): Float {
-        val raw = rawLevel.coerceIn(0f, 1f)
+        // `coerceIn` uses `<` comparisons that propagate NaN unchanged, so a
+        // non-finite input would slip through the clamp and pin the indicator
+        // to a garbage value. Treat anything non-finite as silence.
+        val sanitized = if (rawLevel.isFinite()) rawLevel else 0f
+        val raw = sanitized.coerceIn(0f, 1f)
         val dbfs = if (raw > 0f) (20.0 * ln(raw.toDouble()) / LN_10).toFloat() else NOISE_FLOOR_DB
         val target = ((dbfs - NOISE_FLOOR_DB) / (SPEECH_PEAK_DB - NOISE_FLOOR_DB))
             .coerceIn(0f, 1f)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelPoller.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/AudioLevelPoller.kt
@@ -4,20 +4,24 @@ import android.os.Handler
 import java.util.concurrent.ExecutorService
 
 /**
- * Polls WebRTC stats every [AudioLevelMonitor.UPDATE_INTERVAL_MS] for each
- * peer connection's inbound audio level and the local media-source level,
- * pushes them through per-cid [AudioLevelMonitor]s for dBFS+EMA smoothing,
+ * Polls WebRTC stats every [AudioLevelMonitor.UPDATE_INTERVAL_MS] for the
+ * local media-source level (via [collectLocalAudioLevel]) and each remote
+ * peer's inbound level (via the slot's `collectAudioLevels`), pushes the
+ * raw values through per-cid [AudioLevelMonitor]s for dBFS+EMA smoothing,
  * and reports the results on the main handler.
  *
- * Mirrors the web SDK's `AudioLevelMonitor`, but uses WebRTC stats instead
- * of Web Audio API. The smoothed output range is identical (0..1) so the
- * indicator visual is consistent across platforms.
+ * The local level is sourced from a primer peer connection that stays alive
+ * the entire time the user is in a room, so `media-source.audioLevel`
+ * reads consistently — including the Waiting phase before any real peer
+ * joins. Mirrors the web SDK's `AudioLevelMonitor` smoothing pipeline so
+ * the indicator visual is consistent across platforms.
  */
 internal class AudioLevelPoller(
     private val handler: Handler,
     private val statsExecutorProvider: () -> ExecutorService?,
     private val isActivePhase: () -> Boolean,
     private val getPeerSlots: () -> List<PeerConnectionSlotProtocol>,
+    private val collectLocalLevel: ((Float?) -> Unit) -> Unit,
     private val onLevelsUpdated: (localLevel: Float, remoteLevels: Map<String, Float>) -> Unit,
 ) {
     private val localMonitor = AudioLevelMonitor()
@@ -50,9 +54,9 @@ internal class AudioLevelPoller(
         if (requestInFlight) return
         val slots = getPeerSlots()
         val executor = statsExecutorProvider()?.takeIf { !it.isShutdown }
-        if (slots.isEmpty() || executor == null) {
-            // No peers (or executor torn down): emit a fully decayed sample so the
-            // indicator drops to silence rather than freezing on the last value.
+        if (executor == null) {
+            // Executor torn down mid-session: emit a fully decayed sample so
+            // the indicator drops to silence rather than freezing.
             val local = localMonitor.update(0f)
             val remote = remoteMonitors.mapValues { (_, m) -> m.update(0f) }
             onLevelsUpdated(local, remote)
@@ -67,23 +71,31 @@ internal class AudioLevelPoller(
     }
 
     private fun collectAndReport(slots: List<PeerConnectionSlotProtocol>) {
-        val rawLevels = mutableMapOf<String, Float?>()
+        val rawRemote = mutableMapOf<String, Float?>()
         var rawLocal: Float? = null
-        var remaining = slots.size
-        slots.forEach { slot ->
-            slot.collectAudioLevels { inbound, mediaSource ->
-                synchronized(rawLevels) {
-                    rawLevels[slot.remoteCid] = inbound
-                    // media-source is the same local mic across all peers; take the
-                    // first non-null value seen this round.
-                    if (rawLocal == null && mediaSource != null) rawLocal = mediaSource
-                    remaining -= 1
-                    if (remaining == 0) {
-                        val capturedLocal = rawLocal
-                        val capturedRemote = rawLevels.toMap()
-                        handler.post { applyAndEmit(capturedLocal, capturedRemote) }
-                    }
+        var remaining = slots.size + 1  // +1 for the primer query
+        val sync = Any()
+
+        val finishOne = {
+            synchronized(sync) {
+                remaining -= 1
+                if (remaining == 0) {
+                    val capturedLocal = rawLocal
+                    val capturedRemote = rawRemote.toMap()
+                    handler.post { applyAndEmit(capturedLocal, capturedRemote) }
                 }
+            }
+        }
+
+        collectLocalLevel { level ->
+            synchronized(sync) { rawLocal = level }
+            finishOne()
+        }
+
+        slots.forEach { slot ->
+            slot.collectAudioLevels { inbound, _ ->
+                synchronized(sync) { rawRemote[slot.remoteCid] = inbound }
+                finishOne()
             }
         }
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/LocalAudioPipelinePrimer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/LocalAudioPipelinePrimer.kt
@@ -122,7 +122,12 @@ internal class LocalAudioPipelinePrimer(
             for (stat in report.statsMap.values) {
                 if (stat.type != "media-source") continue
                 if (getMediaKind(stat) != "audio") continue
-                memberDouble(stat, "audioLevel")?.let { level = it.toFloat().coerceIn(0f, 1f) }
+                memberDouble(stat, "audioLevel")?.let { raw ->
+                    // Drop non-finite values rather than letting them poison
+                    // downstream smoothing — `coerceIn` propagates NaN.
+                    val f = raw.toFloat()
+                    if (f.isFinite()) level = f.coerceIn(0f, 1f)
+                }
             }
             onComplete(level)
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/LocalAudioPipelinePrimer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/LocalAudioPipelinePrimer.kt
@@ -1,0 +1,176 @@
+package app.serenada.core.call
+
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
+import org.webrtc.AudioTrack
+import org.webrtc.DataChannel
+import org.webrtc.IceCandidate
+import org.webrtc.MediaConstraints
+import org.webrtc.MediaStream
+import org.webrtc.MediaStreamTrack
+import org.webrtc.PeerConnection
+import org.webrtc.PeerConnectionFactory
+import org.webrtc.RtpReceiver
+import org.webrtc.SdpObserver
+import org.webrtc.SessionDescription
+
+/**
+ * Holds a self-loopback pair of [PeerConnection]s with the local audio
+ * track attached so WebRTC's full audio pipeline (capture → AEC/NS/AGC →
+ * encode → media-source stat) stays active continuously while the user is
+ * in a room — including the Waiting phase before any peer joins. The
+ * audio-level poller can then read the same `media-source.audioLevel`
+ * stat regardless of whether real peers exist, giving consistent indicator
+ * sensitivity throughout the session.
+ *
+ * Two PCs are required because `AudioSendStream` only starts pulling
+ * samples once both descriptions are set and the transport is established
+ * — without an answer the source-level stat reads zero (verified
+ * experimentally). The pair negotiates over loopback host candidates with
+ * default DTLS, so no real network traffic is generated.
+ */
+internal class LocalAudioPipelinePrimer(
+    private val factory: PeerConnectionFactory,
+    private val logger: SerenadaLogger? = null,
+) {
+    /** Sender side — holds the local audio track; queried for `media-source` stat. */
+    private var sender: PeerConnection? = null
+
+    /** Receiver side — completes the loopback so the sender's transport activates. */
+    private var receiver: PeerConnection? = null
+
+    fun start(localAudioTrack: AudioTrack) {
+        if (sender != null) return
+        val config = PeerConnection.RTCConfiguration(emptyList())
+        // Default ICE policy gathers host (loopback) candidates only since we
+        // pass no STUN/TURN servers — enough for the pair to connect locally.
+
+        val senderObserver = forwardingObserver { candidate -> receiver?.addIceCandidate(candidate) }
+        val receiverObserver = forwardingObserver { candidate -> sender?.addIceCandidate(candidate) }
+
+        val s = factory.createPeerConnection(config, senderObserver) ?: run {
+            logger?.log(SerenadaLogLevel.WARNING, TAG, "createPeerConnection (sender) returned null; indicator will be silent while alone")
+            return
+        }
+        val r = factory.createPeerConnection(config, receiverObserver) ?: run {
+            logger?.log(SerenadaLogLevel.WARNING, TAG, "createPeerConnection (receiver) returned null; indicator will be silent while alone")
+            s.close()
+            return
+        }
+        sender = s
+        receiver = r
+
+        s.addTrack(localAudioTrack, listOf(STREAM_ID))
+        s.createOffer(object : SdpObserver {
+            override fun onCreateSuccess(offer: SessionDescription) {
+                s.setLocalDescription(FailureCleanupSdpObserver("setLocal[sender]"), offer)
+                r.setRemoteDescription(object : SdpObserver {
+                    override fun onSetSuccess() {
+                        r.createAnswer(object : SdpObserver {
+                            override fun onCreateSuccess(answer: SessionDescription) {
+                                r.setLocalDescription(FailureCleanupSdpObserver("setLocal[receiver]"), answer)
+                                s.setRemoteDescription(FailureCleanupSdpObserver("setRemote[sender]"), answer)
+                            }
+                            override fun onCreateFailure(error: String?) {
+                                cleanupAfterFailure("createAnswer", error)
+                            }
+                            override fun onSetSuccess() {}
+                            override fun onSetFailure(error: String?) {}
+                        }, MediaConstraints())
+                    }
+                    override fun onSetFailure(error: String?) {
+                        cleanupAfterFailure("setRemote[receiver]", error)
+                    }
+                    override fun onCreateSuccess(desc: SessionDescription?) {}
+                    override fun onCreateFailure(error: String?) {}
+                }, offer)
+            }
+            override fun onCreateFailure(error: String?) {
+                cleanupAfterFailure("createOffer", error)
+            }
+            override fun onSetSuccess() {}
+            override fun onSetFailure(error: String?) {}
+        }, MediaConstraints())
+    }
+
+    /**
+     * Releases both PCs after a negotiation failure so a subsequent
+     * `start()` can retry. Without this the `if (sender != null) return`
+     * guard wedges the primer in a half-initialized state.
+     */
+    private fun cleanupAfterFailure(op: String, error: String?) {
+        logger?.log(SerenadaLogLevel.WARNING, TAG, "$op failed: $error — closing primer")
+        stop()
+    }
+
+    fun stop() {
+        receiver?.close()
+        receiver = null
+        sender?.close()
+        sender = null
+    }
+
+    /**
+     * Queries the sender PC's `media-source.audioLevel` stat. Result is in
+     * [0, 1] or null if the stat isn't yet populated (e.g., the loopback
+     * is still negotiating — typically the first ~100 ms after start).
+     */
+    fun collectAudioLevel(onComplete: (Float?) -> Unit) {
+        val pc = sender ?: return onComplete(null)
+        pc.getStats { report ->
+            var level: Float? = null
+            for (stat in report.statsMap.values) {
+                if (stat.type != "media-source") continue
+                if (getMediaKind(stat) != "audio") continue
+                memberDouble(stat, "audioLevel")?.let { level = it.toFloat().coerceIn(0f, 1f) }
+            }
+            onComplete(level)
+        }
+    }
+
+    private fun forwardingObserver(onIceCandidate: (IceCandidate) -> Unit) = object : PeerConnection.Observer {
+        override fun onIceCandidate(candidate: IceCandidate?) {
+            candidate?.let(onIceCandidate)
+        }
+        // The receiver PC will be handed an incoming audio track from the
+        // sender — silence it so the loopback doesn't echo through the
+        // speaker. Without this the user hears their own voice on a ~50 ms
+        // delay.
+        override fun onAddTrack(receiver: RtpReceiver?, streams: Array<out MediaStream>?) {
+            silenceIfAudio(receiver?.track())
+        }
+        override fun onAddStream(stream: MediaStream?) {
+            stream?.audioTracks?.forEach { silenceIfAudio(it) }
+        }
+        override fun onSignalingChange(state: PeerConnection.SignalingState?) {}
+        override fun onIceConnectionChange(state: PeerConnection.IceConnectionState?) {}
+        override fun onIceConnectionReceivingChange(receiving: Boolean) {}
+        override fun onIceGatheringChange(state: PeerConnection.IceGatheringState?) {}
+        override fun onIceCandidatesRemoved(candidates: Array<out IceCandidate>?) {}
+        override fun onRemoveStream(stream: MediaStream?) {}
+        override fun onDataChannel(channel: DataChannel?) {}
+        override fun onRenegotiationNeeded() {}
+    }
+
+    private fun silenceIfAudio(track: MediaStreamTrack?) {
+        val audio = track as? AudioTrack ?: return
+        audio.setVolume(0.0)
+        audio.setEnabled(false)
+    }
+
+    private inner class FailureCleanupSdpObserver(private val opLabel: String) : SdpObserver {
+        override fun onCreateSuccess(desc: SessionDescription?) {}
+        override fun onSetSuccess() {}
+        override fun onCreateFailure(error: String?) {
+            cleanupAfterFailure("$opLabel createFailure", error)
+        }
+        override fun onSetFailure(error: String?) {
+            cleanupAfterFailure("$opLabel setFailure", error)
+        }
+    }
+
+    companion object {
+        private const val TAG = "AudioPrimer"
+        private const val STREAM_ID = "serenada-primer-stream"
+    }
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
@@ -37,4 +37,11 @@ internal interface SessionMediaEngine {
     fun adjustWorldCameraZoom(scaleFactor: Float): Boolean
     fun toggleFlashlight(): Boolean
     fun getEglContext(): EglBase.Context
+    /**
+     * Asynchronously fetches the local audio level from WebRTC's
+     * `media-source.audioLevel` stat. The implementation keeps a primer
+     * peer connection alive so this stat is available even before any real
+     * peer joins. Result is in [0, 1] or null if the stat isn't ready.
+     */
+    fun collectLocalAudioLevel(onComplete: (Float?) -> Unit)
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -54,6 +54,7 @@ internal class WebRtcEngine(
     private val appContext = context.applicationContext
     private val audioDeviceModule: AudioDeviceModule = createAudioDeviceModule(appContext)
     private val peerConnectionFactory: PeerConnectionFactory
+    private val audioPipelinePrimer: LocalAudioPipelinePrimer
     private val cameraManager = appContext.getSystemService(CameraManager::class.java)
     private var released = false
 
@@ -117,6 +118,7 @@ internal class WebRtcEngine(
             .setVideoEncoderFactory(encoderFactory)
             .setVideoDecoderFactory(decoderFactory)
             .createPeerConnectionFactory()
+        audioPipelinePrimer = LocalAudioPipelinePrimer(peerConnectionFactory, logger)
     }
 
     private fun enableVerboseWebRtcLoggingIfDebug() {
@@ -194,6 +196,10 @@ internal class WebRtcEngine(
 
     override fun getEglContext(): EglBase.Context = eglBase.eglBaseContext
 
+    override fun collectLocalAudioLevel(onComplete: (Float?) -> Unit) {
+        audioPipelinePrimer.collectAudioLevel(onComplete)
+    }
+
     override fun startLocalMedia() {
         if (released) return
         if (localAudioTrack != null || localVideoTrack != null) return
@@ -202,6 +208,7 @@ internal class WebRtcEngine(
         audioSource = peerConnectionFactory.createAudioSource(audioConstraints)
         localAudioTrack = peerConnectionFactory.createAudioTrack("ARDAMSa0", audioSource)
         applyAudioTrackHints()
+        localAudioTrack?.let { audioPipelinePrimer.start(it) }
 
         if (cameraController.availableCameraModes.isEmpty()) {
             peerSlots.forEach { slot ->
@@ -236,6 +243,9 @@ internal class WebRtcEngine(
             localSinks.forEach { sink -> track.removeSink(sink) }
             track.dispose()
         }
+        // Tear down the primer before disposing its audio track — closing the
+        // PC first releases the sender's reference to the track.
+        audioPipelinePrimer.stop()
         localAudioTrack?.dispose()
         videoSource?.dispose()
         videoSource = null

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelMonitorTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelMonitorTest.kt
@@ -42,6 +42,23 @@ class AudioLevelMonitorTest {
     }
 
     @Test
+    fun treatsNonFiniteInputAsSilence() {
+        // `coerceIn` propagates NaN/Infinity unchanged, which would pin the
+        // smoothed level to a garbage value. The monitor must sanitize.
+        val monitor = AudioLevelMonitor()
+        repeat(5) { monitor.update(1.0f) }
+        val rampedUp = monitor.level
+        assertTrue("expected level to ramp up before the NaN injection", rampedUp > 0f)
+        monitor.update(Float.NaN)
+        assertTrue("expected level to remain finite after NaN, got ${monitor.level}", monitor.level.isFinite())
+        assertTrue("expected level to stay in [0, 1] after NaN, got ${monitor.level}", monitor.level in 0f..1f)
+        monitor.update(Float.POSITIVE_INFINITY)
+        assertTrue("expected level finite after +Inf, got ${monitor.level}", monitor.level.isFinite())
+        monitor.update(Float.NEGATIVE_INFINITY)
+        assertTrue("expected level finite after -Inf, got ${monitor.level}", monitor.level.isFinite())
+    }
+
+    @Test
     fun releasesSlowerThanItAttacks() {
         val attack = AudioLevelMonitor()
         attack.update(1.0f)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelPollerFallbackTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/AudioLevelPollerFallbackTest.kt
@@ -1,0 +1,93 @@
+package app.serenada.core.call
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Verifies the poller drives `localMonitor` from `collectLocalLevel` (the
+ * primer PC's `media-source.audioLevel` stat) rather than from peer slots.
+ * This is what gives the indicator consistent sensitivity in Waiting and
+ * InCall — the level source is the same WebRTC pipeline either way.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AudioLevelPollerFallbackTest {
+
+    private lateinit var poller: AudioLevelPoller
+    private val handler = Handler(Looper.getMainLooper())
+    private val executor: ExecutorService = SameThreadExecutorService()
+
+    private var primerCalls = 0
+    private var nextPrimerLevel: Float? = null
+    private var lastLocalLevel: Float? = null
+
+    @Before
+    fun setUp() {
+        poller = AudioLevelPoller(
+            handler = handler,
+            statsExecutorProvider = { executor },
+            isActivePhase = { true },
+            getPeerSlots = { emptyList() },
+            collectLocalLevel = { onComplete ->
+                primerCalls += 1
+                onComplete(nextPrimerLevel)
+            },
+            onLevelsUpdated = { local, _ -> lastLocalLevel = local },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        poller.stop()
+        executor.shutdownNow()
+        ShadowLooper.idleMainLooper()
+    }
+
+    @Test
+    fun usesPrimerLevelWhenNoSlots() {
+        nextPrimerLevel = 0.5f  // mid-speech level
+        poller.start()
+        ShadowLooper.idleMainLooper()
+        assertTrue("expected the primer to be queried", primerCalls > 0)
+        val level = lastLocalLevel ?: error("onLevelsUpdated never fired")
+        assertTrue("expected a non-zero local level fed by the primer, got $level", level > 0f)
+    }
+
+    @Test
+    fun nullPrimerLevelDecaysToSilence() {
+        nextPrimerLevel = null
+        poller.start()
+        repeat(10) {
+            ShadowLooper.runMainLooperToNextTask()
+        }
+        val level = lastLocalLevel ?: error("onLevelsUpdated never fired")
+        assertEquals(0f, level, 0.001f)
+    }
+
+    /**
+     * Runs submitted tasks inline on the calling thread so the test can
+     * proceed deterministically without race conditions between the main
+     * looper and a background stats executor.
+     */
+    private class SameThreadExecutorService : AbstractExecutorService() {
+        @Volatile private var shutdown = false
+        override fun execute(command: Runnable) { command.run() }
+        override fun shutdown() { shutdown = true }
+        override fun shutdownNow(): MutableList<Runnable> { shutdown = true; return mutableListOf() }
+        override fun isShutdown(): Boolean = shutdown
+        override fun isTerminated(): Boolean = shutdown
+        override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean = true
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -79,4 +79,9 @@ internal class FakeMediaEngine : SessionMediaEngine {
     override fun toggleFlashlight(): Boolean = false
     override fun getEglContext(): EglBase.Context =
         throw UnsupportedOperationException("EGL context not available in tests")
+
+    var nextLocalAudioLevel: Float? = null
+    override fun collectLocalAudioLevel(onComplete: (Float?) -> Unit) {
+        onComplete(nextLocalAudioLevel)
+    }
 }

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.6"
+val sdkVersion = "0.6.7"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
+++ b/client-ios/SerenadaCore/Sources/Call/AudioLevelPoller.swift
@@ -1,19 +1,23 @@
 import Combine
 import Foundation
 
-/// Polls each peer's WebRTC stats every `AudioLevelMonitor.updateIntervalSeconds`
-/// for inbound audio level (remote) and media-source level (local mic),
-/// runs them through per-cid `AudioLevelMonitor`s for dBFS+EMA smoothing,
-/// and reports the smoothed values on the main actor.
+/// Polls the primer peer connection for local `media-source.audioLevel`
+/// (via `collectLocalLevel`) and each peer slot for inbound (remote) level
+/// every `AudioLevelMonitor.updateIntervalSeconds`, runs the raw values
+/// through per-cid `AudioLevelMonitor`s for dBFS+EMA smoothing, and reports
+/// the smoothed values on the main actor.
 ///
-/// Mirrors the Android `AudioLevelPoller.kt` and the web SDK's audio level
-/// machinery — output range is identical so the indicator visual is
-/// consistent across platforms.
+/// The primer keeps WebRTC's audio pipeline live throughout a session, so
+/// the local level is consistent across Waiting and InCall — and works on
+/// the very first tick after a peer leaves and we're back to alone in the
+/// room. Mirrors the web SDK's `AudioLevelMonitor` smoothing pipeline so
+/// the indicator visual is consistent across platforms.
 @MainActor
 final class AudioLevelPoller {
     private let clock: SessionClock
     private let isActivePhase: () -> Bool
     private let getPeerSlots: () -> [any PeerConnectionSlotProtocol]
+    private let collectLocalLevel: (@escaping @Sendable (Float?) -> Void) -> Void
     private let onLevelsUpdated: (_ localLevel: Float, _ remoteLevels: [String: Float]) -> Void
 
     private var pollTimerCancellable: AnyCancellable?
@@ -28,11 +32,13 @@ final class AudioLevelPoller {
         clock: SessionClock,
         isActivePhase: @escaping () -> Bool,
         getPeerSlots: @escaping () -> [any PeerConnectionSlotProtocol],
+        collectLocalLevel: @escaping (@escaping @Sendable (Float?) -> Void) -> Void,
         onLevelsUpdated: @escaping (_ localLevel: Float, _ remoteLevels: [String: Float]) -> Void
     ) {
         self.clock = clock
         self.isActivePhase = isActivePhase
         self.getPeerSlots = getPeerSlots
+        self.collectLocalLevel = collectLocalLevel
         self.onLevelsUpdated = onLevelsUpdated
     }
 
@@ -60,14 +66,6 @@ final class AudioLevelPoller {
         guard pollTimerCancellable != nil, isActivePhase() else { return }
         if requestInFlight { return }
         let slots = getPeerSlots()
-        guard !slots.isEmpty else {
-            // No peers: emit a fully decayed sample so the indicator drops to
-            // silence rather than freezing on the last value.
-            let local = localMonitor.update(rawLevel: 0)
-            let remote = remoteMonitors.mapValues { $0.update(rawLevel: 0) }
-            onLevelsUpdated(local, remote)
-            return
-        }
 
         requestInFlight = true
         let tickGeneration = generation
@@ -76,13 +74,20 @@ final class AudioLevelPoller {
         var rawRemote: [String: Float?] = [:]
         var rawLocal: Float?
 
+        group.enter()
+        collectLocalLevel { level in
+            lock.lock()
+            rawLocal = level
+            lock.unlock()
+            group.leave()
+        }
+
         for slot in slots {
             let cid = slot.remoteCid
             group.enter()
-            slot.collectAudioLevels { inbound, mediaSource in
+            slot.collectAudioLevels { inbound, _ in
                 lock.lock()
                 rawRemote[cid] = inbound
-                if rawLocal == nil, let mediaSource { rawLocal = mediaSource }
                 lock.unlock()
                 group.leave()
             }

--- a/client-ios/SerenadaCore/Sources/Call/LocalAudioPipelinePrimer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/LocalAudioPipelinePrimer.swift
@@ -1,0 +1,182 @@
+import Foundation
+#if canImport(WebRTC)
+@preconcurrency import WebRTC
+#endif
+
+/// Holds a self-loopback pair of `RTCPeerConnection`s with the local audio
+/// track attached so WebRTC's full audio pipeline (capture → AEC/NS/AGC →
+/// encode → media-source stat) stays active continuously while the user is
+/// in a room — including the Waiting phase before any peer joins. The
+/// audio-level poller can then read the same `media-source.audioLevel`
+/// stat regardless of whether real peers exist, giving consistent
+/// indicator sensitivity throughout the session.
+///
+/// Two PCs are required because `AudioSendStream` only starts pulling
+/// samples once both descriptions are set and the transport is established
+/// — without an answer the source-level stat reads zero (verified
+/// experimentally on Android). The pair negotiates over loopback host
+/// candidates with default DTLS, so no real network traffic is generated.
+@MainActor
+final class LocalAudioPipelinePrimer {
+    private let logger: SerenadaLogger?
+
+#if canImport(WebRTC)
+    private let factory: RTCPeerConnectionFactory
+    private var senderPc: RTCPeerConnection?
+    private var receiverPc: RTCPeerConnection?
+    private var senderObserver: PrimerPeerConnectionObserver?
+    private var receiverObserver: PrimerPeerConnectionObserver?
+
+    init(factory: RTCPeerConnectionFactory, logger: SerenadaLogger?) {
+        self.factory = factory
+        self.logger = logger
+    }
+
+    func start(localAudioTrack: RTCAudioTrack) {
+        guard senderPc == nil else { return }
+        let config = RTCConfiguration()
+        config.sdpSemantics = .unifiedPlan
+        // Default ICE policy + no servers → host candidates only, enough to
+        // connect the pair locally without touching the network.
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+
+        let senderObs = PrimerPeerConnectionObserver()
+        let receiverObs = PrimerPeerConnectionObserver()
+        guard let sPc = factory.peerConnection(with: config, constraints: constraints, delegate: senderObs) else {
+            logger?.log(.warning, tag: "AudioPrimer", "factory.peerConnection (sender) returned nil; indicator will be silent while alone")
+            return
+        }
+        guard let rPc = factory.peerConnection(with: config, constraints: constraints, delegate: receiverObs) else {
+            logger?.log(.warning, tag: "AudioPrimer", "factory.peerConnection (receiver) returned nil; indicator will be silent while alone")
+            sPc.close()
+            return
+        }
+        // Wire ICE candidate forwarding now that both PCs exist.
+        senderObs.onIceCandidate = { candidate in
+            Task { @MainActor in
+                rPc.add(candidate, completionHandler: { _ in })
+            }
+        }
+        receiverObs.onIceCandidate = { candidate in
+            Task { @MainActor in
+                sPc.add(candidate, completionHandler: { _ in })
+            }
+        }
+        senderPc = sPc
+        receiverPc = rPc
+        senderObserver = senderObs
+        receiverObserver = receiverObs
+
+        _ = sPc.add(localAudioTrack, streamIds: ["serenada-primer-stream"])
+
+        let mediaConstraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        sPc.offer(for: mediaConstraints) { [weak self] offer, error in
+            guard let offer, error == nil else {
+                self?.cleanupAfterFailure("createOffer", error?.localizedDescription)
+                return
+            }
+            sPc.setLocalDescription(offer) { [weak self] err in
+                if let err { self?.cleanupAfterFailure("setLocal[sender]", err.localizedDescription) }
+            }
+            rPc.setRemoteDescription(offer) { [weak self] err in
+                if let err {
+                    self?.cleanupAfterFailure("setRemote[receiver]", err.localizedDescription)
+                    return
+                }
+                rPc.answer(for: mediaConstraints) { [weak self] answer, error in
+                    guard let answer, error == nil else {
+                        self?.cleanupAfterFailure("createAnswer", error?.localizedDescription)
+                        return
+                    }
+                    rPc.setLocalDescription(answer) { [weak self] err in
+                        if let err { self?.cleanupAfterFailure("setLocal[receiver]", err.localizedDescription) }
+                    }
+                    sPc.setRemoteDescription(answer) { [weak self] err in
+                        if let err { self?.cleanupAfterFailure("setRemote[sender]", err.localizedDescription) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Releases both PCs after a negotiation failure so a subsequent
+    /// `start()` can retry. Without this the `senderPc != nil` guard
+    /// wedges the primer in a half-initialized state. WebRTC's SDP
+    /// callbacks fire on a non-main thread, so hop back to MainActor.
+    nonisolated private func cleanupAfterFailure(_ op: String, _ message: String?) {
+        Task { @MainActor [weak self] in
+            self?.logger?.log(.warning, tag: "AudioPrimer", "\(op) failed: \(message ?? "nil") — closing primer")
+            self?.stop()
+        }
+    }
+
+    func stop() {
+        receiverPc?.close()
+        receiverPc = nil
+        senderPc?.close()
+        senderPc = nil
+        senderObserver = nil
+        receiverObserver = nil
+    }
+
+    /// Queries the sender PC's `media-source.audioLevel` stat. Result is
+    /// in [0, 1] or `nil` if the stat isn't yet populated (e.g., the
+    /// loopback is still negotiating — typically the first ~100 ms after
+    /// start).
+    func collectAudioLevel(_ onComplete: @escaping @Sendable (Float?) -> Void) {
+        guard let senderPc else {
+            onComplete(nil)
+            return
+        }
+        senderPc.statistics { report in
+            var level: Float?
+            for stat in report.statistics.values {
+                guard stat.type == "media-source", mediaKind(for: stat) == "audio" else { continue }
+                if let raw = memberDouble(stat, key: "audioLevel") {
+                    level = max(0, min(1, Float(raw)))
+                }
+            }
+            onComplete(level)
+        }
+    }
+#else
+    init(factory: Any?, logger: SerenadaLogger?) {
+        self.logger = logger
+    }
+    func collectAudioLevel(_ onComplete: @escaping @Sendable (Float?) -> Void) {
+        onComplete(nil)
+    }
+    func stop() {}
+#endif
+}
+
+#if canImport(WebRTC)
+private final class PrimerPeerConnectionObserver: NSObject, RTCPeerConnectionDelegate {
+    var onIceCandidate: ((RTCIceCandidate) -> Void)?
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {}
+    // The receiver PC will be handed an incoming audio track from the sender —
+    // silence it so the loopback doesn't echo through the speaker. Without
+    // this the user hears their own voice on a ~50 ms delay.
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
+        for track in stream.audioTracks { silenceAudio(track) }
+    }
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd rtpReceiver: RTCRtpReceiver, streams mediaStreams: [RTCMediaStream]) {
+        if let audio = rtpReceiver.track as? RTCAudioTrack { silenceAudio(audio) }
+    }
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {}
+    func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {}
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {}
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {}
+    func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
+        onIceCandidate?(candidate)
+    }
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {}
+    func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {}
+
+    private func silenceAudio(_ track: RTCAudioTrack) {
+        track.source.volume = 0
+        track.isEnabled = false
+    }
+}
+#endif

--- a/client-ios/SerenadaCore/Sources/Call/LocalAudioPipelinePrimer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/LocalAudioPipelinePrimer.swift
@@ -133,7 +133,10 @@ final class LocalAudioPipelinePrimer {
             for stat in report.statistics.values {
                 guard stat.type == "media-source", mediaKind(for: stat) == "audio" else { continue }
                 if let raw = memberDouble(stat, key: "audioLevel") {
-                    level = max(0, min(1, Float(raw)))
+                    // Drop non-finite values rather than letting them poison
+                    // downstream smoothing — `min`/`max` propagate NaN.
+                    let f = Float(raw)
+                    if f.isFinite { level = max(0, min(1, f)) }
                 }
             }
             onComplete(level)

--- a/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
@@ -34,4 +34,9 @@ protocol SessionMediaEngine: AnyObject {
     func setOnScreenShareStopped(_ handler: @escaping () -> Void)
     func setOnZoomFactorChanged(_ handler: @escaping (Double) -> Void)
     func setOnFeatureDegradation(_ handler: @escaping (FeatureDegradationState) -> Void)
+    /// Asynchronously fetches the local audio level from WebRTC's
+    /// `media-source.audioLevel` stat. The implementation keeps a primer
+    /// peer connection alive so this stat is available even before any real
+    /// peer joins. Result is in [0, 1] or `nil` if the stat isn't ready.
+    func collectLocalAudioLevel(_ onComplete: @escaping @Sendable (Float?) -> Void)
 }

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -125,6 +125,8 @@ internal final class WebRtcEngine: SessionMediaEngine {
     private var localRenderers: [WeakAnyBox] = []
 #endif
 
+    private var audioPipelinePrimer: LocalAudioPipelinePrimer?
+
     public init(
         onCameraFacingChanged: @escaping (Bool) -> Void,
         onCameraModeChanged: @escaping (LocalCameraMode) -> Void,
@@ -167,7 +169,9 @@ internal final class WebRtcEngine: SessionMediaEngine {
         Self.initializeSslIfNeeded()
         let encoderFactory = RTCDefaultVideoEncoderFactory()
         let decoderFactory = RTCDefaultVideoDecoderFactory()
-        self.peerConnectionFactory = RTCPeerConnectionFactory(encoderFactory: encoderFactory, decoderFactory: decoderFactory)
+        let factory = RTCPeerConnectionFactory(encoderFactory: encoderFactory, decoderFactory: decoderFactory)
+        self.peerConnectionFactory = factory
+        self.audioPipelinePrimer = LocalAudioPipelinePrimer(factory: factory, logger: logger)
 #endif
 
 #if canImport(WebRTC)
@@ -248,6 +252,9 @@ internal final class WebRtcEngine: SessionMediaEngine {
         }
 
         attachTrackToRegisteredRenderers()
+        if let localAudioTrack {
+            audioPipelinePrimer?.start(localAudioTrack: localAudioTrack)
+        }
         peerSlots.forEach { $0.attachLocalTracks(audioTrack: localAudioTrack, videoTrack: localVideoTrack) }
 #else
         cameraController.notifyCameraModeAndFlash()
@@ -264,6 +271,9 @@ internal final class WebRtcEngine: SessionMediaEngine {
 
         screenShareController.stopAllCapturers()
 
+        // Tear down the primer before releasing its audio track reference.
+        audioPipelinePrimer?.stop()
+
         localVideoTrack = nil
         localVideoSource = nil
         cameraController.updateLocalVideoSource(nil)
@@ -276,6 +286,14 @@ internal final class WebRtcEngine: SessionMediaEngine {
         stopLocalMedia()
         peerSlots.forEach { $0.closePeerConnection() }
         peerSlots.removeAll()
+    }
+
+    public func collectLocalAudioLevel(_ onComplete: @escaping @Sendable (Float?) -> Void) {
+        guard let audioPipelinePrimer else {
+            onComplete(nil)
+            return
+        }
+        audioPipelinePrimer.collectAudioLevel(onComplete)
     }
 
     public func setIceServers(_ servers: [IceServerConfig]) {

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.6"
+    public static let version = "0.6.7"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -1436,10 +1436,24 @@ public final class SerenadaSession: ObservableObject {
 
         audioLevelPoller = AudioLevelPoller(
             clock: clock,
-            isActivePhase: { [weak self] in self?.internalPhase == .inCall },
+            // Run while local media is live, including the Waiting phase
+            // before a peer joins. The primer peer connection keeps
+            // `media-source` stat available throughout, so sensitivity
+            // matches InCall.
+            isActivePhase: { [weak self] in
+                guard let p = self?.internalPhase else { return false }
+                return p == .inCall || p == .waiting
+            },
             getPeerSlots: { [weak self] in
                 guard let self else { return [] }
                 return Array(self.peerSlots.values)
+            },
+            collectLocalLevel: { [weak self] onComplete in
+                guard let self else {
+                    onComplete(nil)
+                    return
+                }
+                self.webRtcEngine.collectLocalAudioLevel(onComplete)
             },
             onLevelsUpdated: { [weak self] localLevel, remoteLevels in
                 self?.applyAudioLevels(localLevel: localLevel, remoteLevels: remoteLevels)

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelPollerFallbackTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/AudioLevelPollerFallbackTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import SerenadaCore
+
+@MainActor
+final class AudioLevelPollerFallbackTests: XCTestCase {
+    private var clock: FakeSessionClock!
+
+    override func setUp() async throws {
+        clock = FakeSessionClock()
+    }
+
+    override func tearDown() async throws {
+        clock = nil
+    }
+
+    /// The poller drives `localMonitor` from `collectLocalLevel` (the primer
+    /// PC's `media-source.audioLevel` stat) so the indicator animates with
+    /// consistent sensitivity in Waiting and InCall.
+    func testUsesPrimerLevelWhenNoSlots() async {
+        var primerCalls = 0
+        var lastLocalLevel: Float?
+
+        let poller = AudioLevelPoller(
+            clock: clock,
+            isActivePhase: { true },
+            getPeerSlots: { [] },
+            collectLocalLevel: { onComplete in
+                primerCalls += 1
+                onComplete(0.5)  // mid-speech level
+            },
+            onLevelsUpdated: { local, _ in lastLocalLevel = local }
+        )
+
+        poller.start()
+        await clock.advance(byMs: Int64(AudioLevelMonitor.updateIntervalSeconds * 1_000) + 10)
+
+        XCTAssertGreaterThan(primerCalls, 0, "Expected the primer to be queried")
+        XCTAssertNotNil(lastLocalLevel)
+        XCTAssertGreaterThan(lastLocalLevel ?? 0, 0, "Expected a non-zero local level fed by the primer")
+    }
+
+    /// A nil primer level (stat not yet populated) decays the indicator to
+    /// silence rather than freezing it on the prior value.
+    func testNilPrimerLevelDecaysToSilence() async {
+        var lastLocalLevel: Float = 1.0
+
+        let poller = AudioLevelPoller(
+            clock: clock,
+            isActivePhase: { true },
+            getPeerSlots: { [] },
+            collectLocalLevel: { onComplete in onComplete(nil) },
+            onLevelsUpdated: { local, _ in lastLocalLevel = local }
+        )
+
+        poller.start()
+        for _ in 0..<10 {
+            await clock.advance(byMs: Int64(AudioLevelMonitor.updateIntervalSeconds * 1_000) + 1)
+        }
+
+        XCTAssertEqual(lastLocalLevel, 0, accuracy: 0.001, "Expected silent indicator when no PCM samples are available")
+    }
+}

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -104,4 +104,9 @@ final class FakeMediaEngine: SessionMediaEngine {
     func setOnFeatureDegradation(_ handler: @escaping (FeatureDegradationState) -> Void) {
         onFeatureDegradation = handler
     }
+
+    var nextLocalAudioLevel: Float?
+    func collectLocalAudioLevel(_ onComplete: @escaping @Sendable (Float?) -> Void) {
+        onComplete(nextLocalAudioLevel)
+    }
 }

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		6E92E404B6B3E0A636F21C56 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529A15EA2C43DB2F91F46FC /* RootView.swift */; };
 		6EE2ED9D63185C2AA8581CFE /* L10nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8656DA5A095E572174461E96 /* L10nTests.swift */; };
 		71320D322F59D2244B5A2027 /* RoomStatusesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D033C8F77DC9925D9668A /* RoomStatusesTests.swift */; };
+		7249AE4FA6B6BD9FA933F350 /* AudioLevelPollerFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E92820F7589FD19AFAEB65 /* AudioLevelPollerFallbackTests.swift */; };
 		7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D0BE7FF0C166694E0F58114A /* Assets.xcassets */; };
 		7C93696BE2DA979BC57CC03E /* DeepLinkRejoinFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BED6C2775E7E4CB2896F08 /* DeepLinkRejoinFlowUITests.swift */; };
 		80AC65E9FEE68E60586E6055 /* CaptureResolutionSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */; };
@@ -232,6 +233,7 @@
 		F4BB4F1EC53EF165C9E75A96 /* SerenadaiOSTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SerenadaiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRecoveryTests.swift; sourceTree = "<group>"; };
 		F5BC48440A4DD113050C3E29 /* DeepLinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkParserTests.swift; sourceTree = "<group>"; };
+		F5E92820F7589FD19AFAEB65 /* AudioLevelPollerFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelPollerFallbackTests.swift; sourceTree = "<group>"; };
 		F8B7715C6AFF6FAA67DB5D01 /* RoomStatuses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStatuses.swift; sourceTree = "<group>"; };
 		F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCallStoreTests.swift; sourceTree = "<group>"; };
 		FCB3288DA9DF528251D2A52D /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 			isa = PBXGroup;
 			children = (
 				6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */,
+				F5E92820F7589FD19AFAEB65 /* AudioLevelPollerFallbackTests.swift */,
 				9FC9E71EE9415390DBBFC4A7 /* BackoffTests.swift */,
 				9F052EA0D1D083D292B3CF0E /* CameraModeFlowTests.swift */,
 				D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */,
@@ -811,6 +814,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				64A7BCD5402B626283D5F7A7 /* AudioLevelMonitorTests.swift in Sources */,
+				7249AE4FA6B6BD9FA933F350 /* AudioLevelPollerFallbackTests.swift in Sources */,
 				932FE0F4C5B2A808073B537A /* BackoffTests.swift in Sources */,
 				85B89222838ED1AA3AF9F938 /* CallScreenStateTests.swift in Sources */,
 				9ADDE9F64E5B64AB5128AF50 /* CameraModeFlowTests.swift in Sources */,

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "workspaces": [
     "packages/core",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.6';
+export const SERENADA_CORE_VERSION = '0.6.7';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.6",
+    "@serenada/core": "^0.6.7",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"


### PR DESCRIPTION
## Summary

- Adds `LocalAudioPipelinePrimer` (Android + iOS): a self-loopback `PeerConnection` pair that holds the local audio track so WebRTC's audio capture, AEC/NS/AGC, and `media-source.audioLevel` stat stay active continuously while the user is in a room. Receiver's incoming audio is silenced (`volume=0` + `isEnabled=false`) so the loopback doesn't echo through the speaker.
- `AudioLevelPoller` now sources the local mic level from the primer's `media-source` stat (via the new `SessionMediaEngine.collectLocalAudioLevel`) instead of opportunistically scraping it from a peer slot. Peer slots only contribute remote inbound levels.
- Lifts the poller's active-phase gate from `InCall` only to `InCall || Waiting` so the indicator animates while alone — and resumes immediately after a peer leaves and we're back to alone (was a separate iOS-only freeze bug).
- Bumps SDK version to **0.6.7** across all 8 sources; resilience-constant parity verified (23/23).

## Why two PCs?

`AudioSendStream` only starts pulling samples once both descriptions are set and the transport is established — without an answer the source-level stat reads zero (verified empirically with diagnostic logging on Android). One peer connection alone with no remote SDP wedges in `HAVE_LOCAL_OFFER` and never activates the encoder. The pair negotiates over loopback host candidates with default DTLS, so no real network traffic is generated. Cost: a few percent of CPU during Waiting (Opus encoder + AEC/NS/AGC) — same WebRTC pays during a call.

## Why is audio different from video?

Video has a public `VideoTrack.addSink(VideoSink)` API and capture is driven by an independent `VideoCapturer`, so the local preview works without any peer connection. Audio capture is driven by `AudioDeviceModule` whose `startRecording()` is gated on `AudioSendStream` lifecycle, and `AudioTrack` exposes no public PCM-sample sink. The primer is the cleanest workaround that doesn't fork WebRTC.

## Test Coverage

```
CODE PATH COVERAGE
[+] LocalAudioPipelinePrimer (new)        [HARDWARE-TESTED] start/stop/collectAudioLevel/silence
[+] AudioLevelPoller fallback path
    └── Local level via primer
        ├── [★★★ TESTED] Non-null primer level applied
        └── [★★★ TESTED] Null primer decays to silence

USER FLOW COVERAGE
[+] Alone in Waiting              [HARDWARE-TESTED] Bars animate (Android + iPhone)
[+] Peer joined (InCall)          [HARDWARE-TESTED] Bars continue, no echo
[+] Peer leaves → Waiting         [HARDWARE-TESTED] Bars resume (was iOS bug)
```

Tests added: `AudioLevelPollerFallbackTest.kt`, `AudioLevelPollerFallbackTests.swift` (4 tests total, all pass).

## Pre-Landing Review

3 dropped comments in iOS `AudioLevelPoller.swift` (explaining the generation guard and the dictionary-iteration snapshot) auto-restored.

## Adversarial Review

Medium tier (~177 lines). Codex unavailable on this host (model-version mismatch), Claude adversarial subagent ran. Two real findings actioned:
- **FIXED**: Android primer leaked both PCs if any negotiation step (`createOffer`/`createAnswer`/`setLocal`/`setRemote`) failed after PC assignment — `cleanupAfterFailure` now closes both PCs so a subsequent `start()` can retry.
- **FIXED**: Same on iOS — `cleanupAfterFailure` hops to `MainActor` and calls `stop()`.

INVESTIGATE-class findings (battery, AEC reference muddling, stat-name in custom WebRTC build) all empirically verified on real hardware on both platforms — bars animate cleanly with no echo, no perceptible AEC degradation when a real peer joins.

## Test plan

- [x] Android `:serenada-core:testDebugUnitTest` — 240 tests pass
- [x] iOS `xcodebuild test` — full suite passes
- [x] Hardware: Android (A065 / API 16) — bars animate alone, no echo
- [x] Hardware: iPhone (release device) — bars animate alone, hand-back from InCall→Waiting works
- [x] `check-version-parity.mjs` — all 8 sources at 0.6.7
- [x] `check-resilience-constants.mjs` — 23 constants parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)