### PR TITLE
v0.6.8: fix Android 1:1 pinch-to-zoom regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.8] — 2026-05-02
+
+### Fixed
+- Android: pinch-to-zoom on the local camera in 1:1 calls (world / composite
+  modes) was being absorbed by the participant-name/mute badge overlay added
+  with the call-ergonomics work. The badge sat in a fullscreen sibling Box
+  on top of the local video, and its `clickable` modifier intercepted pinch
+  gestures before they reached the `Modifier.transformable` on the
+  local-large Box. The badge now renders as a child of the same Box that
+  holds the video, mirroring the multi-party tile pattern, so pinch
+  gestures reach the zoom controller. Multi-party was unaffected.
+
 ## [0.6.7] — 2026-05-01
 
 Audio activity indicator now animates while the user is alone in the room

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.7"
+                version = "0.6.8"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -455,18 +455,35 @@ internal fun CallScreen(
                         contentScale = ContentScale.Fit,
                         isMediaOverlay = false
                     )
+                    ParticipantBadge(
+                        modifier = Modifier.align(Alignment.BottomStart),
+                        muted = !uiState.localAudioEnabled,
+                        displayName = uiState.localDisplayName,
+                        audioLevel = uiState.localAudioLevel,
+                    )
                 }
             }
             if (uiState.remoteVideoEnabled) {
-                TextureVideoSurface(
-                    modifier = remoteModifier,
-                    rendererName = "remote-pip",
-                    eglContext = eglContext,
-                    onAttach = attachRemoteSink,
-                    onDetach = detachRemoteSink,
-                    mirror = false,
-                    contentScale = ContentScale.Crop
-                )
+                Box(modifier = remoteModifier) {
+                    TextureVideoSurface(
+                        modifier = Modifier.fillMaxSize(),
+                        rendererName = "remote-pip",
+                        eglContext = eglContext,
+                        onAttach = attachRemoteSink,
+                        onDetach = detachRemoteSink,
+                        mirror = false,
+                        contentScale = ContentScale.Crop
+                    )
+                    val remoteP = uiState.remoteParticipants.firstOrNull()
+                    if (remoteP != null) {
+                        ParticipantBadge(
+                            modifier = Modifier.align(Alignment.BottomStart),
+                            muted = !remoteP.audioEnabled,
+                            displayName = if (!remoteP.videoEnabled) null else remoteP.displayName,
+                            audioLevel = remoteP.audioLevel,
+                        )
+                    }
+                }
             }
         } else {
             val ratio = remoteAspectRatio ?: 0f
@@ -514,18 +531,35 @@ internal fun CallScreen(
                         contentScale = ContentScale.Crop,
                         isMediaOverlay = false
                     )
+                    val remoteP = uiState.remoteParticipants.firstOrNull()
+                    if (remoteP != null) {
+                        ParticipantBadge(
+                            modifier = Modifier.align(Alignment.BottomStart),
+                            muted = !remoteP.audioEnabled,
+                            displayName = if (!remoteP.videoEnabled) null else remoteP.displayName,
+                            audioLevel = remoteP.audioLevel,
+                        )
+                    }
                 }
             }
             if (uiState.localVideoEnabled) {
-                TextureVideoSurface(
-                    modifier = localModifier,
-                    rendererName = "local-pip",
-                    eglContext = eglContext,
-                    onAttach = attachLocalSink,
-                    onDetach = detachLocalSink,
-                    mirror = uiState.isFrontCamera && !uiState.isScreenSharing,
-                    contentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop
-                )
+                Box(modifier = localModifier) {
+                    TextureVideoSurface(
+                        modifier = Modifier.fillMaxSize(),
+                        rendererName = "local-pip",
+                        eglContext = eglContext,
+                        onAttach = attachLocalSink,
+                        onDetach = detachLocalSink,
+                        mirror = uiState.isFrontCamera && !uiState.isScreenSharing,
+                        contentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop
+                    )
+                    ParticipantBadge(
+                        modifier = Modifier.align(Alignment.BottomStart),
+                        muted = !uiState.localAudioEnabled,
+                        displayName = uiState.localDisplayName,
+                        audioLevel = uiState.localAudioLevel,
+                    )
+                }
             }
         }
 
@@ -536,6 +570,12 @@ internal fun CallScreen(
                         if (effectiveLocalLarge) resolveString(SerenadaString.CallLocalCameraOff, strings)
                         else resolveString(SerenadaString.CallCameraOff, strings),
                     fontSize = if (effectiveLocalLarge) 16.sp else 10.sp
+                )
+                ParticipantBadge(
+                    modifier = Modifier.align(Alignment.BottomStart),
+                    muted = !uiState.localAudioEnabled,
+                    displayName = uiState.localDisplayName,
+                    audioLevel = uiState.localAudioLevel,
                 )
             }
         }
@@ -558,27 +598,11 @@ internal fun CallScreen(
                     displayName = nameToShow,
                     peerId = remoteP?.peerId,
                 )
-            }
-        }
-
-        if (!isMultiParty) {
-            val remoteP = uiState.remoteParticipants.firstOrNull()
-            Box(modifier = localModifier) {
-                ParticipantBadge(
-                    modifier = Modifier.align(Alignment.BottomStart),
-                    muted = !uiState.localAudioEnabled,
-                    displayName = uiState.localDisplayName,
-                    audioLevel = uiState.localAudioLevel,
-                )
-            }
-            if (remoteP != null) {
-                Box(modifier = remoteModifier) {
-                    val remoteNameForBadge =
-                        if (!remoteP.videoEnabled) null else remoteP.displayName
+                if (remoteP != null) {
                     ParticipantBadge(
                         modifier = Modifier.align(Alignment.BottomStart),
                         muted = !remoteP.audioEnabled,
-                        displayName = remoteNameForBadge,
+                        displayName = if (!remoteP.videoEnabled) null else remoteP.displayName,
                         audioLevel = remoteP.audioLevel,
                     )
                 }

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.7"
+val sdkVersion = "0.6.8"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.7"
+val sdkVersion = "0.6.8"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.7"
+    public static let version = "0.6.8"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.6.7",
-        "@serenada/react-ui": "0.6.7",
+        "@serenada/core": "0.6.8",
+        "@serenada/react-ui": "0.6.8",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.7"
+        "@serenada/core": "0.6.8"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.7",
+        "@serenada/core": "^0.6.8",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.7",
+  "version": "0.6.8",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.6.7",
-    "@serenada/react-ui": "0.6.7",
+    "@serenada/core": "0.6.8",
+    "@serenada/react-ui": "0.6.8",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.7';
+export const SERENADA_CORE_VERSION = '0.6.8';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.7",
+    "@serenada/core": "^0.6.8",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.6.7"
+    "@serenada/core": "0.6.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Pinch-to-zoom on the local camera in 1:1 calls (world / composite modes) was being absorbed by the participant badge overlay added with the call-ergonomics work. Moves the local + remote badges to render as children of the same Box that holds the video / placeholder, mirroring the multi-party tile pattern. Multi-party was unaffected.
- Bumps SDK version to 0.6.8 across web, Android, and iOS.

## Root cause
[CallScreen.kt:564-586 (pre-fix)](https://github.com/agatx/serenada/blob/main/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt#L564) rendered a fullscreen sibling `Box(modifier = localModifier) { ParticipantBadge(...) }` on top of the local-large Box. When `effectiveLocalLarge` is true, `localModifier` resolves to `mainModifier` — `Modifier.fillMaxWidth().fillMaxHeight().padding(...).clickable { toggleControlsVisibility() }`. That fullscreen `clickable` overlay sat above the [`Modifier.transformable`](https://github.com/agatx/serenada/blob/main/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt#L440) on the local-large Box, so pinches were eaten by the overlay and never reached the zoom transformable. Regression introduced in [`d5ae015` "Improved call ergonomics (#68)"](https://github.com/agatx/serenada/commit/d5ae015) (2026-04-19).

## Fix
For each video / placeholder area in the 1:1 path, render the badge as a child of the existing Box (same pattern multi-party already uses):
- Local-large `Box(localLargeModifier)` — local badge inside
- Remote PIP TextureVideoSurface wrapped in `Box(remoteModifier)` — remote badge inside
- Remote-large `Box(remoteModifier.clipToBounds())` — remote badge inside
- Local PIP TextureVideoSurface wrapped in `Box(localModifier)` — local badge inside
- Local-off placeholder Box — local badge inside
- Remote-off placeholder Box — remote badge inside (gated on `remoteP != null`)

Removes the fullscreen `if (!isMultiParty) { ... }` overlay block.

## Test plan
- [x] `./gradlew :serenada-call-ui:assembleDebug` green
- [x] `./gradlew :serenada-core:testDebugUnitTest` green
- [x] `npm test` (web) — 334 passed
- [x] `node scripts/check-version-parity.mjs` — all 8 sources match at 0.6.8
- [x] Manual smoke on physical device: 1:1 call in WORLD mode, pinch-to-zoom on local video — confirmed working
- [x] Manual smoke: badges still appear at bottom-left of local + remote areas across local-large / remote-large × video on / off
- [x] Manual smoke: multi-party zoom + badges unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)