### PR TITLE
v0.6.9: iOS audio-only join + camera UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.9] — 2026-05-02
+
+### Added
+- iOS: `SerenadaConfig.allowAudioOnlyJoin` (default `true`) lets the SDK join
+  an audio-only call when the user has denied or not yet granted camera
+  permission. The session proceeds without a local video track and the local
+  preview falls back to the audio-only placeholder.
+
+### Changed
+- iOS: world / composite camera modes now render the local preview as the
+  primary surface (matching the existing 1:1 video layout) so the world view
+  is the user's main visual context, and pinch-to-zoom is reachable in both
+  the Waiting and InCall phases.
+
+### Fixed
+- iOS: avatar cache now invalidates correctly when a remote participant's
+  avatar URL changes mid-call, so stale images no longer linger after a peer
+  switches accounts in the same room.
+
 ## [0.6.8] — 2026-05-02
 
 ### Fixed

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.8"
+                version = "0.6.9"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.8"
+val sdkVersion = "0.6.9"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.8"
+val sdkVersion = "0.6.9"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.8"
+    public static let version = "0.6.9"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.6.8",
-        "@serenada/react-ui": "0.6.8",
+        "@serenada/core": "0.6.9",
+        "@serenada/react-ui": "0.6.9",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.8"
+        "@serenada/core": "0.6.9"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.8",
+        "@serenada/core": "^0.6.9",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.6.8",
-    "@serenada/react-ui": "0.6.8",
+    "@serenada/core": "0.6.9",
+    "@serenada/react-ui": "0.6.9",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.8';
+export const SERENADA_CORE_VERSION = '0.6.9';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.8",
+    "@serenada/core": "^0.6.9",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.6.8"
+    "@serenada/core": "0.6.9"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.6")
-    implementation("app.serenada:call-ui:0.6.6")
+    implementation("app.serenada:core:0.6.9")
+    implementation("app.serenada:call-ui:0.6.9")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.6.6 @serenada/react-ui@0.6.6 lucide-react
+npm install @serenada/core@0.6.9 @serenada/react-ui@0.6.9 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.1",
+      "version": "0.6.9",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.1",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.1"
+        "@serenada/core": "0.6.9"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.1",
+        "@serenada/core": "^0.6.9",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Bumps SDK version to **0.6.9** across all platforms and updates docs / lock files that had drifted.

**iOS changes (the three commits already on main since v0.6.8):**

- **Audio-only join** — new `SerenadaConfig.allowAudioOnlyJoin` (default `true`). The SDK now joins audio-only when the user has denied or not yet granted camera permission, falling back to the audio-only placeholder for local preview.
- **World / composite camera as primary surface** — in world and composite modes, the local preview is rendered as the primary surface in both Waiting and InCall, matching the existing 1:1 video layout. Pinch-to-zoom is reachable in both phases.
- **Avatar cache** — invalidates correctly when a remote participant's avatar URL changes mid-call.

**Version bump scope (13 files):**

- 8 SDK sources tracked by `check-version-parity.mjs` (TS const, web/android/ios package files)
- `client/package.json` workspace root + `@serenada/*` dep pins
- `client/package-lock.json` workspace + nested package entries
- `samples/web/package-lock.json` (was stuck at 0.6.1)
- `docs/sdk/sdk-integration-{web,android}.md` install snippets (were stuck at 0.6.6)

`node scripts/check-version-parity.mjs` → `OK: All 8 version sources match at 0.6.9.`

No protocol changes. No behavior changes outside iOS.

## Test plan

- [x] `node scripts/check-version-parity.mjs` passes
- [ ] iOS audio-only join: deny camera permission, verify call joins with placeholder
- [ ] iOS world camera: switch to world mode, verify local preview is large in Waiting + InCall, pinch-to-zoom works
- [ ] iOS avatar cache: peer changes avatar URL mid-call, new avatar shows
- [ ] Web + Android: smoke test that a call still works (no behavior changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)