### PR TITLE
Harden Android & iOS  ICE candidate handling

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/IceCandidateSanitizer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/IceCandidateSanitizer.kt
@@ -5,10 +5,10 @@ import app.serenada.core.SerenadaLogger
 import org.webrtc.IceCandidate
 
 /**
- * Drops blank SDP candidates and synthesizes `sdpMid` from `sdpMLineIndex` when
- * the remote omitted it. Native WebRTC rejects candidates with blank or
- * mismatched mid metadata, so we filter at the boundary before they reach the
- * peer connection (or the pending buffer).
+ * Drops blank-SDP candidates and normalizes blank `sdpMid` to null so native
+ * WebRTC falls back to `sdpMLineIndex`. Synthesizing a numeric mid from the
+ * m-line index would mismatch remote SDPs that use named mids (e.g. `audio`),
+ * so we preserve a missing mid rather than fabricate one.
  */
 internal fun sanitizeIceCandidate(
     candidate: IceCandidate,
@@ -21,6 +21,6 @@ internal fun sanitizeIceCandidate(
         return null
     }
     val sdpMid = candidate.sdpMid?.takeIf { it.isNotBlank() }
-    if (sdpMid != null) return candidate
-    return IceCandidate(candidate.sdpMLineIndex.toString(), candidate.sdpMLineIndex, candidateSdp)
+    if (sdpMid == candidate.sdpMid && candidateSdp == candidate.sdp) return candidate
+    return IceCandidate(sdpMid, candidate.sdpMLineIndex, candidateSdp)
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/IceCandidateSanitizer.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/IceCandidateSanitizer.kt
@@ -1,0 +1,26 @@
+package app.serenada.core.call
+
+import app.serenada.core.SerenadaLogLevel
+import app.serenada.core.SerenadaLogger
+import org.webrtc.IceCandidate
+
+/**
+ * Drops blank SDP candidates and synthesizes `sdpMid` from `sdpMLineIndex` when
+ * the remote omitted it. Native WebRTC rejects candidates with blank or
+ * mismatched mid metadata, so we filter at the boundary before they reach the
+ * peer connection (or the pending buffer).
+ */
+internal fun sanitizeIceCandidate(
+    candidate: IceCandidate,
+    remoteCid: String,
+    logger: SerenadaLogger? = null,
+): IceCandidate? {
+    val candidateSdp = candidate.sdp?.takeIf { it.isNotBlank() }
+    if (candidateSdp == null) {
+        logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Dropping blank ICE candidate")
+        return null
+    }
+    val sdpMid = candidate.sdpMid?.takeIf { it.isNotBlank() }
+    if (sdpMid != null) return candidate
+    return IceCandidate(candidate.sdpMLineIndex.toString(), candidate.sdpMLineIndex, candidateSdp)
+}

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -353,10 +353,11 @@ internal class PeerConnectionSlot(
     }
 
     override fun addIceCandidate(candidate: IceCandidate) {
+        val safeCandidate = sanitizeIceCandidate(candidate) ?: return
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) {
                 if (pendingIceCandidates.size < WebRtcResilienceConstants.ICE_CANDIDATE_BUFFER_MAX) {
-                    pendingIceCandidates.add(candidate)
+                    pendingIceCandidates.add(safeCandidate)
                 }
                 return
             }
@@ -365,11 +366,11 @@ internal class PeerConnectionSlot(
 
         if (!remoteDescriptionSet) {
             if (pendingIceCandidates.size < WebRtcResilienceConstants.ICE_CANDIDATE_BUFFER_MAX) {
-                pendingIceCandidates.add(candidate)
+                pendingIceCandidates.add(safeCandidate)
             }
             return
         }
-        pc.addIceCandidate(candidate)
+        pc.addIceCandidate(safeCandidate)
     }
 
     override fun rollbackLocalDescription(onComplete: ((Boolean) -> Unit)?) {
@@ -517,6 +518,17 @@ internal class PeerConnectionSlot(
         val pending = pendingIceCandidates.toList()
         pendingIceCandidates.clear()
         pending.forEach { pc.addIceCandidate(it) }
+    }
+
+    private fun sanitizeIceCandidate(candidate: IceCandidate): IceCandidate? {
+        val candidateSdp = candidate.sdp?.takeIf { it.isNotBlank() }
+        if (candidateSdp == null) {
+            logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Dropping blank ICE candidate")
+            return null
+        }
+        val sdpMid = candidate.sdpMid?.takeIf { it.isNotBlank() }
+        if (sdpMid != null) return candidate
+        return IceCandidate(candidate.sdpMLineIndex.toString(), candidate.sdpMLineIndex, candidateSdp)
     }
 
     @Synchronized

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -353,7 +353,7 @@ internal class PeerConnectionSlot(
     }
 
     override fun addIceCandidate(candidate: IceCandidate) {
-        val safeCandidate = sanitizeIceCandidate(candidate) ?: return
+        val safeCandidate = sanitizeIceCandidate(candidate, remoteCid, logger) ?: return
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) {
                 if (pendingIceCandidates.size < WebRtcResilienceConstants.ICE_CANDIDATE_BUFFER_MAX) {
@@ -518,17 +518,6 @@ internal class PeerConnectionSlot(
         val pending = pendingIceCandidates.toList()
         pendingIceCandidates.clear()
         pending.forEach { pc.addIceCandidate(it) }
-    }
-
-    private fun sanitizeIceCandidate(candidate: IceCandidate): IceCandidate? {
-        val candidateSdp = candidate.sdp?.takeIf { it.isNotBlank() }
-        if (candidateSdp == null) {
-            logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Dropping blank ICE candidate")
-            return null
-        }
-        val sdpMid = candidate.sdpMid?.takeIf { it.isNotBlank() }
-        if (sdpMid != null) return candidate
-        return IceCandidate(candidate.sdpMLineIndex.toString(), candidate.sdpMLineIndex, candidateSdp)
     }
 
     @Synchronized

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -121,10 +121,14 @@ internal class PeerNegotiationEngine(
             }
             "ice" -> {
                 val candidateJson = msg.payload?.optJSONObject("candidate") ?: return
+                val candidateSdp = candidateJson.optString("candidate", "")
+                if (candidateSdp.isBlank()) return
+                val sdpMLineIndex = candidateJson.optInt("sdpMLineIndex", 0)
+                val sdpMid = candidateJson.optString("sdpMid").ifBlank { sdpMLineIndex.toString() }
                 val candidate = IceCandidate(
-                    candidateJson.optString("sdpMid").ifBlank { null },
-                    candidateJson.optInt("sdpMLineIndex", 0),
-                    candidateJson.optString("candidate", "")
+                    sdpMid,
+                    sdpMLineIndex,
+                    candidateSdp
                 )
                 slot.addIceCandidate(candidate)
             }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -124,7 +124,7 @@ internal class PeerNegotiationEngine(
                 val candidateSdp = candidateJson.optString("candidate", "")
                 if (candidateSdp.isBlank()) return
                 val sdpMLineIndex = candidateJson.optInt("sdpMLineIndex", 0)
-                val sdpMid = candidateJson.optString("sdpMid").ifBlank { sdpMLineIndex.toString() }
+                val sdpMid = candidateJson.optString("sdpMid").takeIf { it.isNotBlank() }
                 val candidate = IceCandidate(
                     sdpMid,
                     sdpMLineIndex,

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -79,6 +79,23 @@ class SessionNegotiationTest {
         assertEquals("candidate:test-ice", fakeSlot.addedIceCandidates.first().sdp)
     }
 
+    @Test
+    fun `remote ICE candidate without sdpMid uses m-line index as safe mid`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+
+        factory.simulateIceCandidateFromRemote(
+            fromCid = "remote",
+            candidate = "candidate:test-ice",
+            sdpMid = null,
+            sdpMLineIndex = 1,
+        )
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull(fakeSlot)
+        assertEquals(1, fakeSlot!!.addedIceCandidates.size)
+        assertEquals("1", fakeSlot.addedIceCandidates.first().sdpMid)
+    }
+
     // Group 3: Peer Departure
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -96,6 +96,18 @@ class SessionNegotiationTest {
         assertEquals("1", fakeSlot.addedIceCandidates.first().sdpMid)
     }
 
+    @Test
+    fun `remote ICE candidate with blank sdp is dropped before reaching slot`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+
+        factory.simulateIceCandidateFromRemote(fromCid = "remote", candidate = "")
+        factory.simulateIceCandidateFromRemote(fromCid = "remote", candidate = "   ")
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull(fakeSlot)
+        assertTrue("Blank candidates must not reach the slot", fakeSlot!!.addedIceCandidates.isEmpty())
+    }
+
     // Group 3: Peer Departure
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -80,7 +80,7 @@ class SessionNegotiationTest {
     }
 
     @Test
-    fun `remote ICE candidate without sdpMid uses m-line index as safe mid`() {
+    fun `remote ICE candidate without sdpMid is forwarded with null mid so WebRTC uses m-line index`() {
         factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
 
         factory.simulateIceCandidateFromRemote(
@@ -93,7 +93,9 @@ class SessionNegotiationTest {
         val fakeSlot = factory.fakeMedia.fakeSlots["remote"]
         assertNotNull(fakeSlot)
         assertEquals(1, fakeSlot!!.addedIceCandidates.size)
-        assertEquals("1", fakeSlot.addedIceCandidates.first().sdpMid)
+        val added = fakeSlot.addedIceCandidates.first()
+        assertNull(added.sdpMid)
+        assertEquals(1, added.sdpMLineIndex)
     }
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/IceCandidateSanitizerTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/IceCandidateSanitizerTest.kt
@@ -30,27 +30,25 @@ class IceCandidateSanitizerTest {
     }
 
     @Test
-    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is null`() {
+    fun `passes through null sdpMid so WebRTC uses sdpMLineIndex`() {
         val input = IceCandidate(null, 1, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
         val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
-        assertEquals("1", result?.sdpMid)
-        assertEquals(1, result?.sdpMLineIndex)
-        assertEquals(input.sdp, result?.sdp)
+        assertSame(input, result)
     }
 
     @Test
-    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is blank`() {
+    fun `normalizes blank sdpMid to null`() {
         val input = IceCandidate("", 2, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
         val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
-        assertEquals("2", result?.sdpMid)
+        assertNull(result?.sdpMid)
         assertEquals(2, result?.sdpMLineIndex)
         assertEquals(input.sdp, result?.sdp)
     }
 
     @Test
-    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is whitespace`() {
+    fun `normalizes whitespace sdpMid to null`() {
         val input = IceCandidate("  ", 0, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
         val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
-        assertEquals("0", result?.sdpMid)
+        assertNull(result?.sdpMid)
     }
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/IceCandidateSanitizerTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/IceCandidateSanitizerTest.kt
@@ -1,0 +1,56 @@
+package app.serenada.core.call
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.webrtc.IceCandidate
+
+class IceCandidateSanitizerTest {
+
+    @Test
+    fun `passes through candidate with valid sdpMid`() {
+        val input = IceCandidate("0", 0, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertSame("Should return the same instance when nothing to sanitize", input, result)
+    }
+
+    @Test
+    fun `drops candidate with blank sdp`() {
+        val input = IceCandidate("0", 0, "")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertNull(result)
+    }
+
+    @Test
+    fun `drops candidate with whitespace-only sdp`() {
+        val input = IceCandidate("0", 0, "   ")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertNull(result)
+    }
+
+    @Test
+    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is null`() {
+        val input = IceCandidate(null, 1, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertEquals("1", result?.sdpMid)
+        assertEquals(1, result?.sdpMLineIndex)
+        assertEquals(input.sdp, result?.sdp)
+    }
+
+    @Test
+    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is blank`() {
+        val input = IceCandidate("", 2, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertEquals("2", result?.sdpMid)
+        assertEquals(2, result?.sdpMLineIndex)
+        assertEquals(input.sdp, result?.sdp)
+    }
+
+    @Test
+    fun `synthesizes sdpMid from sdpMLineIndex when sdpMid is whitespace`() {
+        val input = IceCandidate("  ", 0, "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host")
+        val result = sanitizeIceCandidate(input, remoteCid = "remote-1")
+        assertEquals("0", result?.sdpMid)
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
@@ -111,13 +111,18 @@ internal class TestSessionFactory(
         ShadowLooper.idleMainLooper()
     }
 
-    fun simulateIceCandidateFromRemote(fromCid: String, candidate: String = "candidate:test") {
+    fun simulateIceCandidateFromRemote(
+        fromCid: String,
+        candidate: String = "candidate:test",
+        sdpMid: String? = "0",
+        sdpMLineIndex: Int = 0,
+    ) {
         val payload = JSONObject().apply {
             put("from", fromCid)
             put("candidate", JSONObject().apply {
                 put("candidate", candidate)
-                put("sdpMid", "0")
-                put("sdpMLineIndex", 0)
+                sdpMid?.let { put("sdpMid", it) }
+                put("sdpMLineIndex", sdpMLineIndex)
             })
         }
         fakeProvider.simulateMessage(from = fromCid, type = "ice", payload = payload)

--- a/client-ios/SerenadaCore/Sources/Call/IceCandidateSanitizer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/IceCandidateSanitizer.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// Drops blank SDP candidates and synthesizes `sdpMid` from `sdpMLineIndex`
-/// when the remote omitted it. Native WebRTC rejects candidates with blank or
-/// mismatched mid metadata, so we filter at the boundary before they reach the
-/// peer connection (or the pending buffer).
+/// Drops blank-SDP candidates and normalizes blank `sdpMid` to nil so native
+/// WebRTC falls back to `sdpMLineIndex`. Synthesizing a numeric mid from the
+/// m-line index would mismatch remote SDPs that use named mids (e.g. `audio`),
+/// so we preserve a missing mid rather than fabricate one.
 internal func sanitizeIceCandidate(
     _ candidate: IceCandidatePayload,
     remoteCid: String,
@@ -20,7 +20,7 @@ internal func sanitizeIceCandidate(
         return candidate
     }
     return IceCandidatePayload(
-        sdpMid: String(candidate.sdpMLineIndex),
+        sdpMid: nil,
         sdpMLineIndex: candidate.sdpMLineIndex,
         candidate: candidate.candidate
     )

--- a/client-ios/SerenadaCore/Sources/Call/IceCandidateSanitizer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/IceCandidateSanitizer.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Drops blank SDP candidates and synthesizes `sdpMid` from `sdpMLineIndex`
+/// when the remote omitted it. Native WebRTC rejects candidates with blank or
+/// mismatched mid metadata, so we filter at the boundary before they reach the
+/// peer connection (or the pending buffer).
+internal func sanitizeIceCandidate(
+    _ candidate: IceCandidatePayload,
+    remoteCid: String,
+    logger: SerenadaLogger? = nil
+) -> IceCandidatePayload? {
+    let trimmedCandidate = candidate.candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedCandidate.isEmpty {
+        logger?.log(.warning, tag: "PeerConnection", "[\(remoteCid)] Dropping blank ICE candidate")
+        return nil
+    }
+
+    let trimmedMid = candidate.sdpMid?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let mid = trimmedMid, !mid.isEmpty {
+        return candidate
+    }
+    return IceCandidatePayload(
+        sdpMid: String(candidate.sdpMLineIndex),
+        sdpMLineIndex: candidate.sdpMLineIndex,
+        candidate: candidate.candidate
+    )
+}

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -446,22 +446,25 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
 
     public func addIceCandidate(_ candidate: IceCandidatePayload) {
 #if canImport(WebRTC)
+        guard let safeCandidate = sanitizeIceCandidate(candidate, remoteCid: remoteCid) else {
+            return
+        }
         guard let peerConnection = peerConnection ?? (ensurePeerConnection() ? self.peerConnection : nil) else {
             return
         }
 
         if peerConnection.remoteDescription == nil {
             if pendingRemoteIceCandidates.count < WebRtcResilience.iceCandidateBufferMax {
-                pendingRemoteIceCandidates.append(candidate)
+                pendingRemoteIceCandidates.append(safeCandidate)
             }
             return
         }
 
         peerConnection.add(
             RTCIceCandidate(
-                sdp: candidate.candidate,
-                sdpMLineIndex: candidate.sdpMLineIndex,
-                sdpMid: candidate.sdpMid
+                sdp: safeCandidate.candidate,
+                sdpMLineIndex: safeCandidate.sdpMLineIndex,
+                sdpMid: safeCandidate.sdpMid
             )
         ) { _ in }
 #endif

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -176,13 +176,22 @@ final class PeerNegotiationEngine {
 
         case "ice":
             guard let candidateObject = message.payload?.objectValue?["candidate"]?.objectValue,
-                  let candidate = candidateObject["candidate"]?.stringValue else {
+                  let candidate = candidateObject["candidate"]?.stringValue,
+                  !candidate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 return
+            }
+            let sdpMLineIndex = Int32(candidateObject["sdpMLineIndex"]?.intValue ?? 0)
+            let rawSdpMid = candidateObject["sdpMid"]?.stringValue
+            let sdpMid: String
+            if let mid = rawSdpMid?.trimmingCharacters(in: .whitespacesAndNewlines), !mid.isEmpty {
+                sdpMid = mid
+            } else {
+                sdpMid = String(sdpMLineIndex)
             }
             slot.addIceCandidate(
                 IceCandidatePayload(
-                    sdpMid: candidateObject["sdpMid"]?.stringValue,
-                    sdpMLineIndex: Int32(candidateObject["sdpMLineIndex"]?.intValue ?? 0),
+                    sdpMid: sdpMid,
+                    sdpMLineIndex: sdpMLineIndex,
                     candidate: candidate
                 )
             )

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -181,13 +181,8 @@ final class PeerNegotiationEngine {
                 return
             }
             let sdpMLineIndex = Int32(candidateObject["sdpMLineIndex"]?.intValue ?? 0)
-            let rawSdpMid = candidateObject["sdpMid"]?.stringValue
-            let sdpMid: String
-            if let mid = rawSdpMid?.trimmingCharacters(in: .whitespacesAndNewlines), !mid.isEmpty {
-                sdpMid = mid
-            } else {
-                sdpMid = String(sdpMLineIndex)
-            }
+            let trimmedMid = candidateObject["sdpMid"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let sdpMid = trimmedMid.flatMap { $0.isEmpty ? nil : $0 }
             slot.addIceCandidate(
                 IceCandidatePayload(
                     sdpMid: sdpMid,

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Helpers/SessionTestHarness.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Helpers/SessionTestHarness.swift
@@ -145,19 +145,22 @@ final class SessionTestHarness {
     func simulateIceCandidateFromRemote(
         fromCid: String,
         candidate: String = "candidate:1 1 udp 2130706431 192.168.1.1 12345 typ host",
-        sdpMid: String = "0",
+        sdpMid: String? = "0",
         sdpMLineIndex: Int = 0
     ) {
+        var candidateObject: [String: JSONValue] = [
+            "candidate": .string(candidate),
+            "sdpMLineIndex": .number(Double(sdpMLineIndex))
+        ]
+        if let sdpMid {
+            candidateObject["sdpMid"] = .string(sdpMid)
+        }
         fakeProvider.simulateMessage(
             from: fromCid,
             type: "ice",
             payload: [
                 "from": .string(fromCid),
-                "candidate": .object([
-                    "candidate": .string(candidate),
-                    "sdpMid": .string(sdpMid),
-                    "sdpMLineIndex": .number(Double(sdpMLineIndex))
-                ])
+                "candidate": .object(candidateObject)
             ]
         )
     }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IceCandidateSanitizerTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IceCandidateSanitizerTests.swift
@@ -25,35 +25,35 @@ final class IceCandidateSanitizerTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsNil() {
+    func testPassesThroughNilSdpMidSoWebRTCUsesMLineIndex() {
         let input = IceCandidatePayload(
             sdpMid: nil,
             sdpMLineIndex: 1,
             candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
         )
         let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
-        XCTAssertEqual(result?.sdpMid, "1")
-        XCTAssertEqual(result?.sdpMLineIndex, 1)
-        XCTAssertEqual(result?.candidate, input.candidate)
+        XCTAssertEqual(result, input)
     }
 
-    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsBlank() {
+    func testNormalizesBlankSdpMidToNil() {
         let input = IceCandidatePayload(
             sdpMid: "",
             sdpMLineIndex: 2,
             candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
         )
         let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
-        XCTAssertEqual(result?.sdpMid, "2")
+        XCTAssertNil(result?.sdpMid)
+        XCTAssertEqual(result?.sdpMLineIndex, 2)
+        XCTAssertEqual(result?.candidate, input.candidate)
     }
 
-    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsWhitespace() {
+    func testNormalizesWhitespaceSdpMidToNil() {
         let input = IceCandidatePayload(
             sdpMid: "  ",
             sdpMLineIndex: 0,
             candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
         )
         let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
-        XCTAssertEqual(result?.sdpMid, "0")
+        XCTAssertNil(result?.sdpMid)
     }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IceCandidateSanitizerTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IceCandidateSanitizerTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SerenadaCore
+
+final class IceCandidateSanitizerTests: XCTestCase {
+
+    func testPassesThroughCandidateWithValidSdpMid() {
+        let input = IceCandidatePayload(
+            sdpMid: "0",
+            sdpMLineIndex: 0,
+            candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
+        )
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertEqual(result, input)
+    }
+
+    func testDropsCandidateWithBlankSdp() {
+        let input = IceCandidatePayload(sdpMid: "0", sdpMLineIndex: 0, candidate: "")
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertNil(result)
+    }
+
+    func testDropsCandidateWithWhitespaceOnlySdp() {
+        let input = IceCandidatePayload(sdpMid: "0", sdpMLineIndex: 0, candidate: "   ")
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertNil(result)
+    }
+
+    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsNil() {
+        let input = IceCandidatePayload(
+            sdpMid: nil,
+            sdpMLineIndex: 1,
+            candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
+        )
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertEqual(result?.sdpMid, "1")
+        XCTAssertEqual(result?.sdpMLineIndex, 1)
+        XCTAssertEqual(result?.candidate, input.candidate)
+    }
+
+    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsBlank() {
+        let input = IceCandidatePayload(
+            sdpMid: "",
+            sdpMLineIndex: 2,
+            candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
+        )
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertEqual(result?.sdpMid, "2")
+    }
+
+    func testSynthesizesSdpMidFromMLineIndexWhenSdpMidIsWhitespace() {
+        let input = IceCandidatePayload(
+            sdpMid: "  ",
+            sdpMLineIndex: 0,
+            candidate: "candidate:1 1 udp 2113937151 192.168.1.1 54321 typ host"
+        )
+        let result = sanitizeIceCandidate(input, remoteCid: "remote-1")
+        XCTAssertEqual(result?.sdpMid, "0")
+    }
+}

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
@@ -133,7 +133,7 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertEqual(fakeSlot?.addedIceCandidates.first?.candidate, "candidate:test")
     }
 
-    func testRemoteIceCandidateWithoutSdpMidUsesMLineIndex() async throws {
+    func testRemoteIceCandidateWithoutSdpMidIsForwardedWithNilMid() async throws {
         await harness.advanceToInCallWithTurn(
             localCid: "local",
             remoteCid: "remote",
@@ -154,8 +154,9 @@ final class SessionNegotiationTests: XCTestCase {
             fakeSlot?.addedIceCandidates.count == 1
         }
 
-        XCTAssertEqual(fakeSlot?.addedIceCandidates.first?.sdpMid, "1",
-                       "Missing sdpMid should be synthesized from sdpMLineIndex")
+        XCTAssertNil(fakeSlot?.addedIceCandidates.first?.sdpMid,
+                     "Missing sdpMid should be preserved as nil so WebRTC uses sdpMLineIndex")
+        XCTAssertEqual(fakeSlot?.addedIceCandidates.first?.sdpMLineIndex, 1)
     }
 
     func testRemoteIceCandidateWithBlankSdpIsDropped() async throws {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
@@ -133,6 +133,51 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertEqual(fakeSlot?.addedIceCandidates.first?.candidate, "candidate:test")
     }
 
+    func testRemoteIceCandidateWithoutSdpMidUsesMLineIndex() async throws {
+        await harness.advanceToInCallWithTurn(
+            localCid: "local",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+
+        let fakeSlot = harness.fakeMedia.fakeSlots["remote"]
+        XCTAssertNotNil(fakeSlot)
+
+        harness.simulateIceCandidateFromRemote(
+            fromCid: "remote",
+            candidate: "candidate:test-ice",
+            sdpMid: nil,
+            sdpMLineIndex: 1
+        )
+        await waitUntil {
+            fakeSlot?.addedIceCandidates.count == 1
+        }
+
+        XCTAssertEqual(fakeSlot?.addedIceCandidates.first?.sdpMid, "1",
+                       "Missing sdpMid should be synthesized from sdpMLineIndex")
+    }
+
+    func testRemoteIceCandidateWithBlankSdpIsDropped() async throws {
+        await harness.advanceToInCallWithTurn(
+            localCid: "local",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+
+        let fakeSlot = harness.fakeMedia.fakeSlots["remote"]
+        XCTAssertNotNil(fakeSlot)
+
+        harness.simulateIceCandidateFromRemote(fromCid: "remote", candidate: "")
+        harness.simulateIceCandidateFromRemote(fromCid: "remote", candidate: "   ")
+        await harness.yieldToMainActor()
+        await harness.yieldToMainActor()
+
+        XCTAssertEqual(fakeSlot?.addedIceCandidates.count, 0,
+                       "Blank ICE candidates must not reach the slot")
+    }
+
     // MARK: - Group 3: Peer Departure
 
     func testPeerLeavesViaRoomState() async throws {

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		60DD419576BB73E40DC4D993 /* SignalingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */; };
 		6198802831401A13687DDCA9 /* FeedbackScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */; };
 		64A7BCD5402B626283D5F7A7 /* AudioLevelMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */; };
+		6B5F236A91FDD3905C7AFD49 /* IceCandidateSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258D6A80A3E3F6FBE06D77B8 /* IceCandidateSanitizerTests.swift */; };
 		6D7CC8795CCE4899285777B4 /* SerenadaDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */; };
 		6E8767096E3E70790EB1CEE5 /* SessionNegotiationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A65C7CFBDAB1D28D4F50040 /* SessionNegotiationTests.swift */; };
 		6E92E404B6B3E0A636F21C56 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529A15EA2C43DB2F91F46FC /* RootView.swift */; };
@@ -69,7 +70,6 @@
 		B402B3581D8D647DC2D139A7 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
 		B896B31FAF7939AF63947C4C /* FakeSessionSignaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC97F9BB82CE31EBF9C084B /* FakeSessionSignaling.swift */; };
 		BC3AE1438258D205BFE66CD2 /* SerenadaiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */; };
-		BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */; };
 		BED32D7AA3653B78E9DE382C /* SessionSuspendedSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A249E2EA4288C34C4B5FFD48 /* SessionSuspendedSurfaceTests.swift */; };
 		C0500F3658A11A038780B5FD /* LoopbackSignalingProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801D5040B2102E7DFFFDC2B2 /* LoopbackSignalingProviderTests.swift */; };
 		C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9816C392666DC51C1838319 /* RecentCallStoreTests.swift */; };
@@ -160,6 +160,7 @@
 		1B3764EC96FDD478F4ADD4C4 /* BroadcastUpload.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BroadcastUpload.entitlements; sourceTree = "<group>"; };
 		1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingMessageTests.swift; sourceTree = "<group>"; };
 		23CA15C6609960E60FFBCD90 /* JoinFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinFlowCoordinatorTests.swift; sourceTree = "<group>"; };
+		258D6A80A3E3F6FBE06D77B8 /* IceCandidateSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IceCandidateSanitizerTests.swift; sourceTree = "<group>"; };
 		265E1C5C61144DD8395C627C /* SerenadaCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SerenadaCore; path = SerenadaCore; sourceTree = SOURCE_ROOT; };
 		28D54CC01458DA4FCF58D271 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2A15CC6B14E97F4E2C37C573 /* SerenadaServerProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaServerProviderTests.swift; sourceTree = "<group>"; };
@@ -221,7 +222,6 @@
 		D6A49EB1B8C461E0A475E453 /* FakePeerConnectionSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePeerConnectionSlot.swift; sourceTree = "<group>"; };
 		D9036C71CC2E91FAD8FB5170 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		DAE63BC3FBF66FBF7A4015AC /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = Vendor/WebRTC/WebRTC.xcframework; sourceTree = "<group>"; };
-		E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConformanceTests.swift; sourceTree = "<group>"; };
 		E456D79CB34E80195B31FCFC /* SerenadaiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaiOSApp.swift; sourceTree = "<group>"; };
 		E5D3CF250B070B90F00B3B1D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -396,7 +396,6 @@
 			isa = PBXGroup;
 			children = (
 				D0BE7FF0C166694E0F58114A /* Assets.xcassets */,
-				E07431915F3AC5DF220F5B3A /* GoogleService-Info.plist */,
 				E77A32857F53D8DEADAF2B04 /* SerenadaiOS.entitlements */,
 				EA93F28D0C87ABED6B756036 /* Localizable.strings */,
 			);
@@ -421,6 +420,7 @@
 				D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */,
 				F5BC48440A4DD113050C3E29 /* DeepLinkParserTests.swift */,
 				1A7CC3F22BEA1500363B20A6 /* EndpointHostParserTests.swift */,
+				258D6A80A3E3F6FBE06D77B8 /* IceCandidateSanitizerTests.swift */,
 				23CA15C6609960E60FFBCD90 /* JoinFlowCoordinatorTests.swift */,
 				F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */,
 				E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */,
@@ -739,7 +739,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B08F470FBB83FCC41A84E2B /* Assets.xcassets in Resources */,
-				BD10E73D0A99AF24A662C4F6 /* GoogleService-Info.plist in Resources */,
 				0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -829,6 +828,7 @@
 				B896B31FAF7939AF63947C4C /* FakeSessionSignaling.swift in Sources */,
 				467581ED7FB87064203AA780 /* FakeSignalingProvider.swift in Sources */,
 				AFCDC333087CBBB6BFF4566F /* FakeSignalingTransport.swift in Sources */,
+				6B5F236A91FDD3905C7AFD49 /* IceCandidateSanitizerTests.swift in Sources */,
 				5153383FD16DC779F8EBA4B3 /* JoinFlowCoordinatorTests.swift in Sources */,
 				16ED701C50FCF1CF741D04F1 /* JoinRecoveryTests.swift in Sources */,
 				6EE2ED9D63185C2AA8581CFE /* L10nTests.swift in Sources */,


### PR DESCRIPTION
## Summary
- Drop blank remote ICE candidates before they reach WebRTC
- Normalize missing `sdpMid` from `sdpMLineIndex` on inbound and buffered candidates
- Add Android SDK negotiation coverage for candidates without `sdpMid`

## Why
Desktop now normalizes outbound ICE candidates, but Android should still tolerate protocol peers that omit `sdpMid` instead of forwarding unsafe candidates into native WebRTC. This keeps the SDK defensive without coupling it to the Desktop MVP branch.

## Validation
- `./gradlew :serenada-core:testDebugUnitTest --tests app.serenada.core.SessionNegotiationTest`
