### PR TITLE
Web SDK: Reserve video transceiver for audio-only calls

### DIFF
--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -316,6 +316,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
                 turnsOnly: config.turnsOnly,
                 logger: config.logger,
                 initialFacingMode: initialCameraMode === 'world' ? 'environment' : 'user',
+                initialVideoEnabled: this.userPreferredVideoEnabled,
                 videoCaptureSupported: this.availableCameraModes.length > 0,
             },
             (type, payload, to) => {
@@ -1195,7 +1196,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         if (this.permissionCheckDone || this.permissionCheckInFlight) return;
         this.permissionCheckInFlight = true;
 
-        const needsCamera = this.availableCameraModes.length > 0;
+        const needsCamera = this.availableCameraModes.length > 0 && this.userPreferredVideoEnabled;
         const permissionsNeeded: MediaCapability[] = [];
         try {
             if (navigator.permissions) {

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -41,6 +41,8 @@ export interface MediaEngineConfig {
     logger?: SerenadaLogger;
     /** Initial camera facing mode. Defaults to `'user'` (selfie). */
     initialFacingMode?: 'user' | 'environment';
+    /** When `false`, media starts audio-only and camera is requested on first video enable. */
+    initialVideoEnabled?: boolean;
     /** When `false`, the camera is never requested and video is always off. */
     videoCaptureSupported?: boolean;
 }
@@ -59,6 +61,7 @@ export class MediaEngine {
     connectionStatus: ConnectionStatus = 'connected';
 
     private peers = new Map<string, PeerState>();
+    private readonly initialVideoEnabled: boolean;
     // Per-remote-CID tally of cumulative `inbound-rtp.bytesReceived`. Sampled
     // on every `getInboundFlowingCids()` call; a CID is "flowing" when its
     // current sample exceeds the previous one. Drives #3's `media_liveness`
@@ -96,6 +99,7 @@ export class MediaEngine {
         this.turnsOnly = config.turnsOnly ?? false;
         this.logger = config.logger;
         this.facingMode = config.initialFacingMode ?? 'user';
+        this.initialVideoEnabled = config.initialVideoEnabled !== false;
         this.videoCaptureSupported = config.videoCaptureSupported !== false;
         this.sendSignalingMessage = sendMessage;
         this.setupEventListeners();
@@ -119,9 +123,8 @@ export class MediaEngine {
                     peer.lastIceRestartAt = Date.now();
                     void this.createOfferTo(cid, { iceRestart: true });
                 }
-                if (peer.pendingLocalTrackNegotiation && peer.pc.remoteDescription && peer.pc.signalingState === 'stable') {
-                    peer.pendingLocalTrackNegotiation = false;
-                    void this.createOfferTo(cid);
+                if (peer.pendingLocalTrackNegotiation) {
+                    this.scheduleLocalTrackNegotiation(cid, peer);
                 }
             }
         }
@@ -219,7 +222,7 @@ export class MediaEngine {
                 sampleRate: { ideal: 48000 }
             };
             let stream: MediaStream;
-            if (!this.videoCaptureSupported) {
+            if (!this.videoCaptureSupported || !this.initialVideoEnabled) {
                 stream = await navigator.mediaDevices.getUserMedia({ video: false, audio: audioConstraints });
             } else {
                 try {
@@ -243,9 +246,15 @@ export class MediaEngine {
             this.requestingMedia = false;
 
             for (const [remoteCid, peer] of this.peers) {
-                stream.getTracks().forEach(track => peer.pc.addTrack(track, stream));
+                await this.attachLocalTracksToPeer(remoteCid, peer, stream);
                 void this.applyAudioSenderParameters(peer.pc);
-                if (!this.shouldIOffer(remoteCid) && peer.pc.remoteDescription) {
+                if (this.shouldIOffer(remoteCid) && !peer.pc.remoteDescription) {
+                    if (peer.pc.signalingState === 'stable') {
+                        void this.createOfferTo(remoteCid);
+                    } else {
+                        peer.pendingLocalTrackNegotiation = true;
+                    }
+                } else if (!this.shouldIOffer(remoteCid) && peer.pc.remoteDescription) {
                     if (peer.pc.signalingState === 'stable') {
                         void this.createOfferTo(remoteCid);
                     } else {
@@ -554,7 +563,12 @@ export class MediaEngine {
                 this.getOrCreatePeer(peer.cid);
                 if (this.shouldIOffer(peer.cid)) {
                     const peerState = this.peers.get(peer.cid);
-                    if (peerState && peerState.pc.signalingState === 'stable' && !peerState.pc.remoteDescription) {
+                    if (
+                        peerState &&
+                        this.localStream &&
+                        peerState.pc.signalingState === 'stable' &&
+                        !peerState.pc.remoteDescription
+                    ) {
                         void this.createOfferTo(peer.cid);
                     }
                 } else {
@@ -582,6 +596,7 @@ export class MediaEngine {
             this.localStream.getTracks().forEach(track => pc.addTrack(track, this.localStream!));
             void this.applyAudioSenderParameters(pc);
         }
+        this.ensureMediaTransceivers(pc);
 
         pc.ontrack = (event) => {
             this.logger?.log('debug', 'WebRTC', `[${remoteCid}] Remote track received`);
@@ -635,9 +650,7 @@ export class MediaEngine {
                 if (peerState.offerTimeout) { window.clearTimeout(peerState.offerTimeout); peerState.offerTimeout = null; }
             }
             if (pc.signalingState === 'stable' && peerState.pendingLocalTrackNegotiation) {
-                if (!this.isSignalingConnected || !peerState.pc.remoteDescription) return;
-                peerState.pendingLocalTrackNegotiation = false;
-                void this.createOfferTo(remoteCid);
+                this.scheduleLocalTrackNegotiation(remoteCid, peerState);
             }
             if (pc.signalingState === 'stable' && peerState.pendingIceRestart) {
                 if (peerState.offerTimeout) { window.clearTimeout(peerState.offerTimeout); peerState.offerTimeout = null; }
@@ -650,12 +663,22 @@ export class MediaEngine {
 
         pc.onicecandidate = (event) => {
             if (event.candidate) {
-                this.sendSignalingMessage('ice', { candidate: event.candidate }, remoteCid);
+                const candidate = event.candidate.toJSON();
+                if (!candidate.sdpMid) {
+                    candidate.sdpMid = String(candidate.sdpMLineIndex ?? 0);
+                }
+                this.sendSignalingMessage('ice', { candidate }, remoteCid);
             }
         };
 
         pc.onnegotiationneeded = async () => {
+            const peer = this.peers.get(remoteCid);
+            if (!peer) return;
             if (!this.shouldIOffer(remoteCid)) return;
+            if (!this.localStream) {
+                peer.pendingLocalTrackNegotiation = true;
+                return;
+            }
             await this.createOfferTo(remoteCid);
         };
 
@@ -935,14 +958,29 @@ export class MediaEngine {
         return cameraTrack;
     }
 
-    private async replaceVideoTrackOnAllPeers(newTrack: MediaStreamTrack | null): Promise<void> {
+    private async replaceVideoTrackOnAllPeers(newTrack: MediaStreamTrack | null, stream: MediaStream | null): Promise<void> {
         await Promise.all(
-            Array.from(this.peers.values()).map(async (peer) => {
-                const sender = peer.pc.getSenders().find(s => s.track?.kind === 'video')
-                    ?? peer.pc.getTransceivers().find(t => t.receiver.track?.kind === 'video')?.sender;
-                if (sender) {
-                    try { await sender.replaceTrack(newTrack); }
-                    catch (err) { this.logger?.log('warning', 'WebRTC', `Failed to replace track on peer: ${formatError(err)}`); }
+            Array.from(this.peers.entries()).map(async ([remoteCid, peer]) => {
+                const videoTransceiver = this.findTransceiver(peer.pc, 'video');
+                if (videoTransceiver) {
+                    try {
+                        await videoTransceiver.sender.replaceTrack(newTrack);
+                        if (videoTransceiver.direction !== 'sendrecv' && videoTransceiver.direction !== 'stopped' && this.videoCaptureSupported) {
+                            videoTransceiver.direction = 'sendrecv';
+                            this.scheduleLocalTrackNegotiation(remoteCid, peer);
+                        }
+                    } catch (err) {
+                        this.logger?.log('warning', 'WebRTC', `Failed to replace video track on peer: ${formatError(err)}`);
+                    }
+                    return;
+                }
+                if (newTrack && stream) {
+                    try {
+                        peer.pc.addTrack(newTrack, stream);
+                        this.scheduleLocalTrackNegotiation(remoteCid, peer);
+                    } catch (err) {
+                        this.logger?.log('warning', 'WebRTC', `Failed to add video track on peer: ${formatError(err)}`);
+                    }
                 }
             })
         );
@@ -953,7 +991,6 @@ export class MediaEngine {
             if (previousTrack && previousTrack !== nextTrack) previousTrack.stop();
             return;
         }
-        await this.replaceVideoTrackOnAllPeers(nextTrack);
         const nextStream = new MediaStream();
         let replacedVideo = false;
         for (const track of this.localStream.getTracks()) {
@@ -970,8 +1007,76 @@ export class MediaEngine {
             nextStream.addTrack(nextTrack);
         }
         this.localStream = nextStream;
+        await this.replaceVideoTrackOnAllPeers(nextTrack, nextStream);
         if (previousTrack && previousTrack !== nextTrack) previousTrack.stop();
         this.notifyChange();
+    }
+
+    private ensureMediaTransceivers(pc: RTCPeerConnection): void {
+        if (!this.findTransceiver(pc, 'audio') && !pc.getSenders().some(sender => sender.track?.kind === 'audio')) {
+            pc.addTransceiver('audio', { direction: 'recvonly' });
+        }
+        if (!this.findTransceiver(pc, 'video') && !pc.getSenders().some(sender => sender.track?.kind === 'video')) {
+            pc.addTransceiver('video', { direction: this.videoCaptureSupported ? 'sendrecv' : 'recvonly' });
+        }
+    }
+
+    private findTransceiver(pc: RTCPeerConnection, kind: 'audio' | 'video'): RTCRtpTransceiver | undefined {
+        return pc.getTransceivers().find(transceiver => (
+            transceiver.receiver.track?.kind === kind || transceiver.sender.track?.kind === kind
+        ));
+    }
+
+    private async attachLocalTracksToPeer(remoteCid: string, peer: PeerState, stream: MediaStream): Promise<void> {
+        let negotiationNeeded = false;
+        for (const track of stream.getTracks()) {
+            negotiationNeeded = await this.attachLocalTrackToPeer(peer, track, stream) || negotiationNeeded;
+        }
+        if (negotiationNeeded) {
+            this.scheduleLocalTrackNegotiation(remoteCid, peer);
+        }
+    }
+
+    private async attachLocalTrackToPeer(peer: PeerState, track: MediaStreamTrack, stream: MediaStream): Promise<boolean> {
+        if (peer.pc.getSenders().some(sender => sender.track?.kind === track.kind)) {
+            return false;
+        }
+
+        const transceiver = track.kind === 'audio' || track.kind === 'video'
+            ? this.findTransceiver(peer.pc, track.kind)
+            : undefined;
+        if (transceiver) {
+            try {
+                await transceiver.sender.replaceTrack(track);
+                if (transceiver.direction !== 'sendrecv' && transceiver.direction !== 'stopped') {
+                    transceiver.direction = 'sendrecv';
+                    return true;
+                }
+            } catch (err) {
+                this.logger?.log('warning', 'WebRTC', `Failed to attach ${track.kind} track to peer: ${formatError(err)}`);
+            }
+            return false;
+        }
+
+        peer.pc.addTrack(track, stream);
+        return true;
+    }
+
+    private scheduleLocalTrackNegotiation(remoteCid: string, peer: PeerState): void {
+        if (!this.isSignalingConnected) {
+            peer.pendingLocalTrackNegotiation = true;
+            return;
+        }
+        if (!this.shouldIOffer(remoteCid) && !peer.pc.remoteDescription) {
+            peer.pendingLocalTrackNegotiation = true;
+            return;
+        }
+        if (peer.pc.signalingState !== 'stable') {
+            peer.pendingLocalTrackNegotiation = true;
+            return;
+        }
+        peer.pendingLocalTrackNegotiation = false;
+        void this.createOfferTo(remoteCid);
     }
 
     private async refreshLocalVideoTrack(reason: string, forceRefresh = false): Promise<boolean> {

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -236,20 +236,29 @@ describe('SerenadaSession', () => {
     describe('permission gating', () => {
         // Stub navigator.permissions to return 'prompt' for both camera and microphone.
         // This triggers the awaitingPermissions flow in SerenadaSession.
-        function stubPermissionsPrompt(): () => void {
+        function stubPermissionsPromptWithSpy(): {
+            query: ReturnType<typeof vi.fn>;
+            restore: () => void;
+        } {
             const original = navigator.permissions;
+            const query = vi.fn(() => Promise.resolve({ state: 'prompt' }));
             Object.defineProperty(navigator, 'permissions', {
-                value: {
-                    query: () => Promise.resolve({ state: 'prompt' }),
-                },
+                value: { query },
                 configurable: true,
             });
-            return () => {
-                Object.defineProperty(navigator, 'permissions', {
-                    value: original,
-                    configurable: true,
-                });
+            return {
+                query,
+                restore: () => {
+                    Object.defineProperty(navigator, 'permissions', {
+                        value: original,
+                        configurable: true,
+                    });
+                },
             };
+        }
+
+        function stubPermissionsPrompt(): () => void {
+            return stubPermissionsPromptWithSpy().restore;
         }
 
         it('moves to awaitingPermissions when permissions need prompting', async () => {
@@ -299,6 +308,26 @@ describe('SerenadaSession', () => {
             await vi.advanceTimersByTimeAsync(0);
 
             expect(permissionsCb).toHaveBeenCalled();
+            restore();
+        });
+
+        it('only requests microphone permission when default video is disabled', async () => {
+            const { query, restore } = stubPermissionsPromptWithSpy();
+            harness = new TestSessionHarness({
+                config: { defaultVideoEnabled: false },
+            });
+            const permissionsCb = vi.fn();
+            harness.session.onPermissionsRequired = permissionsCb;
+
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(harness.state.phase).toBe('awaitingPermissions');
+            expect(harness.state.requiredPermissions).toEqual(['microphone']);
+            expect(permissionsCb).toHaveBeenCalledWith(['microphone']);
+            expect(query.mock.calls.map(([descriptor]) => descriptor)).toEqual([
+                { name: 'microphone' },
+            ]);
             restore();
         });
 

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -6,6 +6,8 @@ class FakeRtcPeerConnection {
     readonly initialConfiguration: RTCConfiguration;
     readonly configurationUpdates: RTCConfiguration[] = [];
     readonly addedIceCandidates: RTCIceCandidateInit[] = [];
+    readonly senders: FakeRtcRtpSender[] = [];
+    readonly transceivers: FakeRtcRtpTransceiver[] = [];
     signalingState: RTCSignalingState = 'stable';
     remoteDescription: RTCSessionDescriptionInit | null = null;
     localDescription: RTCSessionDescriptionInit | null = null;
@@ -22,8 +24,22 @@ class FakeRtcPeerConnection {
         this.initialConfiguration = configuration;
     }
 
-    addTrack(): void {}
+    addTrack(track: MediaStreamTrack): RTCRtpSender {
+        const sender = new FakeRtcRtpSender(track);
+        this.senders.push(sender);
+        this.transceivers.push(new FakeRtcRtpTransceiver(track.kind as 'audio' | 'video', sender, 'sendrecv'));
+        return sender as unknown as RTCRtpSender;
+    }
+    addTransceiver(kind: 'audio' | 'video', init?: RTCRtpTransceiverInit): RTCRtpTransceiver {
+        const sender = new FakeRtcRtpSender(null);
+        const transceiver = new FakeRtcRtpTransceiver(kind, sender, init?.direction ?? 'sendrecv');
+        this.senders.push(sender);
+        this.transceivers.push(transceiver);
+        return transceiver as unknown as RTCRtpTransceiver;
+    }
     close(): void {}
+    getSenders(): RTCRtpSender[] { return this.senders as unknown as RTCRtpSender[]; }
+    getTransceivers(): RTCRtpTransceiver[] { return this.transceivers as unknown as RTCRtpTransceiver[]; }
     async createOffer(): Promise<RTCSessionDescriptionInit> {
         this.createOfferCalls += 1;
         return {
@@ -61,11 +77,82 @@ class FakeRtcPeerConnection {
     }
 }
 
+class FakeRtcRtpSender {
+    readonly replaceTrackCalls: Array<MediaStreamTrack | null> = [];
+
+    constructor(public track: MediaStreamTrack | null) {}
+
+    async replaceTrack(track: MediaStreamTrack | null): Promise<void> {
+        this.track = track;
+        this.replaceTrackCalls.push(track);
+    }
+}
+
+class FakeRtcRtpTransceiver {
+    readonly receiver: RTCRtpReceiver;
+
+    constructor(
+        kind: 'audio' | 'video',
+        public sender: FakeRtcRtpSender,
+        public direction: RTCRtpTransceiverDirection,
+    ) {
+        this.receiver = {
+            track: createMediaTrack(kind),
+        } as RTCRtpReceiver;
+    }
+}
+
+class FakeMediaStream {
+    private tracks: MediaStreamTrack[];
+
+    constructor(tracks: MediaStreamTrack[] = []) {
+        this.tracks = [...tracks];
+    }
+
+    addTrack(track: MediaStreamTrack): void {
+        this.tracks.push(track);
+    }
+
+    getAudioTracks(): MediaStreamTrack[] {
+        return this.tracks.filter(track => track.kind === 'audio');
+    }
+
+    getVideoTracks(): MediaStreamTrack[] {
+        return this.tracks.filter(track => track.kind === 'video');
+    }
+
+    getTracks(): MediaStreamTrack[] {
+        return [...this.tracks];
+    }
+}
+
+let trackId = 0;
+
+function createMediaTrack(kind: 'audio' | 'video'): MediaStreamTrack {
+    trackId += 1;
+    return {
+        id: `${kind}-${trackId}`,
+        kind,
+        enabled: true,
+        muted: false,
+        readyState: 'live',
+        stop() {},
+    } as MediaStreamTrack;
+}
+
+function createMediaStream(options: { audio?: boolean; video?: boolean } = { audio: true }): MediaStream {
+    const tracks: MediaStreamTrack[] = [];
+    if (options.audio !== false) tracks.push(createMediaTrack('audio'));
+    if (options.video) tracks.push(createMediaTrack('video'));
+    return new FakeMediaStream(tracks) as unknown as MediaStream;
+}
+
 describe('MediaEngine', () => {
     const originalNavigator = globalThis.navigator;
     const originalDocument = globalThis.document;
     const originalWindow = (globalThis as Record<string, unknown>).window;
     const originalRtcPeerConnection = (globalThis as Record<string, unknown>).RTCPeerConnection;
+    const originalMediaStream = (globalThis as Record<string, unknown>).MediaStream;
 
     beforeEach(() => {
         Object.defineProperty(globalThis, 'navigator', {
@@ -85,6 +172,7 @@ describe('MediaEngine', () => {
             clearInterval: (...args: Parameters<typeof globalThis.clearInterval>) => globalThis.clearInterval(...args),
         };
         (globalThis as Record<string, unknown>).RTCPeerConnection = FakeRtcPeerConnection;
+        (globalThis as Record<string, unknown>).MediaStream = FakeMediaStream;
     });
 
     afterEach(() => {
@@ -99,6 +187,7 @@ describe('MediaEngine', () => {
         });
         (globalThis as Record<string, unknown>).window = originalWindow;
         (globalThis as Record<string, unknown>).RTCPeerConnection = originalRtcPeerConnection;
+        (globalThis as Record<string, unknown>).MediaStream = originalMediaStream;
     });
 
     it('applies refreshed ICE servers to existing and future peers', () => {
@@ -145,11 +234,87 @@ describe('MediaEngine', () => {
         expect(peer?.configurationUpdates.at(-1)?.iceServers).toEqual([{ urls: 'stun:stun.l.google.com:19302' }]);
     });
 
+    it('starts with audio-only media when initial video is disabled', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream());
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        await engine.startLocalMedia();
+
+        expect(getUserMedia).toHaveBeenCalledWith({
+            video: false,
+            audio: expect.objectContaining({
+                echoCancellation: { ideal: true },
+            }),
+        });
+    });
+
+    it('uses the reserved video transceiver when video is enabled after an audio-only start', async () => {
+        const getUserMedia = vi.fn().mockImplementation(async (constraints: MediaStreamConstraints) => {
+            if (constraints.video) {
+                return createMediaStream({ audio: false, video: true });
+            }
+            return createMediaStream();
+        });
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+        await engine.startLocalMedia();
+
+        await vi.waitFor(() => {
+            expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
+        });
+        const peer = engine.getPeerConnectionsMap().get('zeta') as FakeRtcPeerConnection | undefined;
+        expect(peer?.senders.map(sender => sender.track?.kind)).toEqual(['audio', undefined]);
+        expect(peer?.transceivers.map(transceiver => `${transceiver.receiver.track.kind}:${transceiver.direction}`)).toEqual(['audio:sendrecv', 'video:sendrecv']);
+        if (peer) {
+            peer.remoteDescription = { type: 'answer', sdp: 'fake-answer-sdp' };
+            peer.signalingState = 'stable';
+        }
+
+        await engine.reacquireVideoTrack();
+
+        expect(getUserMedia).toHaveBeenLastCalledWith({
+            video: { facingMode: 'user' },
+            audio: false,
+        });
+        expect(peer?.senders.map(sender => sender.track?.kind)).toEqual(['audio', 'video']);
+        expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
+    });
+
     it('retries non-host fallback offers after the offer timeout elapses', async () => {
         vi.useFakeTimers();
 
         const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
-        const engine = new MediaEngine({}, (type, payload, to) => {
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
             sentMessages.push({ type, payload, to });
         });
 
@@ -266,15 +431,28 @@ describe('MediaEngine', () => {
     });
 
     it('uses direct string ordering for offer ownership', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream());
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
         const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
         const localeCompareSpy = vi.spyOn(String.prototype, 'localeCompare').mockImplementation(() => {
             throw new Error('should not be called');
         });
-        const engine = new MediaEngine({}, (type, payload, to) => {
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
             sentMessages.push({ type, payload, to });
         });
 
         engine.updateSignalingConnected(true);
+        await engine.startLocalMedia();
         engine.updateRoomState({
             hostCid: 'alpha',
             participants: [{ cid: 'alpha' }, { cid: 'zeta' }],


### PR DESCRIPTION
## Summary
- start audio-only calls without requesting camera while reserving a video transceiver in the initial SDP
- reuse the reserved sender when local video is enabled later instead of adding a new video m-line
- keep camera permission preflight tied to the initial video preference

## Platform reference
Android and iOS both keep video present in the WebRTC peer connection even when the product default is audio-only. Android creates/attaches the local video track and disables it after applying the local video preference. iOS creates/attaches the local video track with the capturer off when `defaultVideoEnabled` is false. The browser equivalent is to reserve a `sendrecv` video transceiver without requesting camera, then attach the camera track when the user turns video on.

## Validation
- npm test -- --run test/media/MediaEngine.test.ts test/SerenadaSession.test.ts
- npm run build:publish
