### PR TITLE
Web SDK: Shrink call flow avatars

### DIFF
--- a/client/packages/react-ui/src/callFlowStyles.ts
+++ b/client/packages/react-ui/src/callFlowStyles.ts
@@ -212,13 +212,13 @@ const CALL_FLOW_CSS = `
   display: flex;
   align-items: center;
   justify-content: center;
-  width: clamp(56px, 22cqi, 168px);
-  height: clamp(56px, 22cqi, 168px);
+  width: clamp(45px, 17.6cqi, 134px);
+  height: clamp(45px, 17.6cqi, 134px);
   border-radius: 50%;
   overflow: hidden;
   background: #2a2a2a;
   color: rgba(255, 255, 255, 0.85);
-  font-size: clamp(20px, 8cqi, 64px);
+  font-size: clamp(16px, 6.4cqi, 51px);
   font-weight: 600;
   line-height: 1;
   text-transform: uppercase;
@@ -227,9 +227,9 @@ const CALL_FLOW_CSS = `
 }
 
 [data-serenada-callflow] .serenada-avatar-circle.compact {
-  width: clamp(40px, 16cqi, 96px);
-  height: clamp(40px, 16cqi, 96px);
-  font-size: clamp(14px, 6cqi, 36px);
+  width: clamp(22px, 8.8cqi, 67px);
+  height: clamp(22px, 8.8cqi, 67px);
+  font-size: clamp(8px, 3.2cqi, 26px);
 }
 
 [data-serenada-callflow] .serenada-avatar-circle img {


### PR DESCRIPTION
## Summary
- Large view avatar shrunk by 20% (`clamp(56px, 22cqi, 168px)` → `clamp(45px, 17.6cqi, 134px)`)
- Compact (PiP) avatar resized to exactly half the new large (`clamp(22px, 8.8cqi, 67px)`)
- Font sizes scaled proportionally so initials stay centered

## Why
Avatars in the React UI call flow were visually too large. The previous compact-to-large ratio was also inconsistent (~0.71); the new sizing locks it to a clean 1:2.

## Test plan
- [ ] Visual check: solo call shows the smaller avatar in the large stage
- [ ] Visual check: 1:1 call with cameras off shows large avatar in main view, half-size avatar in PiP
- [ ] Image avatars (when `resolveAvatar` returns a URL) render at the new sizes
- [ ] Initials remain centered and readable across container widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)