### PR TITLE
Web SDK: Use compact avatar in 1:1 PiP remote tile

### DIFF
--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -1107,11 +1107,12 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                     )}
 
                     {remoteParticipant0?.videoEnabled === false && (
-                        <div className="video-camera-off-overlay">
+                        <div className={`video-camera-off-overlay${effectiveLocalLarge ? ' compact' : ''}`}>
                             <RemoteAvatar
                                 peerId={remoteParticipant0.peerId}
                                 displayName={remoteParticipant0.displayName}
                                 resolveAvatar={resolveAvatar}
+                                compact={effectiveLocalLarge}
                             />
                             <span className="video-camera-off-label">
                                 {remoteParticipant0.displayName ?? resolveString('cameraOff', strings)}

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -1106,7 +1106,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
                         />
                     )}
 
-                    {remoteParticipant0?.videoEnabled === false && (
+                    {remoteParticipant0?.videoEnabled === false && !showWaiting && (
                         <div className={`video-camera-off-overlay${effectiveLocalLarge ? ' compact' : ''}`}>
                             <RemoteAvatar
                                 peerId={remoteParticipant0.peerId}

--- a/client/packages/react-ui/src/callFlowStyles.ts
+++ b/client/packages/react-ui/src/callFlowStyles.ts
@@ -232,6 +232,15 @@ const CALL_FLOW_CSS = `
   font-size: clamp(8px, 3.2cqi, 26px);
 }
 
+[data-serenada-callflow] .video-camera-off-overlay.compact {
+  gap: clamp(4px, 1cqi, 12px);
+}
+
+[data-serenada-callflow] .video-camera-off-overlay.compact .video-camera-off-label {
+  font-size: clamp(10px, 2cqi, 18px);
+  padding: 0 8px;
+}
+
 [data-serenada-callflow] .serenada-avatar-circle img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
Follow-up to #95. The 1:1 remote camera-off overlay in `SerenadaCallFlow.tsx` never received the `compact` flag, so when the user swapped to local-large (making the remote a PiP tile), the avatar still rendered at the full-size dimensions. The avatar visually filled the small tile.

The multi-party `VideoTile` already wires `compact` correctly — only the 1:1 path was missing it.

## Change
In the `effectiveLocalLarge` branch the remote camera-off overlay and `RemoteAvatar` now both go compact:

```tsx
<div className={`video-camera-off-overlay${effectiveLocalLarge ? ' compact' : ''}`}>
    <RemoteAvatar … compact={effectiveLocalLarge} />
```

## Test plan
- [ ] 1:1 call with peer's camera off, tap to swap → remote tile becomes PiP and avatar shrinks to half-size
- [ ] Tap again to swap back → remote becomes primary and avatar returns to large size
- [ ] Multi-party stage tiles continue to use compact avatars unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)