### PR TITLE
v0.6.10: ICE hardening, audio-only video transceiver, React permissions, avatar polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.10] — 2026-05-05
+
+### Added
+- React UI: `SerenadaCallFlowConfig.requestPermissions` lets host apps supply
+  their own permission UI (custom modals, OS-style prompts, deep links into
+  Settings). When unset, the SDK falls back to the built-in
+  `SerenadaPermissions.request` flow.
+- React UI: the in-call video toggle now requests camera permission on demand.
+  Users who joined audio-only (or denied camera at join) can re-enable video
+  later in the call without leaving and rejoining.
+- Web: the SDK reserves a video transceiver on audio-only calls so desktop
+  peers can renegotiate video later in the same session without forcing a
+  full ICE restart.
+
+### Changed
+- Web: call-flow avatar sizes shrunk — the large-view avatar is reduced by
+  20% and the compact (PiP) avatar is now exactly half the size of the large
+  one. Initials and font sizes scale with the circle so they stay centered.
+- Web: in 1:1 calls the remote camera-off overlay now switches to compact
+  styling whenever it lives in the PiP slot (after a local-large swap), and
+  the camera-off label scales down with the avatar instead of dominating the
+  small tile.
+
+### Fixed
+- Android, iOS: ICE candidate handling hardened. Inbound candidates with
+  blank SDP are dropped at the sanitizer boundary, missing `sdpMid` is
+  preserved as null (so WebRTC falls back to `sdpMLineIndex` natively
+  instead of mismatching named mids like `audio`/`video`), and the same
+  sanitizer runs on the buffered-candidate path. Direct unit tests cover
+  the sanitizer on both platforms.
+- Web: the 1:1 waiting overlay (QR + share-link) and the camera-off avatar
+  no longer stack on top of each other when a remote participant is in the
+  room with `videoEnabled=false` but their media stream hasn't arrived yet.
+  The avatar is suppressed while the waiting overlay is showing and takes
+  over once the stream arrives.
+
 ## [0.6.9] — 2026-05-02
 
 ### Added

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.9"
+                version = "0.6.10"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.9"
+val sdkVersion = "0.6.10"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.9"
+val sdkVersion = "0.6.10"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.9"
+    public static let version = "0.6.10"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@serenada/core": "0.6.9",
-        "@serenada/react-ui": "0.6.9",
+        "@serenada/core": "0.6.10",
+        "@serenada/react-ui": "0.6.10",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.9"
+        "@serenada/core": "0.6.10"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.9",
+        "@serenada/core": "^0.6.10",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.9",
+  "version": "0.6.10",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@serenada/core": "0.6.9",
-    "@serenada/react-ui": "0.6.9",
+    "@serenada/core": "0.6.10",
+    "@serenada/react-ui": "0.6.10",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/core",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @serenada/core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.9';
+export const SERENADA_CORE_VERSION = '0.6.10';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenada/react-ui",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -27,13 +27,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@serenada/core": "^0.6.9",
+    "@serenada/core": "^0.6.10",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@serenada/core": "0.6.9"
+    "@serenada/core": "0.6.10"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.9")
-    implementation("app.serenada:call-ui:0.6.9")
+    implementation("app.serenada:core:0.6.10")
+    implementation("app.serenada:call-ui:0.6.10")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @serenada/core@0.6.9 @serenada/react-ui@0.6.9 lucide-react
+npm install @serenada/core@0.6.10 @serenada/react-ui@0.6.10 lucide-react
 ```
 
 `@serenada/core` is framework-agnostic vanilla TypeScript. `@serenada/react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@serenada/core",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@serenada/react-ui",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@serenada/core": "0.6.9"
+        "@serenada/core": "0.6.10"
       },
       "peerDependencies": {
-        "@serenada/core": "^0.6.9",
+        "@serenada/core": "^0.6.10",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Bumps SDK version to **0.6.10** across all platforms and updates docs / lock files.

**Six commits since v0.6.9:**

- **#93 ICE candidate hardening (Android + iOS)** — shared `IceCandidateSanitizer` drops blank-SDP candidates and preserves null `sdpMid` (instead of synthesizing a numeric one that mismatches named remote mids like `audio`/`video`). Same sanitizer runs at the message router and the buffered-candidate path. Direct unit tests on both platforms.
- **#94 Web: reserve video transceiver for audio-only calls** — desktop peers can renegotiate video later in the session without a full ICE restart.
- **#95 Web: shrink call-flow avatars** — large-view avatar -20%, compact (PiP) avatar = ½ the large size. Font sizes scale with the circle.
- **#96 Web: compact avatar in 1:1 PiP remote tile** — fixes oversized avatar/label after a local-large swap; suppresses avatar while the QR/share-link waiting overlay is up.
- **8c8c79a React UI: improved permissions handling** — new `SerenadaCallFlowConfig.requestPermissions` lets host apps inject custom permission UI; in-call video toggle requests camera permission on demand, so audio-only joiners can re-enable video later.

**Version bump scope (13 files):**

- 8 SDK sources tracked by `check-version-parity.mjs` (TS const, web/android/ios package files)
- `client/package.json` workspace root + `@serenada/*` dep pins
- `client/package-lock.json` workspace + nested package entries
- `samples/web/package-lock.json`
- `docs/sdk/sdk-integration-{web,android}.md` install snippets

`node scripts/check-version-parity.mjs` → `OK: All 8 version sources match at 0.6.10.`

No protocol changes.

## Test plan

- [x] `node scripts/check-version-parity.mjs` passes
- [ ] Android ICE: `./gradlew :serenada-core:testDebugUnitTest` (sanitizer + session tests)
- [ ] iOS ICE: `xcodebuild -only-testing:SerenadaiOSTests/IceCandidateSanitizerTests -only-testing:SerenadaiOSTests/SessionNegotiationTests test`
- [ ] Web audio-only: start audio-only call, verify late video renegotiation works without a full ICE restart
- [ ] Web avatars: verify shrunk large + half-size PiP, no overlap with QR/share waiting overlay
- [ ] React UI: deny camera at join, then tap video toggle in-call — should request camera permission and re-enable video on grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)