### PR TITLE
v0.6.11: Android audio-only parity, web screen-share fixes, first npm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.11] — 2026-05-08
+
+First version published to public registries, plus Android and web
+catch-up on the audio-only-join story that started in 0.6.9 (iOS) and
+0.6.10 (React UI).
+
+### Added
+- Android: audio-only join. A session created with `defaultVideoEnabled
+  = false` (or with the user toggling video off pre-join) now requests
+  only `MICROPHONE` and starts the call without acquiring the camera.
+  Mirrors `SerenadaConfig.allowAudioOnlyJoin` behavior on iOS.
+- Android: in-call video toggle requests `CAMERA` on demand. Users who
+  joined audio-only — or who denied camera at join — can flip video on
+  later in the same session; the SDK fires the standard
+  `onPermissionsRequired` delegate, and a denied grant leaves the call
+  intact instead of canceling it. Mirrors the React UI behavior added
+  in 0.6.10.
+
+### Changed
+- Web: npm packages renamed `@serenada/core` → `@agatx/serenada-core`
+  and `@serenada/react-ui` → `@agatx/serenada-react-ui`. Consumers
+  upgrading must update their import paths and `package.json`
+  dependencies. The new names match the GitHub org and remove the
+  unscoped-namespace conflict that previously blocked publishing.
+- Web: packages now publish to public npm (`registry.npmjs.org`) on
+  every `web-release-*` git tag, via the new `Publish web packages`
+  GitHub Actions workflow. GitHub Packages remains available as a
+  mirror for internal consumers. Build pipeline runs `npm run clean`
+  before `tsc -p tsconfig.build.json` so stale `dist/` artifacts can't
+  sneak into a release.
+
+### Fixed
+- Web: stopping a screen share that started from an audio-only session
+  no longer triggers a surprise `getUserMedia` camera prompt. The
+  engine now records whether a real camera track was live at the
+  moment the share started; if there wasn't one, `stopScreenShare`
+  swaps the display track out for null instead of acquiring a camera
+  the user never asked for.
+- Web: starting or stopping a screen share now broadcasts
+  `participant_media_state` to peers and rebuilds the local state
+  snapshot, so the remote tile and local UI flip immediately when an
+  audio-only host begins sharing instead of waiting for the next
+  unrelated media event.
+
 ## [0.6.10] — 2026-05-05
 
 ### Added

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.10"
+                version = "0.6.11"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -20,6 +20,7 @@ import app.serenada.core.SerenadaConfig
 import app.serenada.core.SerenadaCore
 import app.serenada.core.SerenadaSession
 import app.serenada.core.SerenadaTransport
+import app.serenada.core.call.CallPhase
 import org.webrtc.EglBase
 import org.webrtc.RendererCommon
 import org.webrtc.SurfaceViewRenderer
@@ -87,15 +88,18 @@ fun SerenadaCallFlow(
     val state by activeSession.state.collectAsState()
     val diagnostics by activeSession.diagnostics.collectAsState()
     var pendingPermissions by remember(activeSession) { mutableStateOf<List<app.serenada.core.MediaCapability>?>(null) }
+    var pendingPermissionPurpose by remember(activeSession) { mutableStateOf<PermissionRequestPurpose?>(null) }
     var hasStarted by remember(activeSession) { mutableStateOf(false) }
 
     val permissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
             val granted = result.values.all { it }
+            val purpose = pendingPermissionPurpose
             pendingPermissions = null
+            pendingPermissionPurpose = null
             if (granted) {
-                activeSession.resumeJoin()
-            } else {
+                purpose.applyGrant(activeSession)
+            } else if (purpose == PermissionRequestPurpose.Join) {
                 activeSession.cancelJoin()
             }
         }
@@ -104,6 +108,11 @@ fun SerenadaCallFlow(
         val previousHandler = activeSession.onPermissionsRequired
         if (previousHandler == null && activity != null) {
             activeSession.onPermissionsRequired = { permissions ->
+                pendingPermissionPurpose = if (activeSession.state.value.phase == CallPhase.AwaitingPermissions) {
+                    PermissionRequestPurpose.Join
+                } else {
+                    PermissionRequestPurpose.EnableVideo
+                }
                 pendingPermissions = permissions
             }
         }
@@ -115,14 +124,15 @@ fun SerenadaCallFlow(
     }
 
     LaunchedEffect(state.phase, state.requiredPermissions, activity, activeSession) {
-        if (state.phase == app.serenada.core.call.CallPhase.AwaitingPermissions &&
+        if (state.phase == CallPhase.AwaitingPermissions &&
             state.requiredPermissions.isNotEmpty() &&
             pendingPermissions == null &&
             activeSession.onPermissionsRequired == null
         ) {
+            pendingPermissionPurpose = PermissionRequestPurpose.Join
             pendingPermissions = state.requiredPermissions
         }
-        if (state.phase != app.serenada.core.call.CallPhase.Idle) {
+        if (state.phase != CallPhase.Idle) {
             hasStarted = true
         } else if (hasStarted) {
             onDismiss()
@@ -131,15 +141,20 @@ fun SerenadaCallFlow(
 
     LaunchedEffect(pendingPermissions, activity) {
         val requested = pendingPermissions ?: return@LaunchedEffect
+        val purpose = pendingPermissionPurpose
         val hostActivity = activity ?: run {
-            activeSession.cancelJoin()
+            if (purpose == PermissionRequestPurpose.Join) {
+                activeSession.cancelJoin()
+            }
             pendingPermissions = null
+            pendingPermissionPurpose = null
             return@LaunchedEffect
         }
         val androidPermissions = SerenadaPermissions.permissionsFor(requested)
-        if (androidPermissions.isEmpty() || SerenadaPermissions.areGranted(hostActivity)) {
+        if (androidPermissions.isEmpty() || SerenadaPermissions.areGranted(hostActivity, androidPermissions)) {
             pendingPermissions = null
-            activeSession.resumeJoin()
+            pendingPermissionPurpose = null
+            purpose.applyGrant(activeSession)
         } else {
             permissionLauncher.launch(androidPermissions)
         }
@@ -188,6 +203,19 @@ fun SerenadaCallFlow(
         detachRemoteSink = { sink -> activeSession.detachRemoteSink(sink) },
         onDismiss = onDismiss,
     )
+}
+
+private enum class PermissionRequestPurpose {
+    Join,
+    EnableVideo
+}
+
+private fun PermissionRequestPurpose?.applyGrant(session: SerenadaSession) {
+    when (this) {
+        PermissionRequestPurpose.Join -> session.resumeJoin()
+        PermissionRequestPurpose.EnableVideo -> session.toggleVideo()
+        null -> Unit
+    }
 }
 
 /**

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaPermissions.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaPermissions.kt
@@ -12,8 +12,8 @@ object SerenadaPermissions {
         Manifest.permission.RECORD_AUDIO
     )
 
-    fun areGranted(activity: Activity): Boolean {
-        return requiredPermissions.all {
+    fun areGranted(activity: Activity, permissions: Array<String> = requiredPermissions): Boolean {
+        return permissions.all {
             ContextCompat.checkSelfPermission(activity, it) == PackageManager.PERMISSION_GRANTED
         }
     }

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.10"
+val sdkVersion = "0.6.11"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -684,7 +684,12 @@ class SerenadaSession internal constructor(
     fun toggleVideo() {
         assertMainThread()
         if (!videoCaptureSupported) return
-        userPreferredVideoEnabled = !_state.value.localVideoEnabled
+        val requestedEnabled = !_state.value.localVideoEnabled
+        if (requestedEnabled && !hasCameraPermission() && !_diagnostics.value.isScreenSharing) {
+            requestPermissions(listOf(MediaCapability.CAMERA))
+            return
+        }
+        userPreferredVideoEnabled = requestedEnabled
         applyLocalVideoPreference()
         broadcastLocalMediaState()
     }
@@ -715,7 +720,10 @@ class SerenadaSession internal constructor(
     fun startScreenShare(intent: Intent) {
         assertMainThread()
         if (_diagnostics.value.isScreenSharing) return
+        val wasVideoPreferred = userPreferredVideoEnabled
+        userPreferredVideoEnabled = true
         if (!webRtcEngine.startScreenShare(intent)) {
+            userPreferredVideoEnabled = wasVideoPreferred
             logger?.log(SerenadaLogLevel.WARNING, "Session", "Failed to start screen sharing")
             return
         }
@@ -941,7 +949,7 @@ class SerenadaSession internal constructor(
 
         acquirePerformanceLocks()
         callAudioSessionController.activate()
-        webRtcEngine.startLocalMedia()
+        webRtcEngine.startLocalMedia(startVideoCapture = userPreferredVideoEnabled)
 
         if (!config.defaultAudioEnabled) webRtcEngine.toggleAudio(false)
         applyLocalVideoPreference()
@@ -953,11 +961,7 @@ class SerenadaSession internal constructor(
     internal fun startWithPermissionCheck() {
         assertMainThread()
         awaitingPermissions = true
-        val permissions = if (videoCaptureSupported) {
-            listOf(MediaCapability.CAMERA, MediaCapability.MICROPHONE)
-        } else {
-            listOf(MediaCapability.MICROPHONE)
-        }
+        val permissions = requiredPermissionsForJoin()
         updateState(
             _state.value.copy(
                 phase = CallPhase.AwaitingPermissions,
@@ -965,10 +969,7 @@ class SerenadaSession internal constructor(
                 requiredPermissions = permissions,
             )
         )
-        handler.post {
-            onPermissionsRequired?.invoke(permissions)
-                ?: delegate?.invoke()?.onPermissionsRequired(this, permissions)
-        }
+        requestPermissions(permissions)
     }
 
     // --- Internal: WebRTC Engine ---
@@ -1608,13 +1609,34 @@ class SerenadaSession internal constructor(
     }
 
     private fun hasRequiredPermissions(): Boolean {
-        val permissions = if (videoCaptureSupported) {
-            REQUIRED_ANDROID_PERMISSIONS
-        } else {
-            AUDIO_ONLY_REQUIRED_PERMISSIONS
-        }
-        return permissions.all { permission ->
+        return androidPermissionsFor(requiredPermissionsForJoin()).all { permission ->
             appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun hasCameraPermission(): Boolean =
+        appContext.checkSelfPermission(android.Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+
+    private fun requiredPermissionsForJoin(): List<MediaCapability> {
+        val permissions = mutableListOf(MediaCapability.MICROPHONE)
+        if (videoCaptureSupported && userPreferredVideoEnabled) {
+            permissions.add(MediaCapability.CAMERA)
+        }
+        return permissions
+    }
+
+    private fun androidPermissionsFor(capabilities: List<MediaCapability>): List<String> =
+        capabilities.map { capability ->
+            when (capability) {
+                MediaCapability.CAMERA -> android.Manifest.permission.CAMERA
+                MediaCapability.MICROPHONE -> android.Manifest.permission.RECORD_AUDIO
+            }
+        }
+
+    private fun requestPermissions(permissions: List<MediaCapability>) {
+        handler.post {
+            onPermissionsRequired?.invoke(permissions)
+                ?: delegate?.invoke()?.onPermissionsRequired(this, permissions)
         }
     }
 
@@ -1630,12 +1652,5 @@ class SerenadaSession internal constructor(
         // their own; longer is the OS window where Doze / process freeze may
         // have killed the WS.
         const val FOREGROUND_RESUME_MIN_BACKGROUND_MS = 5_000L
-        val REQUIRED_ANDROID_PERMISSIONS = arrayOf(
-            android.Manifest.permission.CAMERA,
-            android.Manifest.permission.RECORD_AUDIO,
-        )
-        val AUDIO_ONLY_REQUIRED_PERMISSIONS = arrayOf(
-            android.Manifest.permission.RECORD_AUDIO,
-        )
     }
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
@@ -10,7 +10,7 @@ import org.webrtc.VideoSink
 import org.webrtc.VideoTrack
 
 internal interface SessionMediaEngine {
-    fun startLocalMedia()
+    fun startLocalMedia(startVideoCapture: Boolean)
     fun release()
     fun toggleAudio(enabled: Boolean)
     fun toggleVideo(enabled: Boolean): Boolean

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -200,7 +200,7 @@ internal class WebRtcEngine(
         audioPipelinePrimer.collectAudioLevel(onComplete)
     }
 
-    override fun startLocalMedia() {
+    override fun startLocalMedia(startVideoCapture: Boolean) {
         if (released) return
         if (localAudioTrack != null || localVideoTrack != null) return
         cameraController.resetCameraState()
@@ -219,9 +219,13 @@ internal class WebRtcEngine(
 
         videoSource = peerConnectionFactory.createVideoSource(false)
         cameraController.resetCameraSourceToInitial()
-        val startedVideo = restartVideoCapturerWithFallback(cameraController.currentCameraSource)
+        val startedVideo = startVideoCapture && restartVideoCapturerWithFallback(cameraController.currentCameraSource)
         if (!startedVideo) {
-            logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "No camera capturer available; continuing audio-only")
+            if (startVideoCapture) {
+                logger?.log(SerenadaLogLevel.WARNING, "WebRTC", "No camera capturer available; continuing audio-only")
+            } else {
+                logger?.log(SerenadaLogLevel.INFO, "WebRTC", "Camera starts disabled; continuing audio-only")
+            }
         }
         localVideoTrack = peerConnectionFactory.createVideoTrack("ARDAMSv0", videoSource)
         localVideoTrack?.setEnabled(startedVideo)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
@@ -49,6 +49,69 @@ class SerenadaSessionContractTest {
         assertTrue(factory.session.state.value.requiredPermissions.isNotEmpty())
     }
 
+    @Test
+    fun `start with default video disabled requires microphone only`() {
+        factory.tearDown()
+        factory = TestSessionFactory(defaultVideoEnabled = false)
+
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(CallPhase.AwaitingPermissions, factory.session.state.value.phase)
+        assertEquals(listOf(MediaCapability.MICROPHONE), factory.session.state.value.requiredPermissions)
+    }
+
+    @Test
+    fun `start with default video disabled does not start camera capture`() {
+        factory.tearDown()
+        factory = TestSessionFactory(defaultVideoEnabled = false)
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(false, factory.fakeMedia.startVideoCaptureCalls.single())
+        assertFalse(factory.session.state.value.localVideoEnabled)
+    }
+
+    @Test
+    fun `turning video on without camera permission requests camera`() {
+        factory.tearDown()
+        factory = TestSessionFactory(defaultVideoEnabled = false)
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+
+        var requestedPermissions: List<MediaCapability>? = null
+        factory.session.onPermissionsRequired = { requestedPermissions = it }
+
+        factory.session.toggleVideo()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(listOf(MediaCapability.CAMERA), requestedPermissions)
+        assertTrue(factory.fakeMedia.toggleVideoCalls.none { it })
+        assertFalse(factory.session.state.value.localVideoEnabled)
+    }
+
+    @Test
+    fun `turning video on after camera permission enables camera`() {
+        factory.tearDown()
+        factory = TestSessionFactory(defaultVideoEnabled = false)
+        val shadowApp = Shadows.shadowOf(RuntimeEnvironment.getApplication())
+        shadowApp.grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+        shadowApp.grantPermissions(android.Manifest.permission.CAMERA)
+
+        factory.session.toggleVideo()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(true, factory.fakeMedia.toggleVideoCalls.last())
+        assertTrue(factory.session.state.value.localVideoEnabled)
+    }
+
     // ── Join → Joined → Waiting ─────────────────────────────────────
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -26,7 +26,12 @@ internal class FakeMediaEngine : SessionMediaEngine {
 
     private var _iceServers: List<PeerConnection.IceServer>? = null
 
-    override fun startLocalMedia() { startLocalMediaCalls++ }
+    val startVideoCaptureCalls = mutableListOf<Boolean>()
+
+    override fun startLocalMedia(startVideoCapture: Boolean) {
+        startLocalMediaCalls++
+        startVideoCaptureCalls.add(startVideoCapture)
+    }
     override fun release() { releaseCalls++ }
     override fun toggleAudio(enabled: Boolean) { toggleAudioCalls.add(enabled) }
     override fun toggleVideo(enabled: Boolean): Boolean {

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
@@ -18,6 +18,7 @@ internal class FakeSessionClock(private var currentTimeMs: Long = 0L) : SessionC
 internal class TestSessionFactory(
     val roomId: String = "test-room-id",
     val handlesReconnection: Boolean = false,
+    defaultVideoEnabled: Boolean = true,
     config: SerenadaConfig? = null,
 ) {
     val fakeProvider = FakeSignalingProvider(handlesReconnection = handlesReconnection)
@@ -28,7 +29,10 @@ internal class TestSessionFactory(
     val session: SerenadaSession = SerenadaSession(
         roomId = roomId,
         roomUrl = null,
-        config = config ?: SerenadaConfig(signalingProvider = fakeProvider),
+        config = config ?: SerenadaConfig(
+            signalingProvider = fakeProvider,
+            defaultVideoEnabled = defaultVideoEnabled,
+        ),
         context = RuntimeEnvironment.getApplication(),
         delegate = null,
         okHttpClient = OkHttpClient(),

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.10"
+val sdkVersion = "0.6.11"
 val webRtcArtifactId = "libwebrtc-7559_173-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -38,7 +38,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.10"
+    public static let version = "0.6.11"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.6.10",
-        "@agatx/serenada-react-ui": "0.6.10",
+        "@agatx/serenada-core": "0.6.11",
+        "@agatx/serenada-react-ui": "0.6.11",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.6.10"
+        "@agatx/serenada-core": "0.6.11"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.6.10",
+        "@agatx/serenada-core": "^0.6.11",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.6.10",
-    "@agatx/serenada-react-ui": "0.6.10",
+    "@agatx/serenada-core": "0.6.11",
+    "@agatx/serenada-react-ui": "0.6.11",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -454,12 +454,22 @@ export class SerenadaSession implements SerenadaSessionHandle {
 
     /** Start sharing the screen, replacing the camera video track. */
     async startScreenShare(): Promise<void> {
+        const wasScreenSharing = this.media.isScreenSharing;
         await this.media.startScreenShare();
+        if (!this.isInactive && !wasScreenSharing && this.media.isScreenSharing) {
+            this.broadcastLocalMediaState();
+            this.rebuildState();
+        }
     }
 
     /** Stop screen sharing and restore the camera video track. */
     async stopScreenShare(): Promise<void> {
+        const wasScreenSharing = this.media.isScreenSharing;
         await this.media.stopScreenShare();
+        if (!this.isInactive && wasScreenSharing && !this.media.isScreenSharing) {
+            this.broadcastLocalMediaState();
+            this.rebuildState();
+        }
     }
 
     /** Clean up all resources. Call when done with the session. */

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.10';
+export const SERENADA_CORE_VERSION = '0.6.11';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -69,6 +69,7 @@ export class MediaEngine {
     private lastInboundBytesByCid = new Map<string, number>();
     private rtcConfig: RTCConfiguration = DEFAULT_RTC_CONFIG;
     private screenShareTrack: MediaStreamTrack | null = null;
+    private screenShareRestoreVideoEnabled: boolean | null = null;
     private requestingMedia = false;
     private destroyed = false;
     private cameraRecoveryInFlight = false;
@@ -277,6 +278,7 @@ export class MediaEngine {
             this.screenShareTrack.onended = null;
             this.screenShareTrack = null;
         }
+        this.screenShareRestoreVideoEnabled = null;
         if (this.localStream) {
             this.localStream.getTracks().forEach(t => t.stop());
             this.localStream = null;
@@ -322,8 +324,8 @@ export class MediaEngine {
             }
 
             const previousVideoTrack = this.localStream.getVideoTracks()[0];
-            const wasVideoEnabled = previousVideoTrack ? previousVideoTrack.enabled : true;
-            displayTrack.enabled = wasVideoEnabled;
+            this.screenShareRestoreVideoEnabled = previousVideoTrack ? previousVideoTrack.enabled : null;
+            displayTrack.enabled = true;
             if ('contentHint' in displayTrack) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- contentHint is a valid but untyped browser API
                 try { (displayTrack as any).contentHint = 'detail'; } catch { /* ignore */ }
@@ -338,6 +340,7 @@ export class MediaEngine {
             this.sendSignalingMessage('content_state', { active: true, contentType: 'screenShare' });
             this.notifyChange();
         } catch (err) {
+            this.screenShareRestoreVideoEnabled = null;
             this.logger?.log('error', 'ScreenShare', `Failed to start screen share: ${formatError(err)}`);
         }
     }
@@ -346,6 +349,7 @@ export class MediaEngine {
         if (!this.isScreenSharing) return;
         if (!this.localStream) {
             this.isScreenSharing = false;
+            this.screenShareRestoreVideoEnabled = null;
             this.sendSignalingMessage('content_state', { active: false });
             this.notifyChange();
             return;
@@ -357,16 +361,21 @@ export class MediaEngine {
         }
 
         const previousVideoTrack = this.localStream.getVideoTracks()[0];
-        const wasVideoEnabled = previousVideoTrack ? previousVideoTrack.enabled : true;
+        const restoreVideoEnabled = this.screenShareRestoreVideoEnabled;
 
         try {
-            const cameraTrack = await this.acquireCameraTrack(this.facingMode, wasVideoEnabled);
-            await this.swapLocalVideoTrack(cameraTrack, previousVideoTrack);
+            if (restoreVideoEnabled === null) {
+                await this.swapLocalVideoTrack(null, previousVideoTrack);
+            } else {
+                const cameraTrack = await this.acquireCameraTrack(this.facingMode, restoreVideoEnabled);
+                await this.swapLocalVideoTrack(cameraTrack, previousVideoTrack);
+            }
         } catch (err) {
             this.logger?.log('error', 'ScreenShare', `Failed to stop screen share and restore camera: ${formatError(err)}`);
             await this.swapLocalVideoTrack(null, previousVideoTrack);
         } finally {
             this.isScreenSharing = false;
+            this.screenShareRestoreVideoEnabled = null;
             this.sendSignalingMessage('content_state', { active: false });
             this.notifyChange();
         }

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -33,6 +33,23 @@ if (typeof globalThis.navigator === 'undefined') {
 describe('SerenadaSession', () => {
     let harness: TestSessionHarness;
 
+    function createMediaTrack(kind: 'audio' | 'video', enabled = true): MediaStreamTrack {
+        return {
+            enabled,
+            kind,
+            stop() {},
+        } as MediaStreamTrack;
+    }
+
+    function createMediaStream(options: { audio?: boolean; video?: boolean } = { audio: true }): MediaStream {
+        const audioTrack = options.audio !== false ? createMediaTrack('audio') : undefined;
+        const videoTrack = options.video ? createMediaTrack('video') : undefined;
+        return {
+            getAudioTracks: () => audioTrack ? [audioTrack] : [],
+            getVideoTracks: () => videoTrack ? [videoTrack] : [],
+        } as unknown as MediaStream;
+    }
+
     function expectTerminalTeardown(expectedPhase: 'ending' | 'error' | 'idle'): void {
         expect(harness.state.phase).toBe(expectedPhase);
         expect(harness.state.localParticipant).toBeNull();
@@ -1262,6 +1279,54 @@ describe('SerenadaSession', () => {
                 'error',
                 'Session',
                 'onPeerMessage listener failed for offer: listener failed',
+            );
+        });
+
+        it('broadcasts local media state after screen share starts from audio-only media', async () => {
+            harness = new TestSessionHarness({
+                config: { defaultVideoEnabled: false },
+            });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-1' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.signaling.broadcastCalls.length = 0;
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = true;
+                harness.media.localStream = createMediaStream({ audio: true, video: true });
+            });
+
+            await harness.session.startScreenShare();
+
+            expect(harness.media.startScreenShare).toHaveBeenCalledTimes(1);
+            expect(harness.signaling.broadcastCalls).toContainEqual({
+                type: 'participant_media_state',
+                payload: {
+                    audioEnabled: true,
+                    videoEnabled: true,
+                },
+            });
+            expect(harness.state.localParticipant?.videoEnabled).toBe(true);
+        });
+
+        it('does not rebroadcast local media state when screen share start is a no-op', async () => {
+            harness = new TestSessionHarness();
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.signaling.broadcastCalls.length = 0;
+            harness.media.startScreenShare = vi.fn(async () => {
+                // MediaEngine returns without changing isScreenSharing when
+                // screen sharing is unavailable or already inactive.
+            });
+
+            await harness.session.startScreenShare();
+
+            expect(harness.media.startScreenShare).toHaveBeenCalledTimes(1);
+            expect(harness.signaling.broadcastCalls).not.toContainEqual(
+                expect.objectContaining({ type: 'participant_media_state' }),
             );
         });
     });

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -310,6 +310,85 @@ describe('MediaEngine', () => {
         expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
     });
 
+    it('does not restore camera after stopping screen share that started from audio-only media', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream());
+        const getDisplayMedia = vi.fn().mockResolvedValue(createMediaStream({ audio: false, video: true }));
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    getDisplayMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+        await engine.startLocalMedia();
+        const peer = engine.getPeerConnectionsMap().get('zeta') as FakeRtcPeerConnection | undefined;
+
+        await engine.startScreenShare();
+        expect(engine.localStream?.getVideoTracks()).toHaveLength(1);
+        expect(peer?.senders.map(sender => sender.track?.kind)).toEqual(['audio', 'video']);
+
+        await engine.stopScreenShare();
+
+        expect(getUserMedia).toHaveBeenCalledTimes(1);
+        expect(getDisplayMedia).toHaveBeenCalledWith({ video: true, audio: false });
+        expect(engine.localStream?.getVideoTracks()).toHaveLength(0);
+        expect(peer?.senders.map(sender => sender.track?.kind)).toEqual(['audio', undefined]);
+        expect(sentMessages).toContainEqual({
+            type: 'content_state',
+            payload: { active: false },
+            to: undefined,
+        });
+    });
+
+    it('restores camera after stopping screen share that started with camera video', async () => {
+        const getUserMedia = vi.fn().mockImplementation(async (constraints: MediaStreamConstraints) => {
+            if (constraints.video) {
+                return createMediaStream({ audio: constraints.audio !== false, video: true });
+            }
+            return createMediaStream();
+        });
+        const getDisplayMedia = vi.fn().mockResolvedValue(createMediaStream({ audio: false, video: true }));
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    getDisplayMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({}, () => {});
+
+        await engine.startLocalMedia();
+        await engine.startScreenShare();
+        await engine.stopScreenShare();
+
+        expect(getUserMedia).toHaveBeenLastCalledWith({
+            video: { facingMode: 'user' },
+            audio: false,
+        });
+        expect(engine.localStream?.getVideoTracks()).toHaveLength(1);
+        expect(engine.localStream?.getVideoTracks()[0]?.enabled).toBe(true);
+    });
+
     it('retries non-host fallback offers after the offer timeout elapses', async () => {
         vi.useFakeTimers();
 

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.6.10",
+    "@agatx/serenada-core": "^0.6.11",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.6.10"
+    "@agatx/serenada-core": "0.6.11"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -30,8 +30,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.10")
-    implementation("app.serenada:call-ui:0.6.10")
+    implementation("app.serenada:core:0.6.11")
+    implementation("app.serenada:call-ui:0.6.11")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.6.10 @agatx/serenada-react-ui@0.6.10 lucide-react
+npm install @agatx/serenada-core@0.6.11 @agatx/serenada-react-ui@0.6.11 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.6.10"
+        "@agatx/serenada-core": "0.6.11"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.6.10",
+        "@agatx/serenada-core": "^0.6.11",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Three things ship in 0.6.11:

### 1. Android: permission-aware video toggle + audio-only join

Brings Android to parity with iOS 0.6.9 (`SerenadaConfig.allowAudioOnlyJoin`) and the React UI 0.6.10 in-call permission request:

- `SerenadaSession.startWithPermissionCheck` only requests `CAMERA` when `userPreferredVideoEnabled` is true — sessions opened with `defaultVideoEnabled = false` (or video toggled off pre-join) no longer block on a denied camera grant. Mic is still required.
- `SerenadaSession.toggleVideo`, when flipping video on, checks for the Android `CAMERA` permission and routes through the standard `onPermissionsRequired` delegate when missing. Screen-share callers bypass the check (system-level capture).
- `WebRtcEngine.startLocalMedia(startVideoCapture)` now skips the camera capturer when starting audio-only.
- `SerenadaCallFlow` tracks the purpose of each permission request (`Join` vs `EnableVideo`) and routes the grant to `resumeJoin()` or `toggleVideo()`. Denying mid-call no longer cancels the session, only the toggle.
- `SerenadaPermissions.areGranted(activity, permissions)` accepts a custom permission list so the call-ui asks exactly what the SDK requested.

Tests in `SerenadaSessionContractTest` cover audio-only join, toggle requesting `CAMERA`, and toggle proceeding once `CAMERA` is granted.

### 2. Web: screen-share fixes for audio-only sessions

- `MediaEngine` now records whether a real camera track was live when a share started. If it wasn't (audio-only join, or video toggled off), `stopScreenShare` swaps the display track out for null instead of acquiring a camera the user never asked for. Eliminates the surprise `getUserMedia` prompt at the end of every share for audio-only callers.
- `SerenadaSession` broadcasts `participant_media_state` and rebuilds local state when the screen-share flag actually toggles, so remote peers see the local video flip on/off and the local UI reflects the change immediately.

Tests in `MediaEngine.test` and `SerenadaSession.test` cover both the no-restore-from-audio-only and the broadcast-on-toggle behaviors.

### 3. First public registry release

- Web npm packages renamed `@serenada/*` → `@agatx/serenada-*` (matches the GitHub org, removes the unscoped-namespace conflict that blocked publishing).
- New `Publish web packages` GitHub Actions workflow fires on `web-release-*` tags and publishes to public npm (`registry.npmjs.org`); GitHub Packages remains as a mirror.
- `npm run clean` runs before `tsc -p tsconfig.build.json` so stale `dist/` artifacts can't leak into a release.

**Web breaking import change** — consumers upgrading from 0.6.10:

```diff
- import { SerenadaCore } from '@serenada/core'
- import { SerenadaCallFlow } from '@serenada/react-ui'
+ import { SerenadaCore } from '@agatx/serenada-core'
+ import { SerenadaCallFlow } from '@agatx/serenada-react-ui'
```

Android (`app.serenada:core` / `app.serenada:call-ui`) and iOS (SPM path) artifact names are **unchanged**.

## Commits

1. `74be358` Android: permission-aware video toggle + audio-only join
2. `26a78b5` Web: don't restore camera on screen-share stop when joined audio-only
3. `b7b581d` v0.6.11: bump SDK version + CHANGELOG (8 source-of-truth files, lock files, samples, integration docs)

`node scripts/check-version-parity.mjs` → `OK: All 8 version sources match at 0.6.11.`

## Test plan

- [x] `node scripts/check-version-parity.mjs` passes
- [ ] Android: `./gradlew :serenada-core:testDebugUnitTest` (audio-only join + toggle permission tests)
- [ ] Android manual: join with `defaultVideoEnabled=false`, deny camera at OS prompt, call should still connect audio-only; mid-call tap video toggle, OS prompt fires, grant → video turns on
- [ ] Web: `npm run test` (MediaEngine + SerenadaSession new cases)
- [ ] Web manual: audio-only join → start screen share → stop share. No camera prompt at stop. Remote peer sees `videoEnabled=true` while sharing.
- [ ] After merge: tag `web-release-0.6.11` → workflow publishes to npm
- [ ] `npm install @agatx/serenada-core@0.6.11 @agatx/serenada-react-ui@0.6.11` resolves cleanly in a fresh project

🤖 Generated with [Claude Code](https://claude.com/claude-code)