### PR TITLE
fix: drop broken npm@^11.5.1 upgrade step in publish workflow

### DIFF
--- a/.github/workflows/publish-web-packages.yml
+++ b/.github/workflows/publish-web-packages.yml
@@ -37,9 +37,6 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
 
-      - name: Use npm 11
-        run: npm install -g npm@^11.5.1
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

The `Use npm 11` step (`npm install -g npm@^11.5.1`) is failing every web-release-* tag run. Node 22.22.2's bundled npm crashes during the self-upgrade with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
…
```

Both the original v0.6.11 run and the rerun failed here. 0.6.11 is on the merged commit, the tag is in place, but npm latest is still 0.6.10.

Node 22 already ships with npm 10.9.x, which supports `npm publish`, workspaces, scoped registries, and OIDC provenance — everything the workflow needs. The upgrade step was buying nothing, so dropping it.

## After merge

Force-update `web-release-0.6.11` to the new HEAD on main and re-push to retrigger the workflow:

```bash
git tag -f web-release-0.6.11 <new-main-head>
git push origin web-release-0.6.11 --force
```

## Test plan

- [x] Diff is a single 3-line removal in `.github/workflows/publish-web-packages.yml`
- [ ] After merge + retag: workflow run reaches `Publish packages` and pushes 0.6.11 to npm
- [ ] `npm view @agatx/serenada-core@0.6.11 version` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)