### PR TITLE
[codex] Fix Android Dokka docs generation

### DIFF
--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.dokka.gradle.DokkaTask
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.plugin.compose")
@@ -40,6 +42,12 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.2")
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("com.google.zxing:core:3.5.3")
+}
+
+tasks.withType<DokkaTask>().configureEach {
+    dokkaSourceSets.maybeCreate("main").apply {
+        sourceRoots.from(file("src/main/java"))
+    }
 }
 
 afterEvaluate {

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.io.File
 import java.security.MessageDigest
 import groovy.util.Node
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
 
 plugins {
@@ -120,6 +121,12 @@ dependencies {
 
 tasks.withType<GenerateModuleMetadata>().matching { it.name == "generateMetadataFileForReleasePublication" }.configureEach {
     enabled = false
+}
+
+tasks.withType<DokkaTask>().configureEach {
+    dokkaSourceSets.maybeCreate("main").apply {
+        sourceRoots.from(file("src/main/java"))
+    }
 }
 
 afterEvaluate {


### PR DESCRIPTION
## Summary
- Configure Dokka source roots explicitly for `serenada-core` and `serenada-call-ui` after the AGP 9 built-in Kotlin migration.
- Restore non-empty Android Dokka HTML output under the paths uploaded by the docs workflow.

## Validation
- `./gradlew :serenada-core:dokkaHtml :serenada-call-ui:dokkaHtml --no-daemon --rerun-tasks --console=plain`
- Verified generated files under `client-android/serenada-core/build/dokka/html/` and `client-android/serenada-call-ui/build/dokka/html/`
- `./gradlew test --console=plain` in `client-android`
- `git diff --check`
- `node scripts/check-version-parity.mjs`