### PR TITLE
Android: Guard peer teardown against WebRTC crashes

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -1,5 +1,7 @@
 package app.serenada.core.call
 
+import android.os.Handler
+import android.os.Looper
 import app.serenada.core.SerenadaLogLevel
 import app.serenada.core.SerenadaLogger
 import org.webrtc.AudioTrack
@@ -35,6 +37,10 @@ internal class PeerConnectionSlot(
     private val isRemoteBlackFrameAnalysisEnabled: () -> Boolean,
     private val logger: SerenadaLogger? = null,
 ) : PeerConnectionSlotProtocol {
+    private companion object {
+        const val DEFERRED_DISPOSE_DELAY_MS = 250L
+    }
+
     private data class MediaTotals(
         var inboundPacketsReceived: Long = 0L,
         var inboundPacketsLost: Long = 0L,
@@ -119,6 +125,8 @@ internal class PeerConnectionSlot(
     override fun clearNonHostFallbackTask() { nonHostFallbackTask = null }
     override fun incrementNonHostFallbackAttempts() { nonHostFallbackAttempts++ }
 
+    private val disposeHandler = Handler(Looper.getMainLooper())
+    @Volatile private var isClosing = false
     private var peerConnection: PeerConnection? = null
     private var remoteVideoTrack: VideoTrack? = null
     private var remoteDescriptionSet = false
@@ -130,16 +138,18 @@ internal class PeerConnectionSlot(
     private val freezeSamples = mutableListOf<FreezeSample>()
     private val remoteBlackFrameAnalyzer = RemoteBlackFrameAnalyzer()
     private val remoteVideoStateSink = VideoSink { frame ->
-        val stateChanged = remoteBlackFrameAnalyzer.onFrame(
-            frame = frame,
-            blackFrameAnalysisEnabled = isRemoteBlackFrameAnalysisEnabled()
-        )
-        if (stateChanged) {
-            logger?.log(
-                SerenadaLogLevel.DEBUG,
-                "PeerConnection",
-                "[RemoteVideo][$remoteCid] syntheticBlack=${remoteBlackFrameAnalyzer.isSyntheticBlackDetected()} trackEnabled=${remoteVideoTrack?.enabled()}"
+        if (!isClosing) {
+            val stateChanged = remoteBlackFrameAnalyzer.onFrame(
+                frame = frame,
+                blackFrameAnalysisEnabled = isRemoteBlackFrameAnalysisEnabled()
             )
+            if (stateChanged) {
+                logger?.log(
+                    SerenadaLogLevel.DEBUG,
+                    "PeerConnection",
+                    "[RemoteVideo][$remoteCid] syntheticBlack=${remoteBlackFrameAnalyzer.isSyntheticBlackDetected()} trackEnabled=${remoteVideoTrack?.enabled()}"
+                )
+            }
         }
     }
 
@@ -149,23 +159,28 @@ internal class PeerConnectionSlot(
     }
 
     override fun ensurePeerConnection(): Boolean {
+        if (isClosing) return false
         if (peerConnection != null) return true
         val f = factory ?: return false
         val servers = iceServers ?: return false
         val config = PeerConnection.RTCConfiguration(servers).apply {
             sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
         }
+        var observerPeerConnection: PeerConnection? = null
         val pc = f.createPeerConnection(config, object : PeerConnection.Observer {
             override fun onIceCandidate(candidate: IceCandidate) {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 onLocalIceCandidate(remoteCid, candidate)
             }
 
             override fun onConnectionChange(newState: PeerConnection.PeerConnectionState) {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] Connection state: $newState")
                 onConnectionStateChange(remoteCid, newState)
             }
 
             override fun onTrack(transceiver: RtpTransceiver?) {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 val track = transceiver?.receiver?.track()
                 if (track is VideoTrack) {
                     remoteVideoTrack?.removeSink(remoteVideoStateSink)
@@ -179,16 +194,19 @@ internal class PeerConnectionSlot(
             }
 
             override fun onSignalingChange(newState: PeerConnection.SignalingState) {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] Signaling state: $newState")
                 onSignalingStateChange(remoteCid, newState)
             }
 
             override fun onIceConnectionChange(newState: PeerConnection.IceConnectionState) {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 logger?.log(SerenadaLogLevel.DEBUG, "PeerConnection", "[$remoteCid] ICE state: $newState")
                 onIceConnectionStateChange(remoteCid, newState)
             }
 
             override fun onRenegotiationNeeded() {
+                if (!isCurrentPeerConnection(observerPeerConnection)) return
                 onRenegotiationNeeded(remoteCid)
             }
 
@@ -200,6 +218,7 @@ internal class PeerConnectionSlot(
             override fun onDataChannel(dc: org.webrtc.DataChannel) = Unit
         }) ?: return false
 
+        observerPeerConnection = pc
         peerConnection = pc
         attachLocalTracks(localAudioTrack, localVideoTrack)
         ensureReceiveTransceivers(pc)
@@ -209,6 +228,7 @@ internal class PeerConnectionSlot(
     }
 
     override fun attachLocalTracks(audioTrack: AudioTrack?, videoTrack: VideoTrack?) {
+        if (isClosing) return
         localAudioTrack = audioTrack
         localVideoTrack = videoTrack
         val pc = peerConnection ?: run {
@@ -226,15 +246,19 @@ internal class PeerConnectionSlot(
         }
     }
 
-    override fun closePeerConnection() {
+    override fun closePeerConnection(deferDispose: Boolean) {
+        if (isClosing && peerConnection == null) return
+        isClosing = true
         offerTimeoutTask = null
         iceRestartTask = null
         nonHostFallbackTask = null
-        peerConnection?.close()
-        peerConnection?.dispose()
+        isMakingOffer = false
+        pendingIceRestart = false
+        val pc = peerConnection
         peerConnection = null
-        remoteVideoTrack?.removeSink(remoteVideoStateSink)
-        remoteSinks.forEach { sink -> remoteVideoTrack?.removeSink(sink) }
+        val track = remoteVideoTrack
+        track?.removeSink(remoteVideoStateSink)
+        remoteSinks.forEach { sink -> track?.removeSink(sink) }
         remoteSinks.clear()
         remoteVideoTrack = null
         remoteBlackFrameAnalyzer.onTrackDetached()
@@ -243,6 +267,10 @@ internal class PeerConnectionSlot(
         lastRealtimeStatsSample = null
         freezeSamples.clear()
         onRemoteVideoTrack(remoteCid, null)
+        pc?.let {
+            closePeerConnectionSafely(it)
+            disposePeerConnectionSafely(it, deferDispose)
+        }
     }
 
     override fun createOffer(
@@ -250,6 +278,7 @@ internal class PeerConnectionSlot(
         onSdp: (String) -> Unit,
         onComplete: ((Boolean) -> Unit)?,
     ): Boolean {
+        if (isClosing) return false
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) return false
             peerConnection
@@ -265,17 +294,20 @@ internal class PeerConnectionSlot(
         }
         pc.createOffer(object : SdpObserverAdapter() {
             override fun onCreateSuccess(desc: SessionDescription?) {
+                if (!isCurrentPeerConnection(pc)) return
                 if (desc == null) {
                     onComplete?.invoke(false)
                     return
                 }
                 pc.setLocalDescription(object : SdpObserverAdapter() {
                     override fun onSetSuccess() {
+                        if (!isCurrentPeerConnection(pc)) return
                         onSdp(desc.description)
                         onComplete?.invoke(true)
                     }
 
                     override fun onSetFailure(error: String?) {
+                        if (!isCurrentPeerConnection(pc)) return
                         logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set local offer: $error")
                         onComplete?.invoke(false)
                     }
@@ -283,6 +315,7 @@ internal class PeerConnectionSlot(
             }
 
             override fun onCreateFailure(error: String?) {
+                if (!isCurrentPeerConnection(pc)) return
                 logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Offer creation failed: $error")
                 onComplete?.invoke(false)
             }
@@ -291,6 +324,10 @@ internal class PeerConnectionSlot(
     }
 
     override fun createAnswer(onSdp: (String) -> Unit, onComplete: ((Boolean) -> Unit)?) {
+        if (isClosing) {
+            onComplete?.invoke(false)
+            return
+        }
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) {
                 onComplete?.invoke(false)
@@ -305,17 +342,20 @@ internal class PeerConnectionSlot(
         val constraints = MediaConstraints()
         pc.createAnswer(object : SdpObserverAdapter() {
             override fun onCreateSuccess(desc: SessionDescription?) {
+                if (!isCurrentPeerConnection(pc)) return
                 if (desc == null) {
                     onComplete?.invoke(false)
                     return
                 }
                 pc.setLocalDescription(object : SdpObserverAdapter() {
                     override fun onSetSuccess() {
+                        if (!isCurrentPeerConnection(pc)) return
                         onSdp(desc.description)
                         onComplete?.invoke(true)
                     }
 
                     override fun onSetFailure(error: String?) {
+                        if (!isCurrentPeerConnection(pc)) return
                         logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set local answer: $error")
                         onComplete?.invoke(false)
                     }
@@ -323,6 +363,7 @@ internal class PeerConnectionSlot(
             }
 
             override fun onCreateFailure(error: String?) {
+                if (!isCurrentPeerConnection(pc)) return
                 logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Answer creation failed: $error")
                 onComplete?.invoke(false)
             }
@@ -334,6 +375,7 @@ internal class PeerConnectionSlot(
         sdp: String,
         onComplete: (() -> Unit)?,
     ) {
+        if (isClosing) return
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) return
             peerConnection
@@ -341,18 +383,21 @@ internal class PeerConnectionSlot(
         val desc = SessionDescription(type, sdp)
         pc.setRemoteDescription(object : SdpObserverAdapter() {
             override fun onSetSuccess() {
+                if (!isCurrentPeerConnection(pc)) return
                 remoteDescriptionSet = true
                 flushPendingIceCandidates()
                 onComplete?.invoke()
             }
 
             override fun onSetFailure(error: String?) {
+                if (!isCurrentPeerConnection(pc)) return
                 logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to set remote description ($type): $error")
             }
         }, desc)
     }
 
     override fun addIceCandidate(candidate: IceCandidate) {
+        if (isClosing) return
         val safeCandidate = sanitizeIceCandidate(candidate, remoteCid, logger) ?: return
         val pc = peerConnection ?: run {
             if (!ensurePeerConnection()) {
@@ -374,14 +419,20 @@ internal class PeerConnectionSlot(
     }
 
     override fun rollbackLocalDescription(onComplete: ((Boolean) -> Unit)?) {
+        if (isClosing) {
+            onComplete?.invoke(false)
+            return
+        }
         val pc = peerConnection ?: return
         val desc = SessionDescription(SessionDescription.Type.ROLLBACK, "")
         pc.setLocalDescription(object : SdpObserverAdapter() {
             override fun onSetSuccess() {
+                if (!isCurrentPeerConnection(pc)) return
                 onComplete?.invoke(true)
             }
 
             override fun onSetFailure(error: String?) {
+                if (!isCurrentPeerConnection(pc)) return
                 logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to rollback local description: $error")
                 onComplete?.invoke(false)
             }
@@ -397,6 +448,7 @@ internal class PeerConnectionSlot(
     }
 
     override fun attachRemoteSink(sink: VideoSink) {
+        if (isClosing) return
         if (!remoteSinks.add(sink)) return
         remoteVideoTrack?.addSink(sink)
     }
@@ -407,6 +459,10 @@ internal class PeerConnectionSlot(
     }
 
     override fun collectWebRtcStats(onComplete: (String, RealtimeCallStats?) -> Unit) {
+        if (isClosing) {
+            onComplete("pc=closing remote=$remoteCid", null)
+            return
+        }
         val pc = peerConnection
         if (pc == null) {
             onComplete("pc=none remote=$remoteCid", null)
@@ -421,6 +477,10 @@ internal class PeerConnectionSlot(
     }
 
     override fun collectInboundBytes(onComplete: (Long) -> Unit) {
+        if (isClosing) {
+            onComplete(0L)
+            return
+        }
         val pc = peerConnection
         if (pc == null) {
             onComplete(0L)
@@ -437,6 +497,10 @@ internal class PeerConnectionSlot(
     }
 
     override fun collectAudioLevels(onComplete: (inboundLevel: Float?, mediaSourceLevel: Float?) -> Unit) {
+        if (isClosing) {
+            onComplete(null, null)
+            return
+        }
         val pc = peerConnection
         if (pc == null) {
             onComplete(null, null)
@@ -459,20 +523,20 @@ internal class PeerConnectionSlot(
         }
     }
 
-    override fun isReady(): Boolean = peerConnection != null
+    override fun isReady(): Boolean = !isClosing && peerConnection != null
 
     override fun isPathDirect(): Boolean? = lastPathIsDirect
 
     override fun getConnectionState(): PeerConnection.PeerConnectionState =
-        peerConnection?.connectionState() ?: PeerConnection.PeerConnectionState.NEW
+        if (isClosing) PeerConnection.PeerConnectionState.CLOSED else peerConnection?.connectionState() ?: PeerConnection.PeerConnectionState.NEW
 
     override fun getIceConnectionState(): PeerConnection.IceConnectionState =
-        peerConnection?.iceConnectionState() ?: PeerConnection.IceConnectionState.NEW
+        if (isClosing) PeerConnection.IceConnectionState.CLOSED else peerConnection?.iceConnectionState() ?: PeerConnection.IceConnectionState.NEW
 
     override fun getSignalingState(): PeerConnection.SignalingState =
-        peerConnection?.signalingState() ?: PeerConnection.SignalingState.STABLE
+        if (isClosing) PeerConnection.SignalingState.CLOSED else peerConnection?.signalingState() ?: PeerConnection.SignalingState.STABLE
 
-    override fun hasRemoteDescription(): Boolean = remoteDescriptionSet || peerConnection?.remoteDescription != null
+    override fun hasRemoteDescription(): Boolean = !isClosing && (remoteDescriptionSet || peerConnection?.remoteDescription != null)
 
     override fun isRemoteVideoTrackEnabled(): Boolean {
         val track = remoteVideoTrack ?: return false
@@ -481,6 +545,7 @@ internal class PeerConnectionSlot(
     }
 
     override fun applyVideoSenderParameters(policy: WebRtcEngine.VideoSenderPolicy) {
+        if (isClosing) return
         val pc = peerConnection ?: return
         val sender = pc.senders.firstOrNull { it.track()?.kind() == MediaStreamTrack.VIDEO_TRACK_KIND } ?: return
         try {
@@ -494,6 +559,38 @@ internal class PeerConnectionSlot(
             sender.setParameters(params)
         } catch (e: Exception) {
             logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to apply video sender parameters: ${e.message}")
+        }
+    }
+
+    private fun isCurrentPeerConnection(pc: PeerConnection?): Boolean =
+        !isClosing && pc != null && peerConnection === pc
+
+    private fun closePeerConnectionSafely(pc: PeerConnection) {
+        runCatching { pc.close() }
+            .onFailure { error ->
+                logger?.log(
+                    SerenadaLogLevel.WARNING,
+                    "PeerConnection",
+                    "[$remoteCid] Failed to close peer connection: ${error.message}",
+                )
+            }
+    }
+
+    private fun disposePeerConnectionSafely(pc: PeerConnection, deferDispose: Boolean) {
+        val dispose = Runnable {
+            runCatching { pc.dispose() }
+                .onFailure { error ->
+                    logger?.log(
+                        SerenadaLogLevel.WARNING,
+                        "PeerConnection",
+                        "[$remoteCid] Failed to dispose peer connection: ${error.message}",
+                    )
+                }
+        }
+        if (deferDispose) {
+            disposeHandler.postDelayed(dispose, DEFERRED_DISPOSE_DELAY_MS)
+        } else {
+            dispose.run()
         }
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlotProtocol.kt
@@ -44,7 +44,7 @@ internal interface PeerConnectionSlotProtocol {
     fun setIceServers(servers: List<PeerConnection.IceServer>)
     fun ensurePeerConnection(): Boolean
     fun attachLocalTracks(audioTrack: AudioTrack?, videoTrack: VideoTrack?)
-    fun closePeerConnection()
+    fun closePeerConnection(deferDispose: Boolean = false)
     fun createOffer(
         iceRestart: Boolean = false,
         onSdp: (String) -> Unit,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -94,6 +94,13 @@ internal class PeerNegotiationEngine(
 
     fun processSignalingPayload(msg: SignalingMessage) {
         val fromCid = msg.payload?.optString("from").orEmpty().ifBlank { return }
+        val roomState = getCurrentRoomState()
+        val localCid = getClientId()
+        if (fromCid == localCid) return
+        if (roomState != null && roomState.participants.none { it.cid == fromCid }) {
+            logger?.log(SerenadaLogLevel.DEBUG, TAG, "Ignoring ${msg.type} from departed peer $fromCid")
+            return
+        }
         val slot = getOrCreateSlot(fromCid)
         if (!slot.isReady() && !slot.ensurePeerConnection()) {
             return
@@ -239,7 +246,7 @@ internal class PeerNegotiationEngine(
         clearNonHostOfferFallback(remoteCid)
         val slot = removeSlotEntry(remoteCid) ?: return
         engineRemoveSlot(slot)
-        slot.closePeerConnection()
+        slot.closePeerConnection(deferDispose = true)
     }
 
     // --- Offer Logic ---

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -2,6 +2,7 @@ package app.serenada.core
 
 import app.serenada.core.call.CallPhase
 import app.serenada.core.call.WebRtcResilienceConstants
+import app.serenada.core.fakes.FakePeerConnectionSlot
 import app.serenada.core.fakes.TestSessionFactory
 import org.junit.After
 import org.junit.Assert.*
@@ -124,6 +125,31 @@ class SessionNegotiationTest {
 
         assertEquals(CallPhase.Waiting, factory.session.state.value.phase)
         assertTrue("Slot should be removed", factory.fakeMedia.removedSlots.isNotEmpty())
+        val removedSlot = factory.fakeMedia.removedSlots.single() as FakePeerConnectionSlot
+        assertTrue("Removed slot should be closed", removedSlot.closePeerConnectionCalled)
+        assertTrue("Peer departure should defer native dispose", removedSlot.closePeerConnectionDeferredDispose)
+    }
+
+    @Test
+    fun `late signaling from departed peer does not recreate slot`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+        val removedPeerSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull(removedPeerSlot)
+
+        factory.simulateRoomState(
+            participants = listOf("alpha" to 1L),
+            hostCid = "alpha",
+        )
+
+        val answersBefore = factory.fakeProvider.sentMessages("answer").size
+        val createdSlotsBefore = factory.fakeMedia.createdSlotCids.size
+        factory.simulateIceCandidateFromRemote("remote", "candidate:late")
+        factory.simulateOfferFromRemote("remote", "late-offer-sdp")
+
+        assertFalse("Departed peer slot should stay removed", factory.fakeMedia.fakeSlots.containsKey("remote"))
+        assertEquals("Late signaling must not create a new slot", createdSlotsBefore, factory.fakeMedia.createdSlotCids.size)
+        assertEquals("Late offer must not be answered", answersBefore, factory.fakeProvider.sentMessages("answer").size)
+        assertTrue("Original slot should stay untouched by late ICE", removedPeerSlot!!.addedIceCandidates.isEmpty())
     }
 
     // Group 4: Pending Message Buffering

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -73,6 +73,7 @@ internal class FakeMediaEngine : SessionMediaEngine {
 
     override fun removeSlot(slot: PeerConnectionSlotProtocol) {
         removedSlots.add(slot)
+        fakeSlots.remove(slot.remoteCid)
     }
 
     val attachLocalSinkCalls = mutableListOf<VideoSink>()

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -42,6 +42,7 @@ internal class FakePeerConnectionSlot(
     val appliedIceServerUrls = mutableListOf<List<String>>()
     var rollbackCalls = 0; private set
     var closePeerConnectionCalled = false; private set
+    var closePeerConnectionDeferredDispose = false; private set
     var ensurePeerConnectionCalls = 0; private set
 
     // Offer lifecycle
@@ -73,7 +74,10 @@ internal class FakePeerConnectionSlot(
     }
     override fun ensurePeerConnection(): Boolean { ensurePeerConnectionCalls++; return true }
     override fun attachLocalTracks(audioTrack: AudioTrack?, videoTrack: VideoTrack?) {}
-    override fun closePeerConnection() { closePeerConnectionCalled = true }
+    override fun closePeerConnection(deferDispose: Boolean) {
+        closePeerConnectionCalled = true
+        closePeerConnectionDeferredDispose = deferDispose
+    }
 
     override fun createOffer(iceRestart: Boolean, onSdp: (String) -> Unit, onComplete: ((Boolean) -> Unit)?): Boolean {
         createOfferCalls++


### PR DESCRIPTION
## Summary
- Guard peer-connection teardown so stale WebRTC callbacks and stats polling do not touch a closing slot
- Defer native PeerConnection disposal for peer-leave removal and ignore late signaling from departed peers
- Add regression coverage for peer departure and stale signaling

## Validation
- ANDROID_HOME=/Users/alexeygavrilov/Library/Android/sdk ANDROID_SDK_ROOT=/Users/alexeygavrilov/Library/Android/sdk ./gradlew :serenada-core:testDebugUnitTest --tests app.serenada.core.SessionNegotiationTest