### PR TITLE
[codex] Add iOS Frontline call UI

### DIFF
--- a/client-ios/Resources/en.lproj/Localizable.strings
+++ b/client-ios/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "settings_language_french" = "French";
 "settings_display_name" = "Display name";
 "settings_display_name_placeholder" = "Your name (optional)";
+"settings_call_screen_style" = "Call screen style";
+"settings_call_screen_style_standard" = "Standard";
+"settings_call_screen_style_frontline" = "Frontline";
 "settings_call_defaults" = "Call defaults";
 "settings_hd_video_experimental" = "HD Video (experimental)";
 "settings_hd_video_experimental_info" = "Enable higher-quality camera modes. May increase CPU usage.";
@@ -166,9 +169,26 @@
 "call_permissions_required" = "Camera and microphone access are required";
 "call_permissions_camera" = "Camera";
 "call_permissions_microphone" = "Microphone";
+"call_grant_access" = "Grant Access";
+"call_dismiss" = "Dismiss";
 "call_error_generic" = "Something went wrong";
 "call_joining" = "Joining...";
 "call_ended" = "Call ended";
+"frontline_you" = "You";
+"frontline_waiting" = "Waiting";
+"frontline_video" = "Video";
+"frontline_video_on" = "Video on";
+"frontline_mute" = "Mute";
+"frontline_more" = "More";
+"frontline_end" = "End";
+"frontline_flip_camera" = "Flip camera";
+"frontline_stop_screen_share" = "Stop screen share";
+"frontline_share_screen" = "Share screen";
+"frontline_return_to_camera" = "Return to camera";
+"frontline_show_your_phone" = "Show your phone screen";
+"frontline_invite_subtitle" = "Send a live-call notification";
+"frontline_share_link_subtitle" = "Copy or share the room link";
+"frontline_close" = "Close";
 
 "feedback_title" = "Feedback";
 "feedback_send_action" = "Send Feedback";

--- a/client-ios/Resources/es.lproj/Localizable.strings
+++ b/client-ios/Resources/es.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "settings_language_french" = "Francés";
 "settings_display_name" = "Nombre para mostrar";
 "settings_display_name_placeholder" = "Tu nombre (opcional)";
+"settings_call_screen_style" = "Estilo de pantalla de llamada";
+"settings_call_screen_style_standard" = "Estándar";
+"settings_call_screen_style_frontline" = "Frontline";
 "settings_call_defaults" = "Valores por defecto de llamada";
 "settings_hd_video_experimental" = "Video HD (experimental)";
 "settings_hd_video_experimental_info" = "Activa modos de cámara de mayor calidad. Puede aumentar el uso de CPU.";
@@ -166,9 +169,26 @@
 "call_permissions_required" = "Se requiere acceso a la cámara y al micrófono";
 "call_permissions_camera" = "Cámara";
 "call_permissions_microphone" = "Micrófono";
+"call_grant_access" = "Conceder acceso";
+"call_dismiss" = "Cerrar";
 "call_error_generic" = "Algo salió mal";
 "call_joining" = "Uniéndose...";
 "call_ended" = "Llamada finalizada";
+"frontline_you" = "Tú";
+"frontline_waiting" = "Esperando";
+"frontline_video" = "Video";
+"frontline_video_on" = "Video activo";
+"frontline_mute" = "Silenciar";
+"frontline_more" = "Más";
+"frontline_end" = "Finalizar";
+"frontline_flip_camera" = "Cambiar cámara";
+"frontline_stop_screen_share" = "Detener pantalla compartida";
+"frontline_share_screen" = "Compartir pantalla";
+"frontline_return_to_camera" = "Volver a la cámara";
+"frontline_show_your_phone" = "Mostrar la pantalla del teléfono";
+"frontline_invite_subtitle" = "Enviar una notificación de llamada";
+"frontline_share_link_subtitle" = "Copiar o compartir el enlace de sala";
+"frontline_close" = "Cerrar";
 
 "feedback_title" = "Comentarios";
 "feedback_send_action" = "Enviar comentarios";

--- a/client-ios/Resources/fr.lproj/Localizable.strings
+++ b/client-ios/Resources/fr.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "settings_language_french" = "Français";
 "settings_display_name" = "Nom d’affichage";
 "settings_display_name_placeholder" = "Votre nom (facultatif)";
+"settings_call_screen_style" = "Style d’écran d’appel";
+"settings_call_screen_style_standard" = "Standard";
+"settings_call_screen_style_frontline" = "Frontline";
 "settings_call_defaults" = "Paramètres d’appel";
 "settings_hd_video_experimental" = "Vidéo HD (expérimental)";
 "settings_hd_video_experimental_info" = "Active des modes caméra de meilleure qualité. Peut augmenter l’utilisation CPU.";
@@ -166,9 +169,26 @@
 "call_permissions_required" = "L'accès à la caméra et au microphone est requis";
 "call_permissions_camera" = "Caméra";
 "call_permissions_microphone" = "Microphone";
+"call_grant_access" = "Autoriser l'accès";
+"call_dismiss" = "Fermer";
 "call_error_generic" = "Une erreur est survenue";
 "call_joining" = "Connexion...";
 "call_ended" = "Appel terminé";
+"frontline_you" = "Vous";
+"frontline_waiting" = "En attente";
+"frontline_video" = "Vidéo";
+"frontline_video_on" = "Vidéo activée";
+"frontline_mute" = "Muet";
+"frontline_more" = "Plus";
+"frontline_end" = "Terminer";
+"frontline_flip_camera" = "Basculer la caméra";
+"frontline_stop_screen_share" = "Arrêter le partage d’écran";
+"frontline_share_screen" = "Partager l’écran";
+"frontline_return_to_camera" = "Revenir à la caméra";
+"frontline_show_your_phone" = "Afficher l’écran du téléphone";
+"frontline_invite_subtitle" = "Envoyer une notification d’appel";
+"frontline_share_link_subtitle" = "Copier ou partager le lien de salle";
+"frontline_close" = "Fermer";
 
 "feedback_title" = "Retour";
 "feedback_send_action" = "Envoyer un retour";

--- a/client-ios/Resources/ru.lproj/Localizable.strings
+++ b/client-ios/Resources/ru.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "settings_language_french" = "Французский";
 "settings_display_name" = "Отображаемое имя";
 "settings_display_name_placeholder" = "Ваше имя (необязательно)";
+"settings_call_screen_style" = "Стиль экрана звонка";
+"settings_call_screen_style_standard" = "Стандартный";
+"settings_call_screen_style_frontline" = "Frontline";
 "settings_call_defaults" = "Параметры звонка";
 "settings_hd_video_experimental" = "HD видео (экспериментально)";
 "settings_hd_video_experimental_info" = "Включает более качественные режимы камеры. Может повысить нагрузку на CPU.";
@@ -166,9 +169,26 @@
 "call_permissions_required" = "Требуется доступ к камере и микрофону";
 "call_permissions_camera" = "Камера";
 "call_permissions_microphone" = "Микрофон";
+"call_grant_access" = "Разрешить доступ";
+"call_dismiss" = "Закрыть";
 "call_error_generic" = "Что-то пошло не так";
 "call_joining" = "Подключение...";
 "call_ended" = "Звонок завершён";
+"frontline_you" = "Вы";
+"frontline_waiting" = "Ожидание";
+"frontline_video" = "Видео";
+"frontline_video_on" = "Видео вкл.";
+"frontline_mute" = "Микрофон";
+"frontline_more" = "Еще";
+"frontline_end" = "Завершить";
+"frontline_flip_camera" = "Переключить камеру";
+"frontline_stop_screen_share" = "Остановить демонстрацию экрана";
+"frontline_share_screen" = "Показать экран";
+"frontline_return_to_camera" = "Вернуться к камере";
+"frontline_show_your_phone" = "Показать экран телефона";
+"frontline_invite_subtitle" = "Отправить уведомление о звонке";
+"frontline_share_link_subtitle" = "Скопировать или отправить ссылку на комнату";
+"frontline_close" = "Закрыть";
 
 "feedback_title" = "Отзыв";
 "feedback_send_action" = "Отправить отзыв";

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -1,0 +1,1718 @@
+import ReplayKit
+import SerenadaCore
+import SwiftUI
+import UIKit
+
+private let frontlineBlack = Color.black
+private let frontlinePanel = Color.black
+private let frontlineSurface = Color(red: 0x1A / 255, green: 0x1A / 255, blue: 0x1A / 255)
+private let frontlineBorder = Color(red: 0x2A / 255, green: 0x2A / 255, blue: 0x2A / 255)
+private let frontlineAccent = Color(red: 0x15 / 255, green: 0xBF / 255, blue: 0x54 / 255)
+private let frontlineDanger = Color(red: 0xF5 / 255, green: 0x56 / 255, blue: 0x4B / 255)
+private let frontlineDim = Color(red: 0xA1 / 255, green: 0xA1 / 255, blue: 0xAA / 255)
+private let frontlineSheet = Color(red: 0x15 / 255, green: 0x16 / 255, blue: 0x1A / 255)
+private let frontlineContentSpotlightPrefix = "content:"
+private let frontlineMoreButtonHeightToWidthRatio: CGFloat = 1.62
+private let frontlineLargeVideoAccentLineWidth: CGFloat = 3
+private let frontlinePipVideoAccentLineWidth: CGFloat = 2.5
+private let frontlinePipBorderLineWidth: CGFloat = 1.5
+
+private enum FrontlineFeed {
+    case local
+    case remote
+}
+
+func frontlineIsWaitingForRemote(_ uiState: CallUiState) -> Bool {
+    (uiState.phase == .waiting || uiState.phase == .inCall) && uiState.remoteParticipants.isEmpty
+}
+
+func frontlineUsesLargeLocalPreview(
+    localVideoEnabled: Bool,
+    localCameraMode: LocalCameraMode,
+    isScreenSharing: Bool,
+    pipSwapped: Bool
+) -> Bool {
+    guard localVideoEnabled else { return false }
+    let localContentMode = localCameraMode == .world || localCameraMode == .composite || isScreenSharing
+    return localContentMode ? !pipSwapped : pipSwapped
+}
+
+func frontlineSnapshotSource(
+    snapshotEnabled: Bool,
+    localVideoEnabled: Bool,
+    remoteParticipants: [RemoteParticipant]
+) -> SnapshotSource? {
+    guard snapshotEnabled else { return nil }
+    if localVideoEnabled { return .local }
+    return remoteParticipants.first(where: { $0.videoEnabled }).map { .remote(cid: $0.cid) }
+}
+
+func frontlineAllowsLocalCameraZoom(
+    phase: CallPhase,
+    localVideoEnabled: Bool,
+    localCameraMode: LocalCameraMode,
+    isScreenSharing: Bool
+) -> Bool {
+    (phase == .waiting || phase == .inCall)
+        && localVideoEnabled
+        && localCameraMode.isContentMode
+        && !isScreenSharing
+}
+
+func frontlineIncludesNormalLocalStageTile(
+    localSpotlightId: String,
+    activeContentOwnerId: String?,
+    contentTileIsSpotlight: Bool
+) -> Bool {
+    activeContentOwnerId != localSpotlightId || contentTileIsSpotlight
+}
+
+struct FrontlineCallScreenView: View {
+    let roomId: String
+    let uiState: CallUiState
+    let sessionPhase: SerenadaCallPhase
+    let roomShareURL: URL?
+    let screenShareExtensionBundleId: String?
+    let roomName: String?
+    let config: SerenadaCallFlowConfig
+    let strings: [SerenadaString: String]?
+    let onToggleAudio: () -> Void
+    let onToggleVideo: () -> Void
+    let onFlipCamera: () -> Void
+    let onToggleScreenShare: () -> Void
+    let onAdjustCameraZoom: (CGFloat) -> Void
+    let onResetCameraZoom: () -> Void
+    let onToggleFlashlight: () -> Void
+    let onEndCall: () -> Void
+    let onInviteToRoom: () async -> Result<Void, Error>
+    let onRequestPermissions: () -> Void
+    let onDismiss: (() -> Void)?
+    let onSnapshotRequested: ((SnapshotSource) -> Void)?
+    let rendererProvider: CallRendererProvider
+
+    @State private var pipSwapped = false
+    @State private var isMoreSheetVisible = false
+    @State private var showShareSheet = false
+    @State private var showSnapshotFlash = false
+    @State private var showDebugPanel = false
+    @State private var lastDebugTapAt: Date?
+    @State private var lastMagnificationValue: CGFloat = 1
+    @State private var remoteTileAspectRatios: [String: CGFloat] = [:]
+    @State private var pinnedSpotlightId: String?
+    @State private var selectedSpotlightId: String?
+    @State private var lastVideoStartedParticipantId: String?
+    @State private var previousRemoteVideoEnabled: [String: Bool] = [:]
+    @State private var broadcastTriggerCount = 0
+
+    private func str(_ key: SerenadaString) -> String {
+        resolveString(key, overrides: strings)
+    }
+
+    private var isCallSurfacePhase: Bool {
+        uiState.phase == .waiting || uiState.phase == .inCall
+    }
+
+    private var localContentMode: Bool {
+        uiState.localCameraMode == .world || uiState.localCameraMode == .composite || uiState.isScreenSharing
+    }
+
+    private var isLocalCameraZoomEnabled: Bool {
+        frontlineAllowsLocalCameraZoom(
+            phase: uiState.phase,
+            localVideoEnabled: uiState.localVideoEnabled,
+            localCameraMode: uiState.localCameraMode,
+            isScreenSharing: uiState.isScreenSharing
+        )
+    }
+
+    private var remote: RemoteParticipant? {
+        uiState.remoteParticipants.first
+    }
+
+    private var snapshotSource: SnapshotSource? {
+        guard isCallSurfacePhase else { return nil }
+        return frontlineSnapshotSource(
+            snapshotEnabled: config.snapshotEnabled && onSnapshotRequested != nil,
+            localVideoEnabled: uiState.localVideoEnabled,
+            remoteParticipants: uiState.remoteParticipants
+        )
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let isLandscape = geometry.size.width > geometry.size.height
+            let isTabletLandscape = isLandscape && geometry.size.width >= 1100 && geometry.size.height >= 720
+            let panelWidth = isLandscape ? (geometry.size.width >= 720 ? 320.0 : 260.0) : geometry.size.width
+            let pipFeed = pipFeed
+            let pipInPanel = isTabletLandscape && pipFeed != nil
+            let pipSize = frontlinePipSize(containerWidth: geometry.size.width, inPanel: pipInPanel)
+
+            ZStack {
+                frontlineBlack.ignoresSafeArea()
+
+                if isLandscape {
+                    HStack(spacing: 0) {
+                        contentArea(
+                            pipFeed: pipFeed,
+                            pipInPanel: pipInPanel,
+                            pipSize: pipSize
+                        )
+                        .frame(width: max(0, geometry.size.width - panelWidth), height: geometry.size.height)
+
+                        controlsPanel(
+                            isLandscape: true,
+                            isTabletLandscape: isTabletLandscape,
+                            panelWidth: panelWidth,
+                            pipFeed: pipFeed,
+                            pipInPanel: pipInPanel,
+                            pipSize: pipSize
+                        )
+                        .frame(width: panelWidth, height: geometry.size.height)
+                    }
+                    .ignoresSafeArea()
+                } else {
+                    VStack(spacing: 0) {
+                        contentArea(
+                            pipFeed: pipFeed,
+                            pipInPanel: false,
+                            pipSize: pipSize
+                        )
+                        .frame(width: geometry.size.width)
+                        .frame(maxHeight: .infinity)
+
+                        controlsPanel(
+                            isLandscape: false,
+                            isTabletLandscape: false,
+                            panelWidth: panelWidth,
+                            pipFeed: pipFeed,
+                            pipInPanel: false,
+                            pipSize: pipSize
+                        )
+                    }
+                    .ignoresSafeArea(edges: .bottom)
+                }
+
+                reconnectingBadge
+                debugOverlay
+                snapshotFlashOverlay
+                moreSheet
+            }
+        }
+        .background(frontlineBlack)
+        .accessibilityIdentifier("call.frontline.screen")
+        .onChange(of: uiState.localVideoEnabled) { _ in pipSwapped = false }
+        .onChange(of: uiState.localCameraMode) { _ in pipSwapped = false }
+        .onChange(of: uiState.remoteParticipants.map { $0.cid }) { activeCids in
+            let active = Set(activeCids)
+            remoteTileAspectRatios = remoteTileAspectRatios.filter { active.contains($0.key) }
+            if let pinnedSpotlightId, !frontlineActiveSpotlightIds.contains(pinnedSpotlightId) {
+                self.pinnedSpotlightId = nil
+            }
+            if let selectedSpotlightId, !frontlineActiveSpotlightIds.contains(selectedSpotlightId) {
+                self.selectedSpotlightId = nil
+            }
+        }
+        .onChange(of: uiState.remoteParticipants.map { "\($0.cid):\($0.videoEnabled)" }) { _ in
+            updateLastVideoStartedParticipant()
+        }
+        .onChange(of: activeContentSpotlightId) { id in
+            if let id {
+                selectedSpotlightId = id
+            } else {
+                if selectedSpotlightId?.isFrontlineContentSpotlightId == true { selectedSpotlightId = nil }
+                if pinnedSpotlightId?.isFrontlineContentSpotlightId == true { pinnedSpotlightId = nil }
+            }
+        }
+        .onChange(of: localContentMode) { enabled in
+            if !enabled {
+                lastMagnificationValue = 1
+                onResetCameraZoom()
+            }
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let roomShareURL {
+                ActivityView(items: [roomShareURL])
+            }
+        }
+    }
+
+    private var localSpotlightId: String {
+        uiState.localCid ?? "local"
+    }
+
+    private var activeContentOwnerId: String? {
+        if uiState.isScreenSharing { return localSpotlightId }
+        if uiState.localVideoEnabled && (uiState.localCameraMode == .world || uiState.localCameraMode == .composite) {
+            return localSpotlightId
+        }
+        return uiState.remoteContentCid
+    }
+
+    private var activeContentSpotlightId: String? {
+        activeContentOwnerId.map { $0.frontlineContentSpotlightId }
+    }
+
+    private var frontlineActiveSpotlightIds: Set<String> {
+        var ids = Set(uiState.remoteParticipants.map(\.cid))
+        ids.insert(localSpotlightId)
+        if let activeContentSpotlightId {
+            ids.insert(activeContentSpotlightId)
+        }
+        return ids
+    }
+
+    private var largeFeed: FrontlineFeed {
+        frontlineUsesLargeLocalPreview(
+            localVideoEnabled: uiState.localVideoEnabled,
+            localCameraMode: uiState.localCameraMode,
+            isScreenSharing: uiState.isScreenSharing,
+            pipSwapped: pipSwapped
+        ) ? .local : .remote
+    }
+
+    private var pipFeed: FrontlineFeed? {
+        guard uiState.localVideoEnabled || remote?.videoEnabled == true else { return nil }
+        return largeFeed == .local ? .remote : .local
+    }
+
+    private var canSwapPip: Bool {
+        pipFeed != nil && uiState.localVideoEnabled && remote != nil
+    }
+
+    @ViewBuilder
+    private func contentArea(
+        pipFeed: FrontlineFeed?,
+        pipInPanel: Bool,
+        pipSize: CGSize
+    ) -> some View {
+        ZStack {
+            if !isCallSurfacePhase {
+                FrontlinePhaseSurface(
+                    sessionPhase: sessionPhase,
+                    localDisplayName: uiState.localDisplayName,
+                    strings: strings,
+                    onRequestPermissions: onRequestPermissions,
+                    onDismiss: onDismiss
+                )
+            } else if frontlineIsWaitingForRemote(uiState) {
+                waitingSurface
+            } else if uiState.remoteParticipants.count > 1 {
+                multiPartyStage
+            } else {
+                largeSurface(feed: largeFeed)
+            }
+
+            if isCallSurfacePhase,
+               !frontlineIsWaitingForRemote(uiState),
+               uiState.remoteParticipants.count <= 1,
+               uiState.localVideoEnabled,
+               largeFeed == .local {
+                Rectangle()
+                    .strokeBorder(frontlineAccent, lineWidth: frontlineLargeVideoAccentLineWidth)
+                    .allowsHitTesting(false)
+            }
+
+            if shouldShowLargeNameChip {
+                FrontlineNameChip(
+                    label: largeFeed == .local ? localDisplayName : remoteDisplayName(remote),
+                    muted: largeFeed == .local ? !uiState.localAudioEnabled : remote?.audioEnabled == false,
+                    audioLevel: largeFeed == .local ? uiState.localAudioLevel : remote?.audioLevel ?? 0
+                )
+                .padding(.leading, 16)
+                .padding(.bottom, 16)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            }
+
+            if isCallSurfacePhase,
+               !frontlineIsWaitingForRemote(uiState),
+               uiState.remoteParticipants.count <= 1,
+               let pipFeed,
+               !pipInPanel {
+                FrontlinePipView(
+                    feed: pipFeed,
+                    uiState: uiState,
+                    remote: remote,
+                    rendererProvider: rendererProvider,
+                    size: pipSize,
+                    showSwapHint: canSwapPip,
+                    strings: strings,
+                    onClick: {
+                        guard canSwapPip else { return }
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            pipSwapped.toggle()
+                        }
+                    }
+                )
+                .padding(.top, 12)
+                .padding(.trailing, 14)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            }
+        }
+        .background(frontlineBlack)
+        .clipped()
+    }
+
+    private var shouldShowLargeNameChip: Bool {
+        guard isCallSurfacePhase,
+              !frontlineIsWaitingForRemote(uiState),
+              uiState.remoteParticipants.count <= 1 else {
+            return false
+        }
+        if largeFeed == .local {
+            return uiState.localVideoEnabled
+        }
+        return remote?.videoEnabled == true
+    }
+
+    private var waitingSurface: some View {
+        ZStack {
+            frontlineBlack
+            if uiState.localVideoEnabled {
+                localVideoView(contentMode: uiState.isScreenSharing ? .scaleAspectFit : .scaleAspectFill)
+                Color.black.opacity(0.18)
+                    .allowsHitTesting(false)
+                localZoomInteractionLayer(enabled: isLocalCameraZoomEnabled)
+            }
+            Text(str(.frontlineWaiting))
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+        .ignoresSafeArea()
+    }
+
+    @ViewBuilder
+    private func largeSurface(feed: FrontlineFeed) -> some View {
+        switch feed {
+        case .local where uiState.localVideoEnabled:
+            ZStack {
+                localVideoView(contentMode: uiState.isScreenSharing ? .scaleAspectFit : .scaleAspectFill)
+                localZoomInteractionLayer(enabled: isLocalCameraZoomEnabled)
+            }
+        case .remote where remote?.videoEnabled == true:
+            WebRTCVideoView(
+                kind: remote.map { .remoteForCid($0.cid) } ?? .remote,
+                rendererProvider: rendererProvider,
+                videoContentMode: .scaleAspectFill
+            )
+            .ignoresSafeArea()
+        default:
+            FrontlineAudioLarge(
+                remote: remote,
+                startedAtMs: uiState.callStartedAtMs,
+                strings: strings
+            )
+        }
+    }
+
+    private var multiPartyStage: some View {
+        FrontlineMultiPartyStage(
+            uiState: uiState,
+            localSpotlightId: localSpotlightId,
+            activeContentSpotlightId: activeContentSpotlightId,
+            localContentMode: localContentMode,
+            remoteTileAspectRatios: $remoteTileAspectRatios,
+            pinnedSpotlightId: $pinnedSpotlightId,
+            selectedSpotlightId: $selectedSpotlightId,
+            lastVideoStartedParticipantId: lastVideoStartedParticipantId,
+            rendererProvider: rendererProvider,
+            strings: strings,
+            onAdjustCameraZoom: onAdjustCameraZoom
+        )
+    }
+
+    private func localVideoView(contentMode: UIView.ContentMode) -> some View {
+        WebRTCVideoView(
+            kind: .local,
+            rendererProvider: rendererProvider,
+            videoContentMode: contentMode,
+            isMirrored: uiState.isFrontCamera && !uiState.isScreenSharing
+        )
+        .ignoresSafeArea()
+    }
+
+    private func localZoomInteractionLayer(enabled: Bool) -> some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .accessibilityHidden(true)
+            .simultaneousGesture(localZoomGesture(enabled: enabled))
+    }
+
+    private func localZoomGesture(enabled: Bool) -> some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                guard enabled else { return }
+                let delta = value / max(lastMagnificationValue, 0.001)
+                lastMagnificationValue = value
+                guard abs(delta - 1) > 0.01 else { return }
+                onAdjustCameraZoom(delta)
+            }
+            .onEnded { _ in
+                lastMagnificationValue = 1
+            }
+    }
+
+    private func controlsPanel(
+        isLandscape: Bool,
+        isTabletLandscape: Bool,
+        panelWidth: CGFloat,
+        pipFeed: FrontlineFeed?,
+        pipInPanel: Bool,
+        pipSize: CGSize
+    ) -> some View {
+        FrontlineControlsPanel(
+            uiState: uiState,
+            isLandscape: isLandscape,
+            isTabletLandscape: isTabletLandscape,
+            panelWidth: panelWidth,
+            callControlsEnabled: isCallSurfacePhase,
+            videoControlsEnabled: isCallSurfacePhase && config.videoEnabled && !uiState.availableCameraModes.isEmpty,
+            showMoreButton: isCallSurfacePhase && (config.screenSharingEnabled || config.inviteControlsEnabled),
+            snapshotSource: snapshotSource,
+            snapshotHandler: onSnapshotRequested,
+            reservePreviewActions: isLandscape,
+            pipInPanel: pipInPanel,
+            pip: {
+                if let pipFeed {
+                    FrontlinePipView(
+                        feed: pipFeed,
+                        uiState: uiState,
+                        remote: remote,
+                        rendererProvider: rendererProvider,
+                        size: pipSize,
+                        showSwapHint: canSwapPip,
+                        strings: strings,
+                        onClick: {
+                            guard canSwapPip else { return }
+                            withAnimation(.easeInOut(duration: 0.18)) {
+                                pipSwapped.toggle()
+                            }
+                        }
+                    )
+                }
+            },
+            strings: strings,
+            onVideoTap: {
+                if uiState.localVideoEnabled {
+                    pipSwapped = false
+                }
+                onToggleVideo()
+            },
+            onToggleAudio: onToggleAudio,
+            onFlipCamera: onFlipCamera,
+            onToggleFlashlight: onToggleFlashlight,
+            onSnapshotFlash: { showSnapshotFlash = true },
+            onMore: { isMoreSheetVisible = true },
+            onEndCall: onEndCall
+        )
+    }
+
+    private var reconnectingBadge: some View {
+        Group {
+            if uiState.phase == .inCall && uiState.connectionStatus != .connected {
+                VStack(spacing: 4) {
+                    Text(str(.callReconnecting))
+                        .font(.system(size: 14, weight: .medium))
+                    if uiState.connectionStatus == .retrying {
+                        Text(str(.callTakingLongerThanUsual))
+                            .font(.system(size: 12, weight: .regular))
+                    }
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.black.opacity(0.72))
+                .clipShape(Capsule())
+                .padding(.top, 16)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+        }
+    }
+
+    private var debugOverlay: some View {
+        Group {
+            if config.debugOverlayEnabled {
+                Color.clear
+                    .frame(width: 72, height: 72)
+                    .contentShape(Rectangle())
+                    .onTapGesture { handleDebugTap() }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                if showDebugPanel {
+                    FrontlineDebugPanel(uiState: uiState)
+                        .padding(.leading, 16)
+                        .padding(.top, 16)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
+            }
+        }
+    }
+
+    private var snapshotFlashOverlay: some View {
+        Group {
+            if showSnapshotFlash {
+                Color.white.opacity(0.86)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+                    .task {
+                        try? await Task.sleep(nanoseconds: 220_000_000)
+                        showSnapshotFlash = false
+                    }
+            }
+        }
+    }
+
+    private var moreSheet: some View {
+        Group {
+            if isMoreSheetVisible {
+                FrontlineMoreSheet(
+                    screenSharingEnabled: config.screenSharingEnabled,
+                    inviteEnabled: config.inviteControlsEnabled,
+                    shareEnabled: config.inviteControlsEnabled && roomShareURL != nil,
+                    isScreenSharing: uiState.isScreenSharing,
+                    screenShareExtensionBundleId: screenShareExtensionBundleId,
+                    broadcastTriggerCount: $broadcastTriggerCount,
+                    strings: strings,
+                    onDismiss: { isMoreSheetVisible = false },
+                    onToggleScreenShare: {
+                        isMoreSheetVisible = false
+                        onToggleScreenShare()
+                    },
+                    onStartBroadcastPicker: {
+                        onToggleScreenShare()
+                        broadcastTriggerCount += 1
+                        DispatchQueue.main.async {
+                            isMoreSheetVisible = false
+                        }
+                    },
+                    onInvite: {
+                        isMoreSheetVisible = false
+                        Task { _ = await onInviteToRoom() }
+                    },
+                    onShare: {
+                        isMoreSheetVisible = false
+                        showShareSheet = true
+                    }
+                )
+            }
+        }
+    }
+
+    private var localDisplayName: String {
+        uiState.localDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? uiState.localDisplayName!
+            : str(.frontlineYou)
+    }
+
+    private func handleDebugTap() {
+        let now = Date()
+        let didDoubleTap = lastDebugTapAt.map { now.timeIntervalSince($0) <= 0.45 } ?? false
+        lastDebugTapAt = now
+        guard didDoubleTap else { return }
+        withAnimation(.easeInOut(duration: 0.18)) {
+            showDebugPanel.toggle()
+        }
+    }
+
+    private func updateLastVideoStartedParticipant() {
+        let next = Dictionary(uniqueKeysWithValues: uiState.remoteParticipants.map { ($0.cid, $0.videoEnabled) })
+        if !previousRemoteVideoEnabled.isEmpty {
+            if let started = uiState.remoteParticipants.last(where: { $0.videoEnabled && previousRemoteVideoEnabled[$0.cid] != true }) {
+                lastVideoStartedParticipantId = started.cid
+            }
+        }
+        previousRemoteVideoEnabled = next
+    }
+}
+
+private func frontlinePipSize(containerWidth: CGFloat, inPanel: Bool) -> CGSize {
+    if inPanel { return CGSize(width: 220, height: 280) }
+    if containerWidth >= 1100 { return CGSize(width: 172, height: 220) }
+    if containerWidth >= 720 { return CGSize(width: 152, height: 196) }
+    if containerWidth >= 480 { return CGSize(width: 120, height: 154) }
+    return CGSize(width: 100, height: 128)
+}
+
+private func remoteDisplayName(_ remote: RemoteParticipant?) -> String {
+    remote?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+}
+
+private extension String {
+    var frontlineContentSpotlightId: String { "\(frontlineContentSpotlightPrefix)\(self)" }
+    var isFrontlineContentSpotlightId: Bool { hasPrefix(frontlineContentSpotlightPrefix) }
+    var removingFrontlineContentSpotlightPrefix: String {
+        hasPrefix(frontlineContentSpotlightPrefix)
+            ? String(dropFirst(frontlineContentSpotlightPrefix.count))
+            : self
+    }
+}
+
+private struct FrontlinePhaseSurface: View {
+    let sessionPhase: SerenadaCallPhase
+    let localDisplayName: String?
+    let strings: [SerenadaString: String]?
+    let onRequestPermissions: () -> Void
+    let onDismiss: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 22) {
+            FrontlineLocalAvatar(size: 124, fontSize: 48, displayName: localDisplayName, strings: strings)
+
+            Text(title)
+                .font(.system(size: 30, weight: .bold))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+
+            if sessionPhase == .awaitingPermissions {
+                Button(resolveString(.callGrantAccess, overrides: strings), action: onRequestPermissions)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .background(frontlineAccent)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            } else if sessionPhase == .error, let onDismiss {
+                Button(resolveString(.callDismiss, overrides: strings), action: onDismiss)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+        }
+        .padding(.horizontal, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(frontlineBlack)
+    }
+
+    private var title: String {
+        switch sessionPhase {
+        case .error:
+            return resolveString(.callErrorGeneric, overrides: strings)
+        case .waiting:
+            return resolveString(.frontlineWaiting, overrides: strings)
+        default:
+            return resolveString(.frontlineWaiting, overrides: strings)
+        }
+    }
+}
+
+private struct FrontlineAudioLarge: View {
+    let remote: RemoteParticipant?
+    let startedAtMs: Int64?
+    let strings: [SerenadaString: String]?
+
+    var body: some View {
+        let name = remoteDisplayName(remote)
+        VStack(spacing: 0) {
+            FrontlineAvatar(peerId: remote?.peerId, displayName: name, size: 140, fontSize: 58)
+            Spacer().frame(height: 18)
+            HStack(spacing: 10) {
+                FrontlineAudioIndicator(
+                    muted: remote?.audioEnabled == false,
+                    audioLevel: remote?.audioLevel ?? 0,
+                    size: 22
+                )
+                if !name.isEmpty {
+                    Text(name)
+                        .font(.system(size: 34, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+            }
+            Spacer().frame(height: 10)
+            FrontlineTimerLabel(startedAtMs: startedAtMs)
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(frontlineBlack)
+    }
+}
+
+private struct FrontlineTimerLabel: View {
+    let startedAtMs: Int64?
+    @State private var nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+    @State private var fallbackStartedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+
+    var body: some View {
+        Text(elapsedLabel)
+            .font(.system(size: 28, weight: .medium))
+            .foregroundStyle(frontlineDim)
+            .monospacedDigit()
+            .task(id: startedAtMs) {
+                fallbackStartedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+                while !Task.isCancelled {
+                    nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                }
+            }
+    }
+
+    private var elapsedLabel: String {
+        let startedAt = startedAtMs ?? fallbackStartedAtMs
+        let elapsedSeconds = max(0, (nowMs - startedAt) / 1000)
+        return String(format: "%02lld:%02lld", elapsedSeconds / 60, elapsedSeconds % 60)
+    }
+}
+
+private struct FrontlinePipView: View {
+    let feed: FrontlineFeed
+    let uiState: CallUiState
+    let remote: RemoteParticipant?
+    let rendererProvider: CallRendererProvider
+    let size: CGSize
+    let showSwapHint: Bool
+    let strings: [SerenadaString: String]?
+    let onClick: () -> Void
+
+    var body: some View {
+        let showsLocal = feed == .local
+        ZStack(alignment: .bottomLeading) {
+            frontlineSurface
+
+            if showsLocal && uiState.localVideoEnabled {
+                WebRTCVideoView(
+                    kind: .local,
+                    rendererProvider: rendererProvider,
+                    videoContentMode: uiState.isScreenSharing ? .scaleAspectFit : .scaleAspectFill,
+                    isMirrored: uiState.isFrontCamera && !uiState.isScreenSharing
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+            } else if !showsLocal, let remote, remote.videoEnabled {
+                WebRTCVideoView(
+                    kind: .remoteForCid(remote.cid),
+                    rendererProvider: rendererProvider,
+                    videoContentMode: .scaleAspectFill
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+            } else {
+                if showsLocal {
+                    FrontlineLocalAvatar(size: 74, fontSize: 34, displayName: uiState.localDisplayName, strings: strings)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    FrontlineAvatar(
+                        peerId: remote?.peerId,
+                        displayName: remoteDisplayName(remote),
+                        size: 74,
+                        fontSize: 30
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+
+            FrontlineNameChip(
+                label: showsLocal
+                    ? (uiState.localDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                        ? uiState.localDisplayName!
+                        : resolveString(.frontlineYou, overrides: strings))
+                    : remoteDisplayName(remote),
+                muted: showsLocal ? !uiState.localAudioEnabled : remote?.audioEnabled == false,
+                audioLevel: showsLocal ? uiState.localAudioLevel : remote?.audioLevel ?? 0,
+                compact: true
+            )
+            .padding(6)
+
+            if showSwapHint {
+                Image(systemName: "camera.rotate.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 22, height: 22)
+                    .background(Color.black.opacity(0.62))
+                    .clipShape(Circle())
+                    .padding(8)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(
+                    showsLocal && uiState.localVideoEnabled ? frontlineAccent : Color.white.opacity(0.4),
+                    lineWidth: showsLocal && uiState.localVideoEnabled ? frontlinePipVideoAccentLineWidth : frontlinePipBorderLineWidth
+                )
+        )
+        .shadow(color: .black.opacity(0.32), radius: 8, y: 4)
+        .contentShape(RoundedRectangle(cornerRadius: 14))
+        .onTapGesture(perform: onClick)
+    }
+}
+
+private struct FrontlineControlsPanel<Pip: View>: View {
+    let uiState: CallUiState
+    let isLandscape: Bool
+    let isTabletLandscape: Bool
+    let panelWidth: CGFloat
+    let callControlsEnabled: Bool
+    let videoControlsEnabled: Bool
+    let showMoreButton: Bool
+    let snapshotSource: SnapshotSource?
+    let snapshotHandler: ((SnapshotSource) -> Void)?
+    let reservePreviewActions: Bool
+    let pipInPanel: Bool
+    @ViewBuilder let pip: () -> Pip
+    let strings: [SerenadaString: String]?
+    let onVideoTap: () -> Void
+    let onToggleAudio: () -> Void
+    let onFlipCamera: () -> Void
+    let onToggleFlashlight: () -> Void
+    let onSnapshotFlash: () -> Void
+    let onMore: () -> Void
+    let onEndCall: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if pipInPanel {
+                VStack {
+                    pip()
+                    Spacer()
+                }
+                .frame(height: 300)
+            } else if isLandscape {
+                Spacer(minLength: 0)
+            }
+
+            if callControlsEnabled {
+                previewActions
+                controlGrid
+            } else {
+                Spacer().frame(height: isLandscape ? 24 : 12)
+            }
+
+            Spacer().frame(height: isLandscape ? 20 : 12)
+            FrontlineEndButton(strings: strings, onClick: onEndCall)
+
+            if isLandscape && !pipInPanel {
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, isLandscape ? 12 : 16)
+        .padding(.top, isLandscape ? 8 : 14)
+        .padding(.bottom, isLandscape ? 16 : 24)
+        .background(frontlinePanel)
+    }
+
+    private var previewActions: some View {
+        let visible = uiState.localVideoEnabled
+        let rowHeight: CGFloat = isLandscape ? 84 : 92
+        return Group {
+            if visible || reservePreviewActions {
+                HStack(spacing: 22) {
+                    FrontlineRoundActionButton(
+                        visible: visible,
+                        size: 56,
+                        systemImage: uiState.isFlashEnabled ? "flashlight.on.fill" : "flashlight.off.fill",
+                        active: uiState.isFlashEnabled && uiState.isFlashAvailable,
+                        enabled: uiState.isFlashAvailable,
+                        accessibilityLabel: uiState.isFlashEnabled ? resolveString(.callA11yFlashlightOn, overrides: strings) : resolveString(.callA11yFlashlightOff, overrides: strings),
+                        onClick: onToggleFlashlight
+                    )
+
+                    FrontlineRoundActionButton(
+                        visible: visible && snapshotSource != nil && snapshotHandler != nil,
+                        size: 72,
+                        systemImage: "camera.fill",
+                        primary: true,
+                        accessibilityLabel: resolveString(.callA11yTakeSnapshot, overrides: strings),
+                        onClick: {
+                            guard let snapshotSource, let snapshotHandler else { return }
+                            onSnapshotFlash()
+                            snapshotHandler(snapshotSource)
+                        }
+                    )
+                    .accessibilityIdentifier("call.frontline.takeSnapshot")
+
+                    FrontlineRoundActionButton(
+                        visible: visible && uiState.availableCameraModes.count > 1,
+                        size: 56,
+                        systemImage: "camera.rotate.fill",
+                        accessibilityLabel: resolveString(.frontlineFlipCamera, overrides: strings),
+                        onClick: onFlipCamera
+                    )
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: rowHeight)
+                .padding(.bottom, isLandscape ? 12 : 14)
+                .opacity(visible ? 1 : 0)
+            }
+        }
+    }
+
+    private var controlGrid: some View {
+        let buttonHeight: CGFloat = {
+            if isTabletLandscape || (!isLandscape && panelWidth >= 320) { return 86 }
+            return isLandscape ? 68 : 74
+        }()
+        let moreWidth = buttonHeight / frontlineMoreButtonHeightToWidthRatio
+        return HStack(spacing: 8) {
+            if videoControlsEnabled {
+                FrontlineGridButton(
+                    label: uiState.localVideoEnabled
+                        ? resolveString(.frontlineVideoOn, overrides: strings)
+                        : resolveString(.frontlineVideo, overrides: strings),
+                    systemImage: uiState.localVideoEnabled ? "video.fill" : "video.slash.fill",
+                    active: uiState.localVideoEnabled,
+                    onClick: onVideoTap
+                )
+                .frame(height: buttonHeight)
+            }
+
+            FrontlineGridButton(
+                label: resolveString(.frontlineMute, overrides: strings),
+                systemImage: uiState.localAudioEnabled ? "mic.fill" : "mic.slash.fill",
+                danger: !uiState.localAudioEnabled,
+                onClick: onToggleAudio
+            )
+            .frame(height: buttonHeight)
+
+            if showMoreButton {
+                FrontlineGridButton(
+                    label: resolveString(.frontlineMore, overrides: strings),
+                    systemImage: "ellipsis",
+                    showLabel: false,
+                    onClick: onMore
+                )
+                .frame(width: moreWidth, height: buttonHeight)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct FrontlineGridButton: View {
+    let label: String
+    let systemImage: String
+    var active = false
+    var danger = false
+    var showLabel = true
+    let onClick: () -> Void
+
+    var body: some View {
+        Button(action: onClick) {
+            VStack(spacing: showLabel ? 4 : 0) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 24, weight: .bold))
+                if showLabel {
+                    Text(label.uppercased())
+                        .font(.system(size: 13, weight: .heavy))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+            }
+            .foregroundStyle(active ? Color.black : Color.white)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 8)
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay(RoundedRectangle(cornerRadius: 14).stroke(frontlineBorder, lineWidth: 1.5))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+
+    private var background: Color {
+        if active { return frontlineAccent }
+        if danger { return frontlineDanger }
+        return frontlineSurface
+    }
+}
+
+private struct FrontlineRoundActionButton: View {
+    let visible: Bool
+    let size: CGFloat
+    let systemImage: String
+    var active = false
+    var primary = false
+    var enabled = true
+    let accessibilityLabel: String
+    let onClick: () -> Void
+
+    var body: some View {
+        Group {
+            if visible {
+                Button(action: onClick) {
+                    Image(systemName: systemImage)
+                        .font(.system(size: primary ? 30 : 24, weight: .bold))
+                        .foregroundStyle(tint)
+                        .frame(width: size, height: size)
+                        .background(background)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Color.white.opacity(primary ? 0.45 : (enabled ? 0.28 : 0.12)), lineWidth: primary ? 4 : 1))
+                }
+                .buttonStyle(.plain)
+                .disabled(!enabled)
+                .accessibilityLabel(accessibilityLabel)
+            } else {
+                Color.clear.frame(width: size, height: size)
+            }
+        }
+    }
+
+    private var background: Color {
+        if primary { return Color.white.opacity(0.95) }
+        if active { return .white }
+        if !enabled { return Color.black.opacity(0.28) }
+        return Color.black.opacity(0.58)
+    }
+
+    private var tint: Color {
+        if primary || active { return .black }
+        if enabled { return .white }
+        return .white.opacity(0.42)
+    }
+}
+
+private struct FrontlineEndButton: View {
+    let strings: [SerenadaString: String]?
+    let onClick: () -> Void
+
+    var body: some View {
+        Button(action: onClick) {
+            HStack(spacing: 8) {
+                Image(systemName: "phone.down.fill")
+                    .font(.system(size: 20, weight: .bold))
+                Text(resolveString(.frontlineEnd, overrides: strings).uppercased())
+                    .font(.system(size: 14, weight: .heavy))
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(frontlineDanger)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .shadow(color: .black.opacity(0.28), radius: 12, y: 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("call.frontline.endCall")
+        .accessibilityLabel(resolveString(.callA11yEndCall, overrides: strings))
+    }
+}
+
+private struct FrontlineMoreSheet: View {
+    let screenSharingEnabled: Bool
+    let inviteEnabled: Bool
+    let shareEnabled: Bool
+    let isScreenSharing: Bool
+    let screenShareExtensionBundleId: String?
+    @Binding var broadcastTriggerCount: Int
+    let strings: [SerenadaString: String]?
+    let onDismiss: () -> Void
+    let onToggleScreenShare: () -> Void
+    let onStartBroadcastPicker: () -> Void
+    let onInvite: () -> Void
+    let onShare: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.black.opacity(0.5)
+                .ignoresSafeArea()
+                .onTapGesture(perform: onDismiss)
+
+            VStack(spacing: 0) {
+                Capsule()
+                    .fill(Color.white.opacity(0.24))
+                    .frame(width: 36, height: 4)
+                    .padding(.top, 18)
+                    .padding(.bottom, 18)
+
+                if screenSharingEnabled {
+                    FrontlineSheetItem(
+                        systemImage: isScreenSharing ? "rectangle.on.rectangle.slash" : "rectangle.on.rectangle",
+                        title: isScreenSharing
+                            ? resolveString(.frontlineStopScreenShare, overrides: strings)
+                            : resolveString(.frontlineShareScreen, overrides: strings),
+                        subtitle: isScreenSharing
+                            ? resolveString(.frontlineReturnToCamera, overrides: strings)
+                            : resolveString(.frontlineShowYourPhone, overrides: strings),
+                        onClick: screenShareAction
+                    )
+                    .overlay {
+                        if shouldUseBroadcastPicker(isScreenSharing: isScreenSharing, screenShareExtensionBundleId: screenShareExtensionBundleId),
+                           let screenShareExtensionBundleId {
+                            FrontlineBroadcastTrigger(
+                                preferredExtension: screenShareExtensionBundleId,
+                                triggerCount: broadcastTriggerCount
+                            )
+                            .frame(width: 1, height: 1)
+                            .allowsHitTesting(false)
+                        }
+                    }
+                }
+
+                if inviteEnabled {
+                    FrontlineSheetItem(
+                        systemImage: "bell.badge.fill",
+                        title: resolveString(.callInviteToRoom, overrides: strings),
+                        subtitle: resolveString(.frontlineInviteSubtitle, overrides: strings),
+                        onClick: onInvite
+                    )
+                }
+
+                if shareEnabled {
+                    FrontlineSheetItem(
+                        systemImage: "square.and.arrow.up",
+                        title: resolveString(.callShareInvitation, overrides: strings),
+                        subtitle: resolveString(.frontlineShareLinkSubtitle, overrides: strings),
+                        onClick: onShare
+                    )
+                }
+
+                Button(action: onDismiss) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "xmark")
+                        Text(resolveString(.frontlineClose, overrides: strings))
+                            .font(.system(size: 15, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 48)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 12)
+            }
+            .padding(.horizontal, 18)
+            .padding(.bottom, 18)
+            .background(frontlineSheet)
+            .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+            .ignoresSafeArea(edges: .bottom)
+        }
+        .transition(.opacity)
+    }
+
+    private func screenShareAction() {
+        if shouldUseBroadcastPicker(isScreenSharing: isScreenSharing, screenShareExtensionBundleId: screenShareExtensionBundleId) {
+            onStartBroadcastPicker()
+        } else {
+            onToggleScreenShare()
+        }
+    }
+}
+
+private struct FrontlineSheetItem: View {
+    let systemImage: String
+    let title: String
+    let subtitle: String
+    let onClick: () -> Void
+
+    var body: some View {
+        Button(action: onClick) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 38, height: 38)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white)
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(frontlineDim)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct FrontlineBroadcastTrigger: UIViewRepresentable {
+    let preferredExtension: String
+    let triggerCount: Int
+
+    func makeUIView(context: Context) -> FrontlineBroadcastPickerContainerView {
+        FrontlineBroadcastPickerContainerView(preferredExtension: preferredExtension)
+    }
+
+    func updateUIView(_ uiView: FrontlineBroadcastPickerContainerView, context: Context) {
+        uiView.preferredExtension = preferredExtension
+        uiView.triggerIfNeeded(triggerCount)
+    }
+}
+
+private final class FrontlineBroadcastPickerContainerView: UIView {
+    private let pickerView = RPSystemBroadcastPickerView(frame: .zero)
+    private var lastTriggerCount = 0
+
+    var preferredExtension: String {
+        get { pickerView.preferredExtension ?? "" }
+        set { pickerView.preferredExtension = newValue }
+    }
+
+    init(preferredExtension: String) {
+        super.init(frame: .zero)
+        pickerView.preferredExtension = preferredExtension
+        pickerView.showsMicrophoneButton = false
+        pickerView.alpha = 0.02
+        addSubview(pickerView)
+        pickerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pickerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pickerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            pickerView.topAnchor.constraint(equalTo: topAnchor),
+            pickerView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func triggerIfNeeded(_ triggerCount: Int) {
+        guard triggerCount != lastTriggerCount else { return }
+        lastTriggerCount = triggerCount
+        DispatchQueue.main.async { [weak self] in
+            guard let button = self?.pickerView.subviews.compactMap({ $0 as? UIButton }).first else { return }
+            button.sendActions(for: .touchUpInside)
+        }
+    }
+}
+
+private struct FrontlineNameChip: View {
+    let label: String
+    let muted: Bool
+    let audioLevel: Float
+    var compact = false
+
+    var body: some View {
+        HStack(spacing: compact ? 5 : 7) {
+            FrontlineAudioIndicator(muted: muted, audioLevel: audioLevel, size: 14)
+            if !label.isEmpty {
+                Text(label)
+                    .font(.system(size: compact ? 11 : 12, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, compact ? 7 : 9)
+        .padding(.vertical, compact ? 4 : 5)
+        .background(Color.black.opacity(0.62))
+        .clipShape(Capsule())
+        .overlay(Capsule().stroke(Color.white.opacity(0.16), lineWidth: 1))
+    }
+}
+
+private struct FrontlineAudioIndicator: View {
+    let muted: Bool
+    let audioLevel: Float
+    let size: CGFloat
+
+    var body: some View {
+        if muted {
+            Image(systemName: "mic.slash.fill")
+                .font(.system(size: size * 0.8, weight: .bold))
+                .foregroundStyle(frontlineDanger)
+                .frame(width: size, height: size)
+        } else {
+            AudioActivityIndicator(level: audioLevel, size: size)
+        }
+    }
+}
+
+private struct FrontlineAvatar: View {
+    let peerId: String?
+    let displayName: String?
+    let size: CGFloat
+    let fontSize: CGFloat
+
+    var body: some View {
+        RemoteAvatarView(peerId: peerId, displayName: displayName, size: size)
+            .frame(width: size, height: size)
+    }
+}
+
+private struct FrontlineLocalAvatar: View {
+    let size: CGFloat
+    let fontSize: CGFloat
+    let displayName: String?
+    let strings: [SerenadaString: String]?
+
+    var body: some View {
+        ZStack {
+            Circle().fill(Color(red: 0x2A / 255, green: 0x35 / 255, blue: 0x40 / 255))
+            Text(label)
+                .font(.system(size: fontSize, weight: .heavy))
+                .foregroundStyle(.white)
+                .minimumScaleFactor(0.4)
+        }
+        .frame(width: size, height: size)
+    }
+
+    private var label: String {
+        let initials = initialsFor(displayName: displayName)
+        return initials.isEmpty ? resolveString(.frontlineYou, overrides: strings) : initials
+    }
+}
+
+private struct FrontlineMultiPartyStage: View {
+    let uiState: CallUiState
+    let localSpotlightId: String
+    let activeContentSpotlightId: String?
+    let localContentMode: Bool
+    @Binding var remoteTileAspectRatios: [String: CGFloat]
+    @Binding var pinnedSpotlightId: String?
+    @Binding var selectedSpotlightId: String?
+    let lastVideoStartedParticipantId: String?
+    let rendererProvider: CallRendererProvider
+    let strings: [SerenadaString: String]?
+    let onAdjustCameraZoom: (CGFloat) -> Void
+
+    @State private var lastMagnificationValue: CGFloat = 1
+    @State private var localAspectRatio: CGFloat?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let layout = computeFrontlineLayout(geometry: geometry)
+            ZStack {
+                ForEach(layout.tiles.sorted(by: { $0.zOrder < $1.zOrder }), id: \.id) { tile in
+                    tileView(tile)
+                        .frame(width: tile.frame.width, height: tile.frame.height)
+                        .clipShape(RoundedRectangle(cornerRadius: tile.cornerRadius))
+                        .position(x: tile.frame.x + tile.frame.width / 2, y: tile.frame.y + tile.frame.height / 2)
+                }
+
+                if let pip = layout.localPip {
+                    FrontlineLayoutTile(
+                        tileId: pip.participantId,
+                        isLocal: true,
+                        isContentTile: false,
+                        remote: nil,
+                        uiState: uiState,
+                        rendererProvider: rendererProvider,
+                        videoContentMode: pip.fit == .contain ? .scaleAspectFit : .scaleAspectFill,
+                        cornerRadius: pip.cornerRadius,
+                        pinned: false,
+                        strings: strings,
+                        onSelect: { selectedSpotlightId = pip.participantId },
+                        onTogglePinned: {
+                            pinnedSpotlightId = pip.participantId == pinnedSpotlightId ? nil : pip.participantId
+                        },
+                        onLocalVideoSizeChanged: { localAspectRatio = quantizedFrontlineAspectRatio($0) },
+                        onRemoteVideoSizeChanged: { _, _ in },
+                        localZoomEnabled: false,
+                        localZoomGesture: localZoomGesture(enabled: false)
+                    )
+                    .frame(width: pip.frame.width, height: pip.frame.height)
+                    .clipShape(RoundedRectangle(cornerRadius: pip.cornerRadius))
+                    .position(x: pip.frame.x + pip.frame.width / 2, y: pip.frame.y + pip.frame.height / 2)
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .background(frontlineBlack)
+        }
+    }
+
+    private func computeFrontlineLayout(geometry: GeometryProxy) -> LayoutResult {
+        let contentSource = activeContentSource
+        var availableIds = Set(uiState.remoteParticipants.map(\.cid))
+        availableIds.insert(localSpotlightId)
+        if let activeContentSpotlightId {
+            availableIds.insert(activeContentSpotlightId)
+        }
+        let defaultPrimary = lastVideoStartedParticipantId.flatMap { availableIds.contains($0) ? $0 : nil }
+            ?? uiState.remoteParticipants.first?.cid
+            ?? localSpotlightId
+        let effectiveSpotlight = pinnedSpotlightId.flatMap { availableIds.contains($0) ? $0 : nil }
+            ?? selectedSpotlightId.flatMap { availableIds.contains($0) ? $0 : nil }
+            ?? defaultPrimary
+        let spotlightIsContent = contentSource != nil && activeContentSpotlightId != nil && effectiveSpotlight == activeContentSpotlightId
+
+        var participants = uiState.remoteParticipants.map {
+            SceneParticipant(
+                id: $0.cid,
+                role: .remote,
+                videoEnabled: $0.videoEnabled,
+                videoAspectRatio: remoteTileAspectRatios[$0.cid]
+            )
+        }
+        if frontlineIncludesNormalLocalStageTile(
+            localSpotlightId: localSpotlightId,
+            activeContentOwnerId: contentSource?.ownerParticipantId,
+            contentTileIsSpotlight: spotlightIsContent
+        ) {
+            participants.append(
+                SceneParticipant(
+                    id: localSpotlightId,
+                    role: .local,
+                    videoEnabled: uiState.localVideoEnabled,
+                    videoAspectRatio: localAspectRatio
+                )
+            )
+        }
+        if let contentSource, let activeContentSpotlightId, !spotlightIsContent {
+            participants.append(
+                SceneParticipant(
+                    id: activeContentSpotlightId,
+                    role: .remote,
+                    videoEnabled: true,
+                    videoAspectRatio: contentSource.aspectRatio
+                )
+            )
+        }
+
+        return computeLayout(scene: CallScene(
+            viewportWidth: geometry.size.width,
+            viewportHeight: geometry.size.height,
+            safeAreaInsets: LayoutInsets(),
+            participants: participants,
+            localParticipantId: localSpotlightId,
+            activeSpeakerId: nil,
+            pinnedParticipantId: spotlightIsContent ? nil : effectiveSpotlight,
+            contentSource: spotlightIsContent ? contentSource : nil,
+            userPrefs: UserLayoutPrefs(dominantFit: .cover)
+        ))
+    }
+
+    @ViewBuilder
+    private func tileView(_ tile: TileLayout) -> some View {
+        let contentSource = activeContentSource
+        let isSyntheticContentTile = activeContentSpotlightId != nil && tile.id == activeContentSpotlightId
+        let isContentTile = tile.type == .contentSource || isSyntheticContentTile
+        let contentOwnerCid = isContentTile ? contentSource?.ownerParticipantId : nil
+        let tileSpotlightId = isContentTile ? (activeContentSpotlightId ?? tile.id) : tile.id
+        let isLocal = tile.id == localSpotlightId && !isContentTile
+        let isLocalContent = isContentTile && contentOwnerCid == localSpotlightId
+        let localZoomEnabled = isLocalContent && frontlineAllowsLocalCameraZoom(
+            phase: uiState.phase,
+            localVideoEnabled: uiState.localVideoEnabled,
+            localCameraMode: uiState.localCameraMode,
+            isScreenSharing: uiState.isScreenSharing
+        )
+        let remote = {
+            if let contentOwnerCid, contentOwnerCid != localSpotlightId {
+                return uiState.remoteParticipants.first(where: { $0.cid == contentOwnerCid })
+            }
+            if !isLocal {
+                return uiState.remoteParticipants.first(where: { $0.cid == tile.id })
+            }
+            return nil
+        }()
+
+        FrontlineLayoutTile(
+            tileId: tile.id,
+            isLocal: isLocal || isLocalContent,
+            isContentTile: isContentTile,
+            remote: remote,
+            uiState: uiState,
+            rendererProvider: rendererProvider,
+            videoContentMode: isLocalContent && uiState.isScreenSharing ? .scaleAspectFit : (tile.fit == .contain ? .scaleAspectFit : .scaleAspectFill),
+            cornerRadius: tile.cornerRadius,
+            pinned: tileSpotlightId == pinnedSpotlightId,
+            strings: strings,
+            onSelect: { selectedSpotlightId = tileSpotlightId },
+            onTogglePinned: {
+                pinnedSpotlightId = tileSpotlightId == pinnedSpotlightId ? nil : tileSpotlightId
+            },
+            onLocalVideoSizeChanged: { localAspectRatio = quantizedFrontlineAspectRatio($0) },
+            onRemoteVideoSizeChanged: { cid, size in remoteTileAspectRatios[cid] = quantizedFrontlineAspectRatio(size) },
+            localZoomEnabled: localZoomEnabled,
+            localZoomGesture: localZoomGesture(enabled: localZoomEnabled)
+        )
+    }
+
+    private var activeContentSource: ContentSource? {
+        guard let activeContentSpotlightId else { return nil }
+        let owner = activeContentSpotlightId.removingFrontlineContentSpotlightPrefix
+        if owner == localSpotlightId {
+            let type: ContentType = {
+                if uiState.isScreenSharing { return .screenShare }
+                if uiState.localCameraMode == .world { return .worldCamera }
+                return .compositeCamera
+            }()
+            return ContentSource(type: type, ownerParticipantId: owner, aspectRatio: localAspectRatio)
+        }
+        if owner == uiState.remoteContentCid {
+            let type: ContentType = {
+                switch uiState.remoteContentType {
+                case ContentTypeWire.worldCamera: return .worldCamera
+                case ContentTypeWire.compositeCamera: return .compositeCamera
+                default: return .screenShare
+                }
+            }()
+            return ContentSource(type: type, ownerParticipantId: owner, aspectRatio: remoteTileAspectRatios[owner])
+        }
+        return nil
+    }
+
+    private func localZoomGesture(enabled: Bool) -> some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                guard enabled else { return }
+                let delta = value / max(lastMagnificationValue, 0.001)
+                lastMagnificationValue = value
+                guard abs(delta - 1) > 0.01 else { return }
+                onAdjustCameraZoom(delta)
+            }
+            .onEnded { _ in lastMagnificationValue = 1 }
+    }
+}
+
+private struct FrontlineLayoutTile<ZoomGesture: Gesture>: View {
+    let tileId: String
+    let isLocal: Bool
+    let isContentTile: Bool
+    let remote: RemoteParticipant?
+    let uiState: CallUiState
+    let rendererProvider: CallRendererProvider
+    let videoContentMode: UIView.ContentMode
+    let cornerRadius: CGFloat
+    let pinned: Bool
+    let strings: [SerenadaString: String]?
+    let onSelect: () -> Void
+    let onTogglePinned: () -> Void
+    let onLocalVideoSizeChanged: (CGSize) -> Void
+    let onRemoteVideoSizeChanged: (String, CGSize) -> Void
+    let localZoomEnabled: Bool
+    let localZoomGesture: ZoomGesture
+
+    var body: some View {
+        let displayName = isLocal
+            ? (uiState.localDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? uiState.localDisplayName! : resolveString(.frontlineYou, overrides: strings))
+            : remoteDisplayName(remote)
+        let muted = isLocal ? !uiState.localAudioEnabled : remote?.audioEnabled == false
+        let audioLevel = isLocal ? uiState.localAudioLevel : remote?.audioLevel ?? 0
+        let videoEnabled = isLocal ? (uiState.localVideoEnabled || uiState.isScreenSharing) : remote?.videoEnabled == true
+        let showLocalVideoAccent = isLocal && uiState.localVideoEnabled
+        let tileShape = RoundedRectangle(cornerRadius: cornerRadius)
+
+        ZStack(alignment: .bottomLeading) {
+            frontlineSurface
+
+            if isLocal {
+                if videoEnabled {
+                    WebRTCVideoView(
+                        kind: .local,
+                        rendererProvider: rendererProvider,
+                        videoContentMode: videoContentMode,
+                        isMirrored: !isContentTile && uiState.isFrontCamera && !uiState.isScreenSharing,
+                        onVideoSizeChanged: onLocalVideoSizeChanged
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipShape(tileShape)
+                    if localZoomEnabled {
+                        Color.clear
+                            .contentShape(tileShape)
+                            .accessibilityHidden(true)
+                            .simultaneousGesture(localZoomGesture)
+                    }
+                } else {
+                    FrontlineLocalAvatar(size: 86, fontSize: 34, displayName: displayName, strings: strings)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            } else if let remote, remote.videoEnabled {
+                WebRTCVideoView(
+                    kind: .remoteForCid(remote.cid),
+                    rendererProvider: rendererProvider,
+                    videoContentMode: videoContentMode,
+                    onVideoSizeChanged: { onRemoteVideoSizeChanged(remote.cid, $0) }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipShape(tileShape)
+            } else {
+                FrontlineAvatar(peerId: remote?.peerId, displayName: displayName, size: 86, fontSize: 32)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            if pinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+                    .background(Color.black.opacity(0.62))
+                    .clipShape(Circle())
+                    .padding(8)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+
+            if !isContentTile {
+                FrontlineNameChip(label: displayName, muted: muted, audioLevel: audioLevel, compact: true)
+                    .padding(6)
+            }
+        }
+        .clipShape(tileShape)
+        .overlay {
+            if showLocalVideoAccent {
+                tileShape
+                    .strokeBorder(frontlineAccent, lineWidth: frontlinePipVideoAccentLineWidth)
+                    .allowsHitTesting(false)
+            }
+        }
+        .contentShape(tileShape)
+        .onTapGesture(perform: onSelect)
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in onTogglePinned() }
+        )
+    }
+}
+
+private func quantizedFrontlineAspectRatio(_ size: CGSize) -> CGFloat {
+    guard size.width > 0, size.height > 0 else {
+        return clampStageTileAspectRatio(nil)
+    }
+    let rawRatio = size.width / size.height
+    let quantized = (rawRatio / 0.05).rounded() * 0.05
+    return clampStageTileAspectRatio(max(0.1, quantized))
+}
+
+private struct FrontlineDebugPanel: View {
+    let uiState: CallUiState
+
+    var body: some View {
+        let sections = buildDebugPanelSections(uiState: uiState)
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(sections) { section in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(section.title)
+                        .font(.caption.weight(.semibold))
+                    ForEach(section.metrics) { metric in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(debugDotColor(metric.status))
+                                .frame(width: 8, height: 8)
+                            if !metric.label.isEmpty {
+                                Text(metric.label)
+                                    .font(.caption2)
+                            }
+                            Spacer(minLength: 8)
+                            Text(metric.value)
+                                .font(.caption2)
+                        }
+                    }
+                }
+            }
+        }
+        .foregroundStyle(Color.white.opacity(0.95))
+        .padding(10)
+        .frame(maxWidth: 430, maxHeight: 520)
+        .background(Color.black.opacity(0.62))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func debugDotColor(_ status: DebugStatus) -> Color {
+        switch status {
+        case .good:
+            return Color(red: 0.18, green: 0.80, blue: 0.44)
+        case .warn:
+            return Color(red: 0.94, green: 0.77, blue: 0.06)
+        case .bad:
+            return Color(red: 0.91, green: 0.30, blue: 0.24)
+        case .na:
+            return Color(red: 0.58, green: 0.65, blue: 0.65)
+        }
+    }
+}

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -180,6 +180,9 @@ private struct URLFirstCallFlow: View {
             var effectiveConfig = serenadaConfig
             if !config.videoEnabled {
                 effectiveConfig.cameraModes = []
+            } else if config.uiVariant == .frontline {
+                effectiveConfig.defaultVideoEnabled = false
+                effectiveConfig.cameraModes = [.world, .selfie, .composite]
             }
             let newCore = SerenadaCore(config: effectiveConfig)
             core = newCore
@@ -239,98 +242,162 @@ private struct SessionFirstCallFlow: View {
         Group {
             switch phase {
             case .idle, .joining:
-                VStack(spacing: 16) {
-                    ProgressView()
-                    Text(resolveString(.callJoining, overrides: strings))
-                        .foregroundStyle(.white)
+                if config.uiVariant == .frontline {
+                    frontlineCallScreen(state: state)
+                } else {
+                    VStack(spacing: 16) {
+                        ProgressView()
+                        Text(resolveString(.callJoining, overrides: strings))
+                            .foregroundStyle(.white)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black)
 
             case .awaitingPermissions:
-                VStack(spacing: 16) {
-                    Text(resolveString(.callPermissionsRequired, overrides: strings))
-                        .foregroundStyle(.white)
-                        .multilineTextAlignment(.center)
-                    Button("Grant Access") {
-                        Task {
-                            let granted = await SerenadaPermissions.request(
-                                state.requiredPermissions ?? [.camera, .microphone]
-                            )
-                            if granted {
-                                session.resumeJoin()
-                            } else {
-                                session.cancelJoin()
+                if config.uiVariant == .frontline {
+                    frontlineCallScreen(state: state)
+                } else {
+                    VStack(spacing: 16) {
+                        Text(resolveString(.callPermissionsRequired, overrides: strings))
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                        Button(resolveString(.callGrantAccess, overrides: strings)) {
+                            requestPermissions(state: state)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black)
+                }
+
+            case .waiting, .inCall:
+                if config.uiVariant == .frontline {
+                    frontlineCallScreen(state: state)
+                } else {
+                    // Session-first mode renders through bridge using session as renderer provider
+                    CallScreenView(
+                        roomId: session.roomId,
+                        uiState: mapSessionToUiState(session),
+                        roomShareURL: session.roomUrl,
+                        screenShareExtensionBundleId: session.screenShareExtensionBundleId,
+                        roomName: params.roomName,
+                        config: config,
+                        strings: strings,
+                        onToggleAudio: { session.toggleAudio() },
+                        onToggleVideo: { session.toggleVideo() },
+                        onFlipCamera: { session.flipCamera() },
+                        onToggleScreenShare: toggleScreenShare,
+                        onAdjustCameraZoom: { _ = session.adjustCameraZoom(by: $0) },
+                        onResetCameraZoom: { _ = session.resetCameraZoom() },
+                        onToggleFlashlight: { _ = session.toggleFlashlight() },
+                        onEndCall: endCall,
+                        onInviteToRoom: inviteToRoom,
+                        onSnapshotRequested: makeSnapshotHandler(),
+                        rendererProvider: session,
+                        initialRemoteVideoFitCover: params.initialRemoteVideoFitCover,
+                        onRemoteVideoFitChanged: params.onRemoteVideoFitChanged
+                    )
+                }
+
+            case .ending:
+                if config.uiVariant == .frontline {
+                    frontlineCallScreen(state: state)
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                                 onDismiss?()
                             }
                         }
+                } else {
+                    VStack(spacing: 16) {
+                        Text(resolveString(.callEnded, overrides: strings))
+                            .foregroundStyle(.white)
                     }
-                    .buttonStyle(.borderedProminent)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black)
-
-            case .waiting, .inCall:
-                // Session-first mode renders through bridge using session as renderer provider
-                CallScreenView(
-                    roomId: session.roomId,
-                    uiState: mapSessionToUiState(session),
-                    roomShareURL: session.roomUrl,
-                    screenShareExtensionBundleId: session.screenShareExtensionBundleId,
-                    roomName: params.roomName,
-                    config: config,
-                    strings: strings,
-                    onToggleAudio: { session.toggleAudio() },
-                    onToggleVideo: { session.toggleVideo() },
-                    onFlipCamera: { session.flipCamera() },
-                    onToggleScreenShare: {
-                        if session.state.localParticipant.cameraMode == .screenShare {
-                            session.stopScreenShare()
-                        } else {
-                            session.startScreenShare()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            onDismiss?()
                         }
-                    },
-                    onAdjustCameraZoom: { _ = session.adjustCameraZoom(by: $0) },
-                    onResetCameraZoom: { _ = session.resetCameraZoom() },
-                    onToggleFlashlight: { _ = session.toggleFlashlight() },
-                    onEndCall: {
-                        session.leave()
-                        onCallEnded?(.localLeft)
-                        onDismiss?()
-                    },
-                    onInviteToRoom: params.onInviteToRoom ?? {
-                        .failure(NSError(domain: "SerenadaCallUI", code: 0, userInfo: [NSLocalizedDescriptionKey: "Not implemented"]))
-                    },
-                    onSnapshotRequested: makeSnapshotHandler(),
-                    rendererProvider: session,
-                    initialRemoteVideoFitCover: params.initialRemoteVideoFitCover,
-                    onRemoteVideoFitChanged: params.onRemoteVideoFitChanged
-                )
-
-            case .ending:
-                VStack(spacing: 16) {
-                    Text(resolveString(.callEnded, overrides: strings))
-                        .foregroundStyle(.white)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black)
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                        onDismiss?()
                     }
                 }
 
             case .error:
-                VStack(spacing: 16) {
-                    Text(resolveString(.callErrorGeneric, overrides: strings))
-                        .foregroundStyle(.white)
-                    if let onDismiss {
-                        Button("Dismiss") { onDismiss() }
-                            .buttonStyle(.borderedProminent)
+                if config.uiVariant == .frontline {
+                    frontlineCallScreen(state: state)
+                } else {
+                    VStack(spacing: 16) {
+                        Text(resolveString(.callErrorGeneric, overrides: strings))
+                            .foregroundStyle(.white)
+                        if let onDismiss {
+                            Button(resolveString(.callDismiss, overrides: strings)) { onDismiss() }
+                                .buttonStyle(.borderedProminent)
+                        }
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black)
+            }
+        }
+    }
+
+    private func frontlineCallScreen(state: CallState) -> some View {
+        FrontlineCallScreenView(
+            roomId: session.roomId,
+            uiState: mapSessionToUiState(session),
+            sessionPhase: state.phase,
+            roomShareURL: session.roomUrl,
+            screenShareExtensionBundleId: session.screenShareExtensionBundleId,
+            roomName: params.roomName,
+            config: config,
+            strings: strings,
+            onToggleAudio: { session.toggleAudio() },
+            onToggleVideo: { session.toggleVideo() },
+            onFlipCamera: { session.flipCamera() },
+            onToggleScreenShare: toggleScreenShare,
+            onAdjustCameraZoom: { _ = session.adjustCameraZoom(by: $0) },
+            onResetCameraZoom: { _ = session.resetCameraZoom() },
+            onToggleFlashlight: { _ = session.toggleFlashlight() },
+            onEndCall: endCall,
+            onInviteToRoom: inviteToRoom,
+            onRequestPermissions: { requestPermissions(state: state) },
+            onDismiss: onDismiss,
+            onSnapshotRequested: makeSnapshotHandler(),
+            rendererProvider: session
+        )
+    }
+
+    private func toggleScreenShare() {
+        if session.state.localParticipant.cameraMode == .screenShare {
+            session.stopScreenShare()
+        } else {
+            session.startScreenShare()
+        }
+    }
+
+    private func endCall() {
+        session.leave()
+        onCallEnded?(.localLeft)
+        onDismiss?()
+    }
+
+    private func inviteToRoom() async -> Result<Void, Error> {
+        if let onInviteToRoom = params.onInviteToRoom {
+            return await onInviteToRoom()
+        }
+        return .failure(NSError(domain: "SerenadaCallUI", code: 0, userInfo: [NSLocalizedDescriptionKey: "Not implemented"]))
+    }
+
+    private func requestPermissions(state: CallState) {
+        Task {
+            let granted = await SerenadaPermissions.request(
+                state.requiredPermissions ?? [.camera, .microphone]
+            )
+            if granted {
+                session.resumeJoin()
+            } else {
+                session.cancelJoin()
+                onDismiss?()
             }
         }
     }
@@ -385,6 +452,7 @@ private struct SessionFirstCallFlow: View {
         uiState.isFlashEnabled = diagnostics.isFlashEnabled
         uiState.remoteContentCid = diagnostics.remoteContentParticipantId
         uiState.remoteContentType = diagnostics.remoteContentType
+        uiState.callStartedAtMs = state.callStartedAtMs
         // Hide presumed-lost remotes from the call grid — the SDK keeps their
         // peer connections open in case they reattach, but the active grid
         // should not display them. Host apps wanting different presentation

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// Visual presentation used by the prebuilt Serenada call UI.
+public enum SerenadaCallUiVariant: String, CaseIterable {
+    case standard
+    case frontline
+}
+
 /// Configuration for SerenadaCallFlow feature toggles.
 /// When a feature is disabled, the corresponding control is removed from the UI entirely.
 public struct SerenadaCallFlowConfig {
@@ -38,6 +44,10 @@ public struct SerenadaCallFlowConfig {
     /// `SerenadaConfig` used to build the session.
     public var videoEnabled: Bool
 
+    /// Selects the prebuilt visual presentation. Defaults to the existing
+    /// standard call UI.
+    public var uiVariant: SerenadaCallUiVariant
+
     public init(
         screenSharingEnabled: Bool = true,
         inviteControlsEnabled: Bool = true,
@@ -45,7 +55,8 @@ public struct SerenadaCallFlowConfig {
         autoHideControls: Bool = true,
         snapshotEnabled: Bool = false,
         avatarProvider: AvatarProvider? = nil,
-        videoEnabled: Bool = true
+        videoEnabled: Bool = true,
+        uiVariant: SerenadaCallUiVariant = .standard
     ) {
         self.screenSharingEnabled = screenSharingEnabled
         self.inviteControlsEnabled = inviteControlsEnabled
@@ -54,5 +65,6 @@ public struct SerenadaCallFlowConfig {
         self.snapshotEnabled = snapshotEnabled
         self.avatarProvider = avatarProvider
         self.videoEnabled = videoEnabled
+        self.uiVariant = uiVariant
     }
 }

--- a/client-ios/SerenadaCallUI/Sources/SerenadaString.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaString.swift
@@ -34,6 +34,23 @@ public enum SerenadaString: String, CaseIterable {
     case callPermissionsRequired
     case callPermissionsCamera
     case callPermissionsMicrophone
+    case callGrantAccess
+    case callDismiss
+    case frontlineYou
+    case frontlineWaiting
+    case frontlineVideo
+    case frontlineVideoOn
+    case frontlineMute
+    case frontlineMore
+    case frontlineEnd
+    case frontlineFlipCamera
+    case frontlineStopScreenShare
+    case frontlineShareScreen
+    case frontlineReturnToCamera
+    case frontlineShowYourPhone
+    case frontlineInviteSubtitle
+    case frontlineShareLinkSubtitle
+    case frontlineClose
 }
 
 /// Default English strings for SerenadaCallUI.
@@ -69,6 +86,23 @@ public let serenadaDefaultStrings: [SerenadaString: String] = [
     .callPermissionsRequired: "Camera and microphone access are required",
     .callPermissionsCamera: "Camera",
     .callPermissionsMicrophone: "Microphone",
+    .callGrantAccess: "Grant Access",
+    .callDismiss: "Dismiss",
+    .frontlineYou: "You",
+    .frontlineWaiting: "Waiting",
+    .frontlineVideo: "Video",
+    .frontlineVideoOn: "Video on",
+    .frontlineMute: "Mute",
+    .frontlineMore: "More",
+    .frontlineEnd: "End",
+    .frontlineFlipCamera: "Flip camera",
+    .frontlineStopScreenShare: "Stop screen share",
+    .frontlineShareScreen: "Share screen",
+    .frontlineReturnToCamera: "Return to camera",
+    .frontlineShowYourPhone: "Show your phone screen",
+    .frontlineInviteSubtitle: "Send a live-call notification",
+    .frontlineShareLinkSubtitle: "Copy or share the room link",
+    .frontlineClose: "Close",
 ]
 
 /// Resolves a string key, checking overrides first, then falling back to English defaults.

--- a/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
+++ b/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
@@ -159,4 +159,80 @@ final class CallScreenStateTests: XCTestCase {
             )
         )
     }
+
+    func testFrontlineWaitingOnlyWhenCallSurfaceHasNoRemoteParticipants() {
+        var state = CallUiState()
+        state.phase = .waiting
+        XCTAssertTrue(frontlineIsWaitingForRemote(state))
+
+        state.remoteParticipants = [
+            RemoteParticipant(cid: "r1", videoEnabled: false, connectionState: .new)
+        ]
+        XCTAssertFalse(frontlineIsWaitingForRemote(state))
+
+        state.phase = .joining
+        state.remoteParticipants = []
+        XCTAssertFalse(frontlineIsWaitingForRemote(state))
+    }
+
+    func testFrontlineLargeLocalPreviewMatchesContentModeAndPipSwap() {
+        XCTAssertTrue(frontlineUsesLargeLocalPreview(localVideoEnabled: true, localCameraMode: .world, isScreenSharing: false, pipSwapped: false))
+        XCTAssertFalse(frontlineUsesLargeLocalPreview(localVideoEnabled: true, localCameraMode: .world, isScreenSharing: false, pipSwapped: true))
+        XCTAssertFalse(frontlineUsesLargeLocalPreview(localVideoEnabled: true, localCameraMode: .selfie, isScreenSharing: false, pipSwapped: false))
+        XCTAssertTrue(frontlineUsesLargeLocalPreview(localVideoEnabled: true, localCameraMode: .selfie, isScreenSharing: false, pipSwapped: true))
+        XCTAssertTrue(frontlineUsesLargeLocalPreview(localVideoEnabled: true, localCameraMode: .selfie, isScreenSharing: true, pipSwapped: false))
+        XCTAssertFalse(frontlineUsesLargeLocalPreview(localVideoEnabled: false, localCameraMode: .world, isScreenSharing: false, pipSwapped: false))
+    }
+
+    func testFrontlineZoomEligibilityAllowsWaitingAndInCallContentCameraOnly() {
+        XCTAssertTrue(frontlineAllowsLocalCameraZoom(phase: .waiting, localVideoEnabled: true, localCameraMode: .world, isScreenSharing: false))
+        XCTAssertTrue(frontlineAllowsLocalCameraZoom(phase: .inCall, localVideoEnabled: true, localCameraMode: .composite, isScreenSharing: false))
+        XCTAssertFalse(frontlineAllowsLocalCameraZoom(phase: .joining, localVideoEnabled: true, localCameraMode: .world, isScreenSharing: false))
+        XCTAssertFalse(frontlineAllowsLocalCameraZoom(phase: .inCall, localVideoEnabled: true, localCameraMode: .selfie, isScreenSharing: false))
+        XCTAssertFalse(frontlineAllowsLocalCameraZoom(phase: .inCall, localVideoEnabled: false, localCameraMode: .world, isScreenSharing: false))
+        XCTAssertFalse(frontlineAllowsLocalCameraZoom(phase: .inCall, localVideoEnabled: true, localCameraMode: .world, isScreenSharing: true))
+    }
+
+    func testFrontlineStageOmitsNormalLocalTileWhenLocalContentIsInFilmstrip() {
+        XCTAssertFalse(
+            frontlineIncludesNormalLocalStageTile(
+                localSpotlightId: "local",
+                activeContentOwnerId: "local",
+                contentTileIsSpotlight: false
+            )
+        )
+        XCTAssertTrue(
+            frontlineIncludesNormalLocalStageTile(
+                localSpotlightId: "local",
+                activeContentOwnerId: "local",
+                contentTileIsSpotlight: true
+            )
+        )
+        XCTAssertTrue(
+            frontlineIncludesNormalLocalStageTile(
+                localSpotlightId: "local",
+                activeContentOwnerId: "remote",
+                contentTileIsSpotlight: false
+            )
+        )
+        XCTAssertTrue(
+            frontlineIncludesNormalLocalStageTile(
+                localSpotlightId: "local",
+                activeContentOwnerId: nil,
+                contentTileIsSpotlight: false
+            )
+        )
+    }
+
+    func testFrontlineSnapshotPrefersLocalThenFirstRemoteVideo() {
+        let remotes = [
+            RemoteParticipant(cid: "r1", videoEnabled: false, connectionState: .new),
+            RemoteParticipant(cid: "r2", videoEnabled: true, connectionState: .new)
+        ]
+
+        XCTAssertNil(frontlineSnapshotSource(snapshotEnabled: false, localVideoEnabled: true, remoteParticipants: remotes))
+        XCTAssertEqual(frontlineSnapshotSource(snapshotEnabled: true, localVideoEnabled: true, remoteParticipants: remotes), .local)
+        XCTAssertEqual(frontlineSnapshotSource(snapshotEnabled: true, localVideoEnabled: false, remoteParticipants: remotes), .remote(cid: "r2"))
+        XCTAssertNil(frontlineSnapshotSource(snapshotEnabled: true, localVideoEnabled: false, remoteParticipants: []))
+    }
 }

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -213,6 +213,8 @@ public struct CallState: Equatable {
     public var requiredPermissions: [MediaCapability]?
     /// Current error, if the phase is `.error`.
     public var error: CallError?
+    /// Wall-clock timestamp in milliseconds when the local participant joined this call.
+    public var callStartedAtMs: Int64?
 
     public init() {}
 }

--- a/client-ios/SerenadaCore/Sources/Models/CallUiState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallUiState.swift
@@ -36,6 +36,7 @@ public struct CallUiState: Equatable {
     public var isFlashEnabled: Bool = false
     public var remoteContentCid: String?
     public var remoteContentType: String?
+    public var callStartedAtMs: Int64?
 
     public var remoteVideoEnabled: Bool {
         remoteParticipants.first?.videoEnabled ?? false

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -98,6 +98,7 @@ public final class SerenadaCore {
                 signalingProvider: nil,
                 defaultAudioEnabled: config.defaultAudioEnabled,
                 defaultVideoEnabled: config.defaultVideoEnabled,
+                cameraModes: config.cameraModes,
                 transports: config.transports,
                 proximityMonitoringEnabled: config.proximityMonitoringEnabled
             )

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -227,6 +227,7 @@ public final class SerenadaSession: ObservableObject {
 
     private let recoveryStorage: RecoveryStorage
     private var sessionStartTs: Int64?
+    private var callStartedAtMs: Int64?
 
     public convenience init(
         roomId: String,
@@ -517,7 +518,8 @@ public final class SerenadaSession: ObservableObject {
     /// Adjust camera zoom by a relative scale delta. Returns the new zoom factor, or nil if inactive.
     @discardableResult
     public func adjustCameraZoom(by scaleDelta: CGFloat) -> Double? {
-        guard internalPhase == .inCall, state.localParticipant.cameraMode.isContentMode else { return nil }
+        guard (internalPhase == .inCall || internalPhase == .waiting),
+              state.localParticipant.cameraMode.isContentMode else { return nil }
         return webRtcEngine.adjustCaptureZoom(by: scaleDelta)
     }
 
@@ -529,6 +531,7 @@ public final class SerenadaSession: ObservableObject {
         currentRequiredPermissions = nil
         currentError = nil
         internalPhase = .joining
+        callStartedAtMs = Self.nowMs()
         commitSnapshot()
         Task { @MainActor [weak self] in
             await self?.prepareMediaAndConnect()
@@ -609,6 +612,7 @@ public final class SerenadaSession: ObservableObject {
             delegateProvider?()?.sessionRequiresPermissions(self, permissions: required)
             return
         }
+        callStartedAtMs = Self.nowMs()
         await prepareMediaAndConnect()
     }
 
@@ -861,6 +865,13 @@ public final class SerenadaSession: ObservableObject {
         let count = max(1, roomState.participants.count)
         let phase: CallPhase = count <= 1 ? .waiting : .inCall
         if phase != .joining { joinFlowCoordinator?.clearJoinTimeout() }
+        let localJoinedAtMs = roomState.participants
+            .first(where: { $0.cid == clientId })?
+            .joinedAt
+            .flatMap { Self.isPlausibleJoinedAtMs($0, nowMs: Self.nowMs()) ? $0 : nil }
+        if let localJoinedAtMs {
+            callStartedAtMs = localJoinedAtMs
+        }
 
         internalPhase = phase
         participantCount = count
@@ -1124,6 +1135,7 @@ public final class SerenadaSession: ObservableObject {
         connectionStatusTracker?.cancelTimer()
         iceFetchGeneration += 1
         sessionStartTs = nil
+        callStartedAtMs = nil
         if clearRecovery { recoveryStorage.clear() }
 
         let videoCaptureSupported = !availableCameraModes.isEmpty
@@ -1425,6 +1437,7 @@ public final class SerenadaSession: ObservableObject {
         nextState.phase = currentRequiredPermissions != nil ? .awaitingPermissions : mapPhase(internalPhase)
         nextState.roomId = roomId; nextState.roomUrl = roomUrl
         nextState.error = currentError; nextState.requiredPermissions = currentRequiredPermissions
+        nextState.callStartedAtMs = callStartedAtMs
         nextDiag.callStats = CallStats(from: nextDiag.realtimeStats)
         if nextState != state { state = nextState }
         if nextDiag != diagnostics { diagnostics = nextDiag }
@@ -1697,7 +1710,13 @@ public final class SerenadaSession: ObservableObject {
         Int64(Date().timeIntervalSince1970 * 1000)
     }
 
+    private static func isPlausibleJoinedAtMs(_ joinedAtMs: Int64, nowMs: Int64) -> Bool {
+        joinedAtMs >= plausibleEpochMs && joinedAtMs <= nowMs + joinedAtFutureSkewMs
+    }
+
     /// Matches the server's `reconnectTokenTTL` (= `suspendHardEvictionTimeout`).
     /// Used when the server did not surface `reconnectTokenTTLMs`.
     private static let defaultRecoveryTokenTTLMs: Int64 = 10 * 60 * 1000
+    private static let plausibleEpochMs: Int64 = 946_684_800_000
+    private static let joinedAtFutureSkewMs: Int64 = 5 * 60 * 1000
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -45,7 +45,12 @@ final class FakeMediaEngine: SessionMediaEngine {
     @discardableResult func toggleFlashlight() -> Bool { false }
     func startScreenShare(onComplete: ((Bool) -> Void)?) -> Bool { false }
     func stopScreenShare() -> Bool { false }
-    @discardableResult func adjustCaptureZoom(by scaleDelta: CGFloat) -> Double? { nil }
+    private(set) var adjustCaptureZoomCalls: [CGFloat] = []
+    var adjustCaptureZoomResult: Double? = 1.25
+    @discardableResult func adjustCaptureZoom(by scaleDelta: CGFloat) -> Double? {
+        adjustCaptureZoomCalls.append(scaleDelta)
+        return adjustCaptureZoomResult
+    }
     @discardableResult func resetCaptureZoom() -> Double { 1.0 }
 
     func setIceServers(_ servers: [IceServerConfig]) {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
@@ -79,4 +79,44 @@ final class SerenadaSessionTests: XCTestCase {
         XCTAssertEqual(media.startLocalMediaCalls.first, false)
         session.cancelJoin()
     }
+
+    func testAdjustCameraZoomAllowedWhileWaitingWithContentCamera() async {
+        let provider = FakeSignalingProvider()
+        let media = FakeMediaEngine()
+        let session = SerenadaSession(
+            roomId: "provider-room",
+            config: SerenadaConfig(
+                signalingProvider: provider,
+                cameraModes: [.world]
+            ),
+            initialSignalingProvider: provider,
+            mediaEngine: media
+        )
+
+        await yieldToMainActor()
+        if session.state.phase == .awaitingPermissions {
+            session.resumeJoin()
+            await yieldToMainActor()
+        }
+        provider.simulateConnected()
+        provider.simulateJoined(
+            peerId: "local-cid-1",
+            participants: [SignalingProviderParticipant(peerId: "local-cid-1", joinedAt: 1)],
+            hostPeerId: "local-cid-1"
+        )
+        await yieldToMainActor()
+
+        XCTAssertEqual(session.state.phase, .waiting)
+        XCTAssertEqual(session.state.localParticipant.cameraMode, .world)
+        XCTAssertEqual(session.adjustCameraZoom(by: 1.2), 1.25)
+        XCTAssertEqual(media.adjustCaptureZoomCalls, [1.2])
+        session.cancelJoin()
+    }
+
+    private func yieldToMainActor() async {
+        await Task.yield()
+        await Task.yield()
+        await Task.yield()
+        await Task.yield()
+    }
 }

--- a/client-ios/Sources/App/RootView.swift
+++ b/client-ios/Sources/App/RootView.swift
@@ -107,7 +107,8 @@ struct RootView: View {
                             screenSharingEnabled: true,
                             inviteControlsEnabled: true,
                             debugOverlayEnabled: true,
-                            snapshotEnabled: true
+                            snapshotEnabled: true,
+                            uiVariant: callManager.callUiVariant
                         ),
                         strings: L10n.serenadaCallStrings,
                         onInviteToRoom: { await callManager.inviteToCurrentRoom() },
@@ -189,6 +190,7 @@ struct RootView: View {
                     isDefaultCameraEnabled: callManager.isDefaultCameraEnabled,
                     isDefaultMicrophoneEnabled: callManager.isDefaultMicrophoneEnabled,
                     isHdVideoExperimentalEnabled: callManager.isHdVideoExperimentalEnabled,
+                    callUiVariant: callManager.callUiVariant,
                     areSavedRoomsShownFirst: callManager.areSavedRoomsShownFirst,
                     areRoomInviteNotificationsEnabled: callManager.areRoomInviteNotificationsEnabled,
                     showFeedback: $showFeedback,
@@ -199,6 +201,7 @@ struct RootView: View {
                     onDefaultCameraChange: { callManager.updateDefaultCamera($0) },
                     onDefaultMicrophoneChange: { callManager.updateDefaultMicrophone($0) },
                     onHdVideoExperimentalChange: { callManager.updateHdVideoExperimental($0) },
+                    onCallUiVariantChange: { callManager.updateCallUiVariant($0) },
                     onSavedRoomsShownFirstChange: { callManager.updateSavedRoomsShownFirst($0) },
                     onRoomInviteNotificationsChange: { callManager.updateRoomInviteNotifications($0) },
                     onDisplayNameChange: { callManager.updateDisplayName($0) }

--- a/client-ios/Sources/Core/Call/CallManager.swift
+++ b/client-ios/Sources/Core/Call/CallManager.swift
@@ -11,6 +11,7 @@ final class CallManager: ObservableObject {
     @Published private(set) var isDefaultCameraEnabled: Bool
     @Published private(set) var isDefaultMicrophoneEnabled: Bool
     @Published private(set) var isHdVideoExperimentalEnabled: Bool
+    @Published private(set) var callUiVariant: SerenadaCallUiVariant
     @Published private(set) var areSavedRoomsShownFirst: Bool
     @Published private(set) var areRoomInviteNotificationsEnabled: Bool
     @Published private(set) var displayName: String
@@ -100,6 +101,7 @@ final class CallManager: ObservableObject {
         self.isDefaultCameraEnabled = settingsStore.isDefaultCameraEnabled
         self.isDefaultMicrophoneEnabled = settingsStore.isDefaultMicrophoneEnabled
         self.isHdVideoExperimentalEnabled = settingsStore.isHdVideoExperimentalEnabled
+        self.callUiVariant = settingsStore.callUiVariant
         self.areSavedRoomsShownFirst = settingsStore.areSavedRoomsShownFirst
         self.areRoomInviteNotificationsEnabled = settingsStore.areRoomInviteNotificationsEnabled
         self.displayName = settingsStore.displayName
@@ -181,6 +183,11 @@ final class CallManager: ObservableObject {
         settingsStore.isHdVideoExperimentalEnabled = enabled
         isHdVideoExperimentalEnabled = enabled
         activeSession?.setHdVideoExperimentalEnabled(enabled)
+    }
+
+    func updateCallUiVariant(_ variant: SerenadaCallUiVariant) {
+        settingsStore.callUiVariant = variant
+        callUiVariant = variant
     }
 
     func updateSavedRoomsShownFirst(_ enabled: Bool) {
@@ -411,11 +418,14 @@ final class CallManager: ObservableObject {
     }
 
     private func makeSerenadaCore(host: String) -> SerenadaCore {
+        let frontline = settingsStore.callUiVariant == .frontline
+        let cameraModes: [LocalCameraMode]? = frontline ? [.world, .selfie, .composite] : nil
         let core = SerenadaCore(
             config: SerenadaConfig(
                 serverHost: host,
                 defaultAudioEnabled: settingsStore.isDefaultMicrophoneEnabled,
-                defaultVideoEnabled: settingsStore.isDefaultCameraEnabled,
+                defaultVideoEnabled: frontline ? false : settingsStore.isDefaultCameraEnabled,
+                cameraModes: cameraModes,
                 proximityMonitoringEnabled: true
             )
         )
@@ -483,12 +493,17 @@ final class CallManager: ObservableObject {
         next.participantCount = participantCount
         next.localAudioEnabled = state.localParticipant.audioEnabled
         next.localVideoEnabled = state.localParticipant.videoEnabled
+        next.localDisplayName = state.localParticipant.displayName
+        next.localAudioLevel = state.localParticipant.audioLevel
         next.remoteParticipants = state.remoteParticipants.map {
             RemoteParticipant(
                 cid: $0.cid,
                 displayName: $0.displayName,
+                peerId: $0.peerId,
+                audioEnabled: $0.audioEnabled,
                 videoEnabled: $0.videoEnabled,
-                connectionState: $0.connectionState
+                connectionState: $0.connectionState,
+                audioLevel: $0.audioLevel
             )
         }
         next.connectionStatus = mapSessionConnectionStatus(state.connectionStatus)
@@ -501,11 +516,13 @@ final class CallManager: ObservableObject {
         next.isFrontCamera = diagnostics.isFrontCamera
         next.isScreenSharing = diagnostics.isScreenSharing
         next.localCameraMode = state.localParticipant.cameraMode
+        next.availableCameraModes = state.localParticipant.availableCameraModes
         next.cameraZoomFactor = diagnostics.cameraZoomFactor
         next.isFlashAvailable = diagnostics.isFlashAvailable
         next.isFlashEnabled = diagnostics.isFlashEnabled
         next.remoteContentCid = diagnostics.remoteContentParticipantId
         next.remoteContentType = diagnostics.remoteContentType
+        next.callStartedAtMs = state.callStartedAtMs
         uiState = next
 
         if state.phase == .error {

--- a/client-ios/Sources/Core/Stores/SettingsStore.swift
+++ b/client-ios/Sources/Core/Stores/SettingsStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SerenadaCallUI
 
 final class SettingsStore {
     private enum Key {
@@ -13,6 +14,7 @@ final class SettingsStore {
         static let roomInviteNotificationsEnabled = "room_invite_notifications_enabled"
         static let remoteVideoFitCover = "remote_video_fit_cover"
         static let displayName = "display_name"
+        static let callUiVariant = "call_ui_variant"
     }
 
     private let defaults: UserDefaults
@@ -143,6 +145,15 @@ final class SettingsStore {
         }
     }
 
+    var callUiVariant: SerenadaCallUiVariant {
+        get {
+            normalizeCallUiVariant(defaults.string(forKey: Key.callUiVariant))
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: Key.callUiVariant)
+        }
+    }
+
     func normalizeLanguage(_ raw: String?) -> String {
         guard let raw else { return AppConstants.languageAuto }
         let value = raw.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
@@ -150,6 +161,11 @@ final class SettingsStore {
             return value
         }
         return AppConstants.languageAuto
+    }
+
+    func normalizeCallUiVariant(_ raw: String?) -> SerenadaCallUiVariant {
+        guard let raw else { return .standard }
+        return SerenadaCallUiVariant(rawValue: raw.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)) ?? .standard
     }
 
     private static func defaultStore() -> UserDefaults {

--- a/client-ios/Sources/Core/Utils/L10n.swift
+++ b/client-ios/Sources/Core/Utils/L10n.swift
@@ -75,6 +75,9 @@ enum L10n {
     static var settingsLanguageFrench: String { text("settings_language_french") }
     static var settingsDisplayName: String { text("settings_display_name") }
     static var settingsDisplayNamePlaceholder: String { text("settings_display_name_placeholder") }
+    static var settingsCallScreenStyle: String { text("settings_call_screen_style") }
+    static var settingsCallScreenStyleStandard: String { text("settings_call_screen_style_standard") }
+    static var settingsCallScreenStyleFrontline: String { text("settings_call_screen_style_frontline") }
     static var settingsCallDefaults: String { text("settings_call_defaults") }
     static var settingsCameraEnabled: String { text("camera_enabled") }
     static var settingsCameraEnabledInfo: String { text("camera_enabled_info") }
@@ -240,6 +243,23 @@ enum L10n {
             .callPermissionsRequired: text("call_permissions_required"),
             .callPermissionsCamera: text("call_permissions_camera"),
             .callPermissionsMicrophone: text("call_permissions_microphone"),
+            .callGrantAccess: text("call_grant_access"),
+            .callDismiss: text("call_dismiss"),
+            .frontlineYou: text("frontline_you"),
+            .frontlineWaiting: text("frontline_waiting"),
+            .frontlineVideo: text("frontline_video"),
+            .frontlineVideoOn: text("frontline_video_on"),
+            .frontlineMute: text("frontline_mute"),
+            .frontlineMore: text("frontline_more"),
+            .frontlineEnd: text("frontline_end"),
+            .frontlineFlipCamera: text("frontline_flip_camera"),
+            .frontlineStopScreenShare: text("frontline_stop_screen_share"),
+            .frontlineShareScreen: text("frontline_share_screen"),
+            .frontlineReturnToCamera: text("frontline_return_to_camera"),
+            .frontlineShowYourPhone: text("frontline_show_your_phone"),
+            .frontlineInviteSubtitle: text("frontline_invite_subtitle"),
+            .frontlineShareLinkSubtitle: text("frontline_share_link_subtitle"),
+            .frontlineClose: text("frontline_close"),
         ]
     }
 }

--- a/client-ios/Sources/UI/Screens/SettingsScreen.swift
+++ b/client-ios/Sources/UI/Screens/SettingsScreen.swift
@@ -1,3 +1,4 @@
+import SerenadaCallUI
 import SwiftUI
 
 struct SettingsScreen: View {
@@ -9,6 +10,7 @@ struct SettingsScreen: View {
     let isDefaultCameraEnabled: Bool
     let isDefaultMicrophoneEnabled: Bool
     let isHdVideoExperimentalEnabled: Bool
+    let callUiVariant: SerenadaCallUiVariant
     let areSavedRoomsShownFirst: Bool
     let areRoomInviteNotificationsEnabled: Bool
     @Binding var showFeedback: Bool
@@ -19,6 +21,7 @@ struct SettingsScreen: View {
     let onDefaultCameraChange: (Bool) -> Void
     let onDefaultMicrophoneChange: (Bool) -> Void
     let onHdVideoExperimentalChange: (Bool) -> Void
+    let onCallUiVariantChange: (SerenadaCallUiVariant) -> Void
     let onSavedRoomsShownFirstChange: (Bool) -> Void
     let onRoomInviteNotificationsChange: (Bool) -> Void
     let onDisplayNameChange: (String) -> Void
@@ -99,6 +102,17 @@ struct SettingsScreen: View {
                         }
                         onDisplayNameChange(clamped)
                     }
+            }
+
+            Section(L10n.settingsCallScreenStyle) {
+                Picker(L10n.settingsCallScreenStyle, selection: Binding(
+                    get: { callUiVariant },
+                    set: { onCallUiVariantChange($0) }
+                )) {
+                    Text(L10n.settingsCallScreenStyleStandard).tag(SerenadaCallUiVariant.standard)
+                    Text(L10n.settingsCallScreenStyleFrontline).tag(SerenadaCallUiVariant.frontline)
+                }
+                .pickerStyle(.segmented)
             }
 
             Section(L10n.settingsCallDefaults) {

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -65,7 +65,7 @@ Provider mode does not expose Serenada server helpers. These APIs require `serve
 
 | Field | Type | Default | Effect |
 |---|---|---|---|
-| `uiVariant` | `SerenadaCallUiVariant` | `Standard` | Android-only. Selects the visual presentation for the prebuilt call UI. `Frontline` uses an audio-first layout optimized for large touch targets and field use, and keeps Frontline styling across lifecycle, 1:1, and multi-party states. |
+| `uiVariant` | `SerenadaCallUiVariant` | `Standard` | Android and iOS. Selects the visual presentation for the prebuilt call UI. `Frontline` uses an audio-first layout optimized for large touch targets and field use, and keeps Frontline styling across lifecycle, 1:1, and multi-party states. |
 | `screenSharingEnabled` | Bool | `true` | Show/hide the screen-share control when the current browser/device supports screen capture |
 | `videoEnabled` | Bool | `true` | When `true`, the video on/off and camera-mode (flip) controls appear and the SDK requests camera permission on join. When `false`, both controls are hidden and URL-first call flows configure the internally-created session with no camera modes (camera is never requested). Session-first hosts that want audio-only should also pass `cameraModes: []` to `SerenadaConfig`. |
 | `inviteControlsEnabled` | Bool | `true` | Show/hide the built-in QR code and share-link UI in the waiting screen |
@@ -82,7 +82,8 @@ SerenadaCallFlow(
         inviteControlsEnabled: false,
         debugOverlayEnabled: true,
         autoHideControls: false,
-        videoEnabled: false
+        videoEnabled: false,
+        uiVariant: .frontline
     ),
     onDismiss: { dismiss() }
 )
@@ -123,9 +124,9 @@ SerenadaCallFlow(
 
 `inviteControlsEnabled` only hides the built-in invite UI. Any custom `waitingActions` still render.
 
-### Android Frontline Variant
+### Android and iOS Frontline Variant
 
-`SerenadaCallUiVariant.Frontline` is an opt-in Android call UI for frontline workflows. It keeps the same SDK/session contract as the standard UI, but changes the presentation to an audio-first screen with larger controls, local-camera preview actions, multi-party Frontline tiles, Frontline lifecycle states, and a More sheet for supported secondary actions.
+`SerenadaCallUiVariant.Frontline` / `.frontline` is an opt-in native call UI for frontline workflows. It keeps the same SDK/session contract as the standard UI, but changes the presentation to an audio-first screen with larger controls, local-camera preview actions, multi-party Frontline tiles, Frontline lifecycle states, and a More sheet for supported secondary actions.
 
 For URL-first calls, the call flow configures the internally-created session as audio-first and world-camera-first:
 
@@ -136,6 +137,16 @@ SerenadaCallFlow(
         uiVariant = SerenadaCallUiVariant.Frontline,
         snapshotEnabled = true,
     ),
+)
+```
+
+```swift
+SerenadaCallFlow(
+    url: url,
+    config: SerenadaCallFlowConfig(
+        snapshotEnabled: true,
+        uiVariant: .frontline
+    )
 )
 ```
 
@@ -154,6 +165,21 @@ val serenada = SerenadaCore(
 SerenadaCallFlow(
     session = serenada.join(url),
     config = SerenadaCallFlowConfig(uiVariant = SerenadaCallUiVariant.Frontline),
+)
+```
+
+```swift
+let serenada = SerenadaCore(
+    config: SerenadaConfig(
+        serverHost: "serenada.app",
+        defaultVideoEnabled: false,
+        cameraModes: [.world, .selfie, .composite]
+    )
+)
+
+SerenadaCallFlow(
+    session: serenada.join(url: url),
+    config: SerenadaCallFlowConfig(uiVariant: .frontline)
 )
 ```
 
@@ -327,8 +353,8 @@ Available string keys:
 - `CallWaitingOverlay`
 - `CallShareLinkChooser`, `CallShareInvitation`, `CallInviteToRoom`
 - `CallQrCode`, `CallToggleFlashlight`, `CallToggleVideoFit`, `CallTakeSnapshot`
-- Android Frontline: `FrontlineYou`, `FrontlineWaiting`, `FrontlineVideo`, `FrontlineVideoOn`, `FrontlineMute`, `FrontlineMore`, `FrontlineEnd`, `FrontlineFlipCamera`
-- Android Frontline: `FrontlineStopScreenShare`, `FrontlineShareScreen`, `FrontlineReturnToCamera`, `FrontlineShowYourPhone`, `FrontlineInviteSubtitle`, `FrontlineShareLinkSubtitle`, `FrontlineClose`
+- Native Frontline: `FrontlineYou` / `frontlineYou`, `FrontlineWaiting` / `frontlineWaiting`, `FrontlineVideo` / `frontlineVideo`, `FrontlineVideoOn` / `frontlineVideoOn`, `FrontlineMute` / `frontlineMute`, `FrontlineMore` / `frontlineMore`, `FrontlineEnd` / `frontlineEnd`, `FrontlineFlipCamera` / `frontlineFlipCamera`
+- Native Frontline: `FrontlineStopScreenShare` / `frontlineStopScreenShare`, `FrontlineShareScreen` / `frontlineShareScreen`, `FrontlineReturnToCamera` / `frontlineReturnToCamera`, `FrontlineShowYourPhone` / `frontlineShowYourPhone`, `FrontlineInviteSubtitle` / `frontlineInviteSubtitle`, `FrontlineShareLinkSubtitle` / `frontlineShareLinkSubtitle`, `FrontlineClose` / `frontlineClose`
 
 ### Web
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -413,7 +413,7 @@ val config = SerenadaConfig(
 )
 ```
 
-See [Camera Modes](sdk-customization.md#camera-modes) for how `cameraModes` interacts with the call-flow controls, and [Android Frontline Variant](sdk-customization.md#android-frontline-variant) for the audio-first frontline call UI.
+See [Camera Modes](sdk-customization.md#camera-modes) for how `cameraModes` interacts with the call-flow controls, and [Frontline Variant](sdk-customization.md#android-and-ios-frontline-variant) for the audio-first frontline call UI.
 
 ## Next Steps
 

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -51,6 +51,23 @@ struct CallView: View {
 
 That's it. `SerenadaCallFlow` handles permissions, joining, the in-call UI, and cleanup.
 
+### Optional Frontline UI
+
+iOS can opt into the frontline call layout while keeping the same call-flow API:
+
+```swift
+SerenadaCallFlow(
+    url: url,
+    config: SerenadaCallFlowConfig(
+        uiVariant: .frontline,
+        snapshotEnabled: true
+    ),
+    onDismiss: { dismiss() }
+)
+```
+
+URL-first frontline calls start audio-first and use the camera order `world -> selfie -> composite`. For session-first usage, set `defaultVideoEnabled = false` and `cameraModes = [.world, .selfie, .composite]` on the `SerenadaConfig` used to create the session. When `frontline` is selected, iOS keeps Frontline styling for lifecycle states, 1:1 calls, and multi-party calls. Invite/share actions remain in the Frontline More sheet; the standard waiting-screen QR code is not shown.
+
 ## Session-First (Pre-Observation)
 
 Create a session before presenting UI to observe state early:
@@ -316,7 +333,7 @@ let config = SerenadaConfig(
 )
 ```
 
-See [Camera Modes](sdk-customization.md#camera-modes) for how `cameraModes` interacts with the call-flow controls.
+See [Camera Modes](sdk-customization.md#camera-modes) for how `cameraModes` interacts with the call-flow controls, and [Frontline Variant](sdk-customization.md#android-and-ios-frontline-variant) for the audio-first frontline call UI.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Add the iOS Frontline call UI variant and route the iOS app/settings flow to select it.
- Port the Android Frontline 1:1 and multiparty/filmstrip styling into SwiftUI, including local content spotlight handling and the duplicate-local-filmstrip guard.
- Add iOS localization strings and focused state tests for Frontline call-screen behavior.
- Updates documentation

## Validation
- `git diff --cached --check`
- `xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' test` built and ran; one `SessionOrchestrationTests.testIceServersChangedUpdatesExistingAndFuturePeerSlots` assertion failed once during the full run.
- `xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' -only-testing:SerenadaiOSTests/SessionOrchestrationTests/testIceServersChangedUpdatesExistingAndFuturePeerSlots test` passed on rerun.