### PR TITLE
[codex] Polish Frontline more menu rows

### DIFF
--- a/client-android/app/src/main/java/app/serenada/android/i18n/SerenadaCallStrings.kt
+++ b/client-android/app/src/main/java/app/serenada/android/i18n/SerenadaCallStrings.kt
@@ -29,9 +29,5 @@ fun buildSerenadaCallStrings(context: Context): Map<SerenadaString, String> = ma
     SerenadaString.FrontlineFlipCamera to context.getString(R.string.frontline_flip_camera),
     SerenadaString.FrontlineStopScreenShare to context.getString(R.string.frontline_stop_screen_share),
     SerenadaString.FrontlineShareScreen to context.getString(R.string.frontline_share_screen),
-    SerenadaString.FrontlineReturnToCamera to context.getString(R.string.frontline_return_to_camera),
-    SerenadaString.FrontlineShowYourPhone to context.getString(R.string.frontline_show_your_phone),
-    SerenadaString.FrontlineInviteSubtitle to context.getString(R.string.frontline_invite_subtitle),
-    SerenadaString.FrontlineShareLinkSubtitle to context.getString(R.string.frontline_share_link_subtitle),
     SerenadaString.FrontlineClose to context.getString(R.string.frontline_close),
 )

--- a/client-android/app/src/main/res/values/strings.xml
+++ b/client-android/app/src/main/res/values/strings.xml
@@ -148,10 +148,6 @@
     <string name="frontline_flip_camera">Flip camera</string>
     <string name="frontline_stop_screen_share">Stop screen share</string>
     <string name="frontline_share_screen">Share screen</string>
-    <string name="frontline_return_to_camera">Return to camera</string>
-    <string name="frontline_show_your_phone">Show your phone</string>
-    <string name="frontline_invite_subtitle">Bring in another teammate</string>
-    <string name="frontline_share_link_subtitle">Send the call link</string>
     <string name="frontline_close">Close</string>
 
     <string name="notification_call_title">Serenada call</string>

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -2002,34 +2002,39 @@ private fun FrontlineSheetItem(
     onClick: () -> Unit,
 ) {
     val shape = RoundedCornerShape(16.dp)
-    Row(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 5.dp)
-            .clip(shape)
-            .background(FrontlineSheetRow)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 18.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+            .padding(vertical = 5.dp),
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = Color.White,
+        Row(
             modifier = Modifier
-                .size(38.dp)
-                .padding(8.dp),
-        )
-        Text(
-            text = title,
-            color = Color.White,
-            fontSize = 15.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
+                .fillMaxWidth()
+                .clip(shape)
+                .background(FrontlineSheetRow)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier
+                    .size(38.dp)
+                    .padding(8.dp),
+            )
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -125,6 +125,7 @@ private val FrontlineAccent = Color(0xFF15BF54)
 private val FrontlineDanger = Color(0xFFF5564B)
 private val FrontlineDim = Color(0xFFA1A1AA)
 private val FrontlineSheet = Color(0xFF15161A)
+private val FrontlineSheetRow = Color.White.copy(alpha = 0.09f)
 private val FrontlineStageLocalAccentWidth = 2.5.dp
 private const val FRONTLINE_ZOOM_CHANGE_THRESHOLD = 0.01f
 private const val FRONTLINE_CONTENT_SPOTLIGHT_PREFIX = "content:"
@@ -1948,11 +1949,6 @@ private fun FrontlineMoreSheet(
                             } else {
                                 resolveString(SerenadaString.FrontlineShareScreen, strings)
                             },
-                            subtitle = if (isScreenSharing) {
-                                resolveString(SerenadaString.FrontlineReturnToCamera, strings)
-                            } else {
-                                resolveString(SerenadaString.FrontlineShowYourPhone, strings)
-                            },
                             onClick = onToggleScreenShare,
                         )
                     }
@@ -1960,7 +1956,6 @@ private fun FrontlineMoreSheet(
                         FrontlineSheetItem(
                             icon = Icons.Default.NotificationsActive,
                             title = resolveString(SerenadaString.CallInviteToRoom, strings),
-                            subtitle = resolveString(SerenadaString.FrontlineInviteSubtitle, strings),
                             onClick = onInvite,
                         )
                     }
@@ -1968,7 +1963,6 @@ private fun FrontlineMoreSheet(
                         FrontlineSheetItem(
                             icon = Icons.Default.Share,
                             title = resolveString(SerenadaString.CallShareInvitation, strings),
-                            subtitle = resolveString(SerenadaString.FrontlineShareLinkSubtitle, strings),
                             onClick = onShare,
                         )
                     }
@@ -2005,42 +1999,37 @@ private fun FrontlineMoreSheet(
 private fun FrontlineSheetItem(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     title: String,
-    subtitle: String,
     onClick: () -> Unit,
 ) {
+    val shape = RoundedCornerShape(16.dp)
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .padding(vertical = 5.dp)
+            .clip(shape)
+            .background(FrontlineSheetRow)
             .clickable(onClick = onClick)
-            .padding(horizontal = 4.dp, vertical = 10.dp),
+            .padding(horizontal = 18.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Surface(
-            modifier = Modifier.size(38.dp),
-            color = Color.White.copy(alpha = 0.08f),
-            shape = RoundedCornerShape(10.dp),
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(22.dp))
-            }
-        }
-        Column(Modifier.weight(1f)) {
-            Text(
-                text = title,
-                color = Color.White,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = subtitle,
-                color = FrontlineDim,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier
+                .size(38.dp)
+                .padding(8.dp),
+        )
+        Text(
+            text = title,
+            color = Color.White,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaString.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaString.kt
@@ -25,10 +25,6 @@ enum class SerenadaString {
     FrontlineFlipCamera,
     FrontlineStopScreenShare,
     FrontlineShareScreen,
-    FrontlineReturnToCamera,
-    FrontlineShowYourPhone,
-    FrontlineInviteSubtitle,
-    FrontlineShareLinkSubtitle,
     FrontlineClose,
 }
 
@@ -57,10 +53,6 @@ val serenadaDefaultStrings: Map<SerenadaString, String> = mapOf(
     SerenadaString.FrontlineFlipCamera to "Flip camera",
     SerenadaString.FrontlineStopScreenShare to "Stop screen share",
     SerenadaString.FrontlineShareScreen to "Share screen",
-    SerenadaString.FrontlineReturnToCamera to "Return to camera",
-    SerenadaString.FrontlineShowYourPhone to "Show your phone",
-    SerenadaString.FrontlineInviteSubtitle to "Bring in another teammate",
-    SerenadaString.FrontlineShareLinkSubtitle to "Send the call link",
     SerenadaString.FrontlineClose to "Close",
 )
 

--- a/client-ios/Resources/en.lproj/Localizable.strings
+++ b/client-ios/Resources/en.lproj/Localizable.strings
@@ -184,10 +184,6 @@
 "frontline_flip_camera" = "Flip camera";
 "frontline_stop_screen_share" = "Stop screen share";
 "frontline_share_screen" = "Share screen";
-"frontline_return_to_camera" = "Return to camera";
-"frontline_show_your_phone" = "Show your phone screen";
-"frontline_invite_subtitle" = "Send a live-call notification";
-"frontline_share_link_subtitle" = "Copy or share the room link";
 "frontline_close" = "Close";
 
 "feedback_title" = "Feedback";

--- a/client-ios/Resources/es.lproj/Localizable.strings
+++ b/client-ios/Resources/es.lproj/Localizable.strings
@@ -184,10 +184,6 @@
 "frontline_flip_camera" = "Cambiar cámara";
 "frontline_stop_screen_share" = "Detener pantalla compartida";
 "frontline_share_screen" = "Compartir pantalla";
-"frontline_return_to_camera" = "Volver a la cámara";
-"frontline_show_your_phone" = "Mostrar la pantalla del teléfono";
-"frontline_invite_subtitle" = "Enviar una notificación de llamada";
-"frontline_share_link_subtitle" = "Copiar o compartir el enlace de sala";
 "frontline_close" = "Cerrar";
 
 "feedback_title" = "Comentarios";

--- a/client-ios/Resources/fr.lproj/Localizable.strings
+++ b/client-ios/Resources/fr.lproj/Localizable.strings
@@ -184,10 +184,6 @@
 "frontline_flip_camera" = "Basculer la caméra";
 "frontline_stop_screen_share" = "Arrêter le partage d’écran";
 "frontline_share_screen" = "Partager l’écran";
-"frontline_return_to_camera" = "Revenir à la caméra";
-"frontline_show_your_phone" = "Afficher l’écran du téléphone";
-"frontline_invite_subtitle" = "Envoyer une notification d’appel";
-"frontline_share_link_subtitle" = "Copier ou partager le lien de salle";
 "frontline_close" = "Fermer";
 
 "feedback_title" = "Retour";

--- a/client-ios/Resources/ru.lproj/Localizable.strings
+++ b/client-ios/Resources/ru.lproj/Localizable.strings
@@ -184,10 +184,6 @@
 "frontline_flip_camera" = "Переключить камеру";
 "frontline_stop_screen_share" = "Остановить демонстрацию экрана";
 "frontline_share_screen" = "Показать экран";
-"frontline_return_to_camera" = "Вернуться к камере";
-"frontline_show_your_phone" = "Показать экран телефона";
-"frontline_invite_subtitle" = "Отправить уведомление о звонке";
-"frontline_share_link_subtitle" = "Скопировать или отправить ссылку на комнату";
 "frontline_close" = "Закрыть";
 
 "feedback_title" = "Отзыв";

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -11,6 +11,7 @@ private let frontlineAccent = Color(red: 0x15 / 255, green: 0xBF / 255, blue: 0x
 private let frontlineDanger = Color(red: 0xF5 / 255, green: 0x56 / 255, blue: 0x4B / 255)
 private let frontlineDim = Color(red: 0xA1 / 255, green: 0xA1 / 255, blue: 0xAA / 255)
 private let frontlineSheet = Color(red: 0x15 / 255, green: 0x16 / 255, blue: 0x1A / 255)
+private let frontlineSheetRow = Color.white.opacity(0.09)
 private let frontlineContentSpotlightPrefix = "content:"
 private let frontlineMoreButtonHeightToWidthRatio: CGFloat = 1.62
 private let frontlineLargeVideoAccentLineWidth: CGFloat = 3
@@ -1125,9 +1126,6 @@ private struct FrontlineMoreSheet: View {
                         title: isScreenSharing
                             ? resolveString(.frontlineStopScreenShare, overrides: strings)
                             : resolveString(.frontlineShareScreen, overrides: strings),
-                        subtitle: isScreenSharing
-                            ? resolveString(.frontlineReturnToCamera, overrides: strings)
-                            : resolveString(.frontlineShowYourPhone, overrides: strings),
                         onClick: screenShareAction
                     )
                     .overlay {
@@ -1147,7 +1145,6 @@ private struct FrontlineMoreSheet: View {
                     FrontlineSheetItem(
                         systemImage: "bell.badge.fill",
                         title: resolveString(.callInviteToRoom, overrides: strings),
-                        subtitle: resolveString(.frontlineInviteSubtitle, overrides: strings),
                         onClick: onInvite
                     )
                 }
@@ -1156,7 +1153,6 @@ private struct FrontlineMoreSheet: View {
                     FrontlineSheetItem(
                         systemImage: "square.and.arrow.up",
                         title: resolveString(.callShareInvitation, overrides: strings),
-                        subtitle: resolveString(.frontlineShareLinkSubtitle, overrides: strings),
                         onClick: onShare
                     )
                 }
@@ -1197,7 +1193,6 @@ private struct FrontlineMoreSheet: View {
 private struct FrontlineSheetItem: View {
     let systemImage: String
     let title: String
-    let subtitle: String
     let onClick: () -> Void
 
     var body: some View {
@@ -1207,25 +1202,22 @@ private struct FrontlineSheetItem: View {
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundStyle(.white)
                     .frame(width: 38, height: 38)
-                    .background(Color.white.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(.white)
-                    Text(subtitle)
-                        .font(.system(size: 12))
-                        .foregroundStyle(frontlineDim)
-                        .lineLimit(1)
-                }
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 10)
-            .contentShape(Rectangle())
+            .padding(.horizontal, 18)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+            .background(frontlineSheetRow)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         }
         .buttonStyle(.plain)
+        .padding(.vertical, 5)
     }
 }
 

--- a/client-ios/SerenadaCallUI/Sources/SerenadaString.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaString.swift
@@ -46,10 +46,6 @@ public enum SerenadaString: String, CaseIterable {
     case frontlineFlipCamera
     case frontlineStopScreenShare
     case frontlineShareScreen
-    case frontlineReturnToCamera
-    case frontlineShowYourPhone
-    case frontlineInviteSubtitle
-    case frontlineShareLinkSubtitle
     case frontlineClose
 }
 
@@ -98,10 +94,6 @@ public let serenadaDefaultStrings: [SerenadaString: String] = [
     .frontlineFlipCamera: "Flip camera",
     .frontlineStopScreenShare: "Stop screen share",
     .frontlineShareScreen: "Share screen",
-    .frontlineReturnToCamera: "Return to camera",
-    .frontlineShowYourPhone: "Show your phone screen",
-    .frontlineInviteSubtitle: "Send a live-call notification",
-    .frontlineShareLinkSubtitle: "Copy or share the room link",
     .frontlineClose: "Close",
 ]
 

--- a/client-ios/Sources/Core/Utils/L10n.swift
+++ b/client-ios/Sources/Core/Utils/L10n.swift
@@ -255,10 +255,6 @@ enum L10n {
             .frontlineFlipCamera: text("frontline_flip_camera"),
             .frontlineStopScreenShare: text("frontline_stop_screen_share"),
             .frontlineShareScreen: text("frontline_share_screen"),
-            .frontlineReturnToCamera: text("frontline_return_to_camera"),
-            .frontlineShowYourPhone: text("frontline_show_your_phone"),
-            .frontlineInviteSubtitle: text("frontline_invite_subtitle"),
-            .frontlineShareLinkSubtitle: text("frontline_share_link_subtitle"),
             .frontlineClose: text("frontline_close"),
         ]
     }

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -354,7 +354,7 @@ Available string keys:
 - `CallShareLinkChooser`, `CallShareInvitation`, `CallInviteToRoom`
 - `CallQrCode`, `CallToggleFlashlight`, `CallToggleVideoFit`, `CallTakeSnapshot`
 - Native Frontline: `FrontlineYou` / `frontlineYou`, `FrontlineWaiting` / `frontlineWaiting`, `FrontlineVideo` / `frontlineVideo`, `FrontlineVideoOn` / `frontlineVideoOn`, `FrontlineMute` / `frontlineMute`, `FrontlineMore` / `frontlineMore`, `FrontlineEnd` / `frontlineEnd`, `FrontlineFlipCamera` / `frontlineFlipCamera`
-- Native Frontline: `FrontlineStopScreenShare` / `frontlineStopScreenShare`, `FrontlineShareScreen` / `frontlineShareScreen`, `FrontlineReturnToCamera` / `frontlineReturnToCamera`, `FrontlineShowYourPhone` / `frontlineShowYourPhone`, `FrontlineInviteSubtitle` / `frontlineInviteSubtitle`, `FrontlineShareLinkSubtitle` / `frontlineShareLinkSubtitle`, `FrontlineClose` / `frontlineClose`
+- Native Frontline: `FrontlineStopScreenShare` / `frontlineStopScreenShare`, `FrontlineShareScreen` / `frontlineShareScreen`, `FrontlineClose` / `frontlineClose`
 
 ### Web
 


### PR DESCRIPTION
## Summary
- remove subtitles from the native Frontline More menu rows
- remove now-unused subtitle string keys and resource entries
- apply the shared row styling with plain icons and full-row hit targets on Android and iOS

## Validation
- git diff --check
- client-android: ./gradlew assembleDebug
- client-ios: xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build