### PR TITLE
[codex] Fix reconnect token refresh

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -10,6 +10,7 @@ import app.serenada.core.call.WebRtcResilienceConstants
 import app.serenada.core.call.toErrorPayload
 import app.serenada.core.call.toJoinedPayload
 import app.serenada.core.call.toNegotiationDirtyPayload
+import app.serenada.core.call.toReconnectTokenRefreshedPayload
 import app.serenada.core.call.toRelayFailedPayload
 import app.serenada.core.call.toRoomStatePayload
 import app.serenada.core.network.CoreApiClient
@@ -51,6 +52,7 @@ internal class SerenadaServerProvider(
     private var reconnectAttempts = 0
     private var reconnectRunnable: Runnable? = null
     private var turnRefreshRunnable: Runnable? = null
+    private var reconnectTokenRefreshRunnable: Runnable? = null
     // Absolute expiry timestamp (wall clock ms) for the current TURN creds.
     // Used by the skip path to compute remaining lifetime for recheck pacing.
     private var turnTokenExpiresAtMs: Long = 0
@@ -66,6 +68,7 @@ internal class SerenadaServerProvider(
     private var currentReconnectPeerId: String? = null
     private var currentTurnToken: String? = null
     private var reconnectToken: String? = null
+    private var reconnectTokenTTLMs: Long? = null
     private var clientId: String? = null
     private var currentHostPeerId: String? = null
     private var previousParticipants = linkedMapOf<String, SignalingProviderParticipant>()
@@ -83,6 +86,7 @@ internal class SerenadaServerProvider(
         closedByClient = true
         clearReconnect()
         clearTurnRefresh()
+        clearReconnectTokenRefresh()
         pendingJoinRoomId = null
         previousParticipants.clear()
         signaling.close()
@@ -167,6 +171,7 @@ internal class SerenadaServerProvider(
         }
 
         override fun onClosed(reason: String) {
+            clearReconnectTokenRefresh()
             listener?.onDisconnected(reason)
             if (!closedByClient && currentRoomId != null) {
                 pendingJoinRoomId = currentRoomId
@@ -186,15 +191,15 @@ internal class SerenadaServerProvider(
             "room_ended" -> {
                 val endedBy = message.payload?.optString("by").orEmpty().ifBlank { currentHostPeerId }
                 val reason = message.payload?.optString("reason").orEmpty().ifBlank { "room ended" }
-                clearReconnect()
-                clearTurnRefresh()
-                currentRoomId = null
-                previousParticipants.clear()
+                clearRoomState()
                 listener?.onRoomEnded(RoomEndedEvent(by = endedBy, reason = reason))
             }
             "error" -> {
                 message.payload.toErrorPayload()?.let { payload ->
                     val code = payload.code ?: "UNKNOWN"
+                    if (code == "INVALID_RECONNECT_TOKEN" && retryFreshJoinAfterInvalidReconnectToken()) {
+                        return
+                    }
                     // Terminal codes that invalidate persisted reconnect
                     // authority. Drop the stored token so a future join can
                     // not try to reclaim the (gone) slot.
@@ -208,6 +213,18 @@ internal class SerenadaServerProvider(
                         )
                     )
                 }
+            }
+            "reconnect-token-refreshed" -> {
+                val payload = message.payload.toReconnectTokenRefreshedPayload() ?: return
+                reconnectToken = payload.reconnectToken
+                reconnectTokenTTLMs = payload.reconnectTokenTTLMs ?: WebRtcResilienceConstants.RECONNECT_TOKEN_TTL_FALLBACK_MS
+                scheduleReconnectTokenRefresh(reconnectTokenTTLMs)
+                listener?.onReconnectTokenRefreshed(
+                    ReconnectTokenRefreshedEvent(
+                        reconnectToken = payload.reconnectToken,
+                        reconnectTokenTTLMs = reconnectTokenTTLMs,
+                    )
+                )
             }
             "turn-refreshed" -> {
                 currentTurnToken = message.payload?.optString("turnToken").orEmpty().ifBlank { null }
@@ -258,6 +275,10 @@ internal class SerenadaServerProvider(
         // participant alongside our suspended record.
         currentReconnectPeerId = peerId
         reconnectToken = payload.reconnectToken ?: reconnectToken
+        reconnectTokenTTLMs = payload.reconnectTokenTTLMs ?: reconnectTokenTTLMs
+        if (payload.reconnectToken != null) {
+            scheduleReconnectTokenRefresh(reconnectTokenTTLMs ?: WebRtcResilienceConstants.RECONNECT_TOKEN_TTL_FALLBACK_MS)
+        }
         currentHostPeerId = payload.hostCid
         currentTurnToken = payload.turnToken
         payload.turnTokenTTLMs?.let { scheduleTurnRefresh(it) } ?: clearTurnRefresh()
@@ -273,6 +294,8 @@ internal class SerenadaServerProvider(
                 maxParticipants = payload.maxParticipants,
                 epoch = payload.epoch,
                 reconnectOutcome = payload.reconnect.toProviderOutcome(),
+                reconnectToken = reconnectToken,
+                reconnectTokenTTLMs = reconnectTokenTTLMs,
             )
         )
     }
@@ -381,6 +404,7 @@ internal class SerenadaServerProvider(
     private fun clearRoomState() {
         clearReconnect()
         clearTurnRefresh()
+        clearReconnectTokenRefresh()
         currentRoomId = null
         currentReconnectPeerId = null
         currentTurnToken = null
@@ -388,6 +412,7 @@ internal class SerenadaServerProvider(
         previousParticipants.clear()
         clientId = null
         reconnectToken = null
+        reconnectTokenTTLMs = null
     }
 
     private fun scheduleReconnect() {
@@ -410,6 +435,45 @@ internal class SerenadaServerProvider(
     private fun clearReconnect() {
         reconnectRunnable?.let { handler.removeCallbacks(it) }
         reconnectRunnable = null
+    }
+
+    private fun clearReconnectAuthorityForFreshJoin() {
+        clearReconnectTokenRefresh()
+        currentReconnectPeerId = null
+        reconnectToken = null
+        reconnectTokenTTLMs = null
+        clientId = null
+    }
+
+    private fun retryFreshJoinAfterInvalidReconnectToken(): Boolean {
+        val roomId = currentRoomId ?: return false
+        logger?.log(SerenadaLogLevel.WARNING, "Signaling", "Reconnect token rejected; retrying as a fresh join")
+        clearReconnectAuthorityForFreshJoin()
+        sendJoin(roomId)
+        return true
+    }
+
+    private fun scheduleReconnectTokenRefresh(ttlMs: Long?) {
+        clearReconnectTokenRefresh()
+        val ttl = ttlMs?.takeIf { it > 0 } ?: WebRtcResilienceConstants.RECONNECT_TOKEN_TTL_FALLBACK_MS
+        if (!signaling.isConnected() || currentRoomId == null || reconnectToken.isNullOrBlank()) return
+        val delayMs = if (ttl > WebRtcResilienceConstants.RECONNECT_TOKEN_REFRESH_LEEWAY_MS) {
+            ttl - WebRtcResilienceConstants.RECONNECT_TOKEN_REFRESH_LEEWAY_MS
+        } else {
+            maxOf(30_000L, ttl / 2)
+        }
+        val runnable = Runnable {
+            reconnectTokenRefreshRunnable = null
+            if (!signaling.isConnected() || currentRoomId == null || reconnectToken.isNullOrBlank()) return@Runnable
+            sendRawMessage(type = "reconnect-token-refresh")
+        }
+        reconnectTokenRefreshRunnable = runnable
+        handler.postDelayed(runnable, delayMs)
+    }
+
+    private fun clearReconnectTokenRefresh() {
+        reconnectTokenRefreshRunnable?.let { handler.removeCallbacks(it) }
+        reconnectTokenRefreshRunnable = null
     }
 
     private fun scheduleTurnRefresh(ttlMs: Long, delayOverrideMs: Long? = null) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -236,10 +236,11 @@ class SerenadaSession internal constructor(
     private val signalingMessageRouter = SignalingMessageRouter(
         getClientId = { clientId },
         getHostCid = { hostCid },
-        onJoined = { cid, _, roomState, _, _, newReconnectToken ->
+        onJoined = { cid, _, roomState, _, _, newReconnectToken, newReconnectTokenTTL ->
             clientId = cid
             updateState(_state.value.copy(localCid = clientId))
             newReconnectToken?.let { reconnectToken = it }
+            newReconnectTokenTTL?.let { reconnectTokenTTLMs = it }
             if (roomState != null) {
                 currentRoomState = roomState
                 hostCid = roomState.hostCid
@@ -340,6 +341,7 @@ class SerenadaSession internal constructor(
     private val peerNegotiationEngine: PeerNegotiationEngine
     private val signalingProvider: SignalingProvider
     private var reconnectToken: String? = null
+    private var reconnectTokenTTLMs: Long? = null
     private var reconnectRecoveryPending = false
     // True between transport reconnect and the first authoritative room_state
     // snapshot; gates ICE restart so it runs against a confirmed peer set.
@@ -651,6 +653,14 @@ class SerenadaSession internal constructor(
                     "Session",
                     "RX relay_failed reason=${event.reason} of=${event.of ?: "n/a"} targets=${event.targets.joinToString(",")}",
                 )
+            }
+        }
+
+        override fun onReconnectTokenRefreshed(event: ReconnectTokenRefreshedEvent) {
+            runOnMain {
+                reconnectToken = event.reconnectToken
+                event.reconnectTokenTTLMs?.let { reconnectTokenTTLMs = it }
+                persistRecoveryRecord()
             }
         }
     }
@@ -1565,7 +1575,7 @@ class SerenadaSession internal constructor(
         pendingJoinRoom = null; pendingMessages.clear(); remoteMediaStates.clear()
         connectionStatusTracker.cancelTimer()
         userPreferredVideoEnabled = config.defaultVideoEnabled; isVideoPausedByProximity = false
-        reconnectToken = null; reconnectRecoveryPending = false; hasInitialIceServers = false
+        reconnectToken = null; reconnectTokenTTLMs = null; reconnectRecoveryPending = false; hasInitialIceServers = false
         cancelPostReconnectResync()
         clearAllRemoteSuspensionTracking()
         stopMediaLivenessTimer()
@@ -1595,7 +1605,7 @@ class SerenadaSession internal constructor(
         val cid = clientId ?: return
         val token = reconnectToken ?: return
         if (sessionStartTs == null) sessionStartTs = clock.nowMs()
-        val ttlMs = RecoveryTokenTTLMs
+        val ttlMs = reconnectTokenTTLMs ?: WebRtcResilienceConstants.RECONNECT_TOKEN_TTL_FALLBACK_MS
         val record = RecoveryRecord(
             roomId = roomId,
             cid = cid,
@@ -1700,10 +1710,6 @@ class SerenadaSession internal constructor(
         const val CPU_WAKE_LOCK_TAG = "serenada:call-cpu"
         const val PLAUSIBLE_EPOCH_MS = 946_684_800_000L // 2000-01-01T00:00:00Z
         const val JOINED_AT_FUTURE_SKEW_MS = 5L * 60L * 1000L
-        // Matches the server's reconnectTokenTTL (= suspendHardEvictionTimeout).
-        // The recovery record stops offering rejoin past this window because
-        // the persisted token would no longer be honored anyway.
-        const val RecoveryTokenTTLMs = 10L * 60L * 1000L
         // Background duration that triggers a foreground force-ping. Anything
         // shorter is short enough that pings would have noticed the failure on
         // their own; longer is the OS window where Doze / process freeze may

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SignalingProvider.kt
@@ -66,6 +66,10 @@ data class JoinedEvent(
     val epoch: Long? = null,
     /** How the server treated this join. Null means an older provider that did not surface this field. */
     val reconnectOutcome: JoinReconnectOutcome? = null,
+    /** Server-issued reconnect token from `joined.reconnectToken`. */
+    val reconnectToken: String? = null,
+    /** How long (ms) the server is willing to honor `reconnectToken`. */
+    val reconnectTokenTTLMs: Long? = null,
 )
 
 data class RoomStateEvent(
@@ -119,6 +123,11 @@ data class RelayFailedEvent(
     val targets: List<String>,
     /** Original signaling type that failed, e.g. `"offer" | "answer" | "ice"`. */
     val of: String? = null,
+)
+
+data class ReconnectTokenRefreshedEvent(
+    val reconnectToken: String,
+    val reconnectTokenTTLMs: Long? = null,
 )
 
 /**
@@ -176,5 +185,6 @@ interface SignalingProvider {
         fun onIceServersChanged(iceServers: List<PeerConnection.IceServer>) {}
         fun onNegotiationDirty(event: NegotiationDirtyEvent) {}
         fun onRelayFailed(event: RelayFailedEvent) {}
+        fun onReconnectTokenRefreshed(event: ReconnectTokenRefreshedEvent) {}
     }
 }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
@@ -24,7 +24,7 @@ internal class SignalingMessageRouter(
     private val getClientId: () -> String?,
     private val getHostCid: () -> String?,
     // Mutation callbacks
-    private val onJoined: (clientId: String, hostCid: String?, roomState: RoomState?, turnToken: String?, turnTTL: Long?, reconnectToken: String?) -> Unit,
+    private val onJoined: (clientId: String, hostCid: String?, roomState: RoomState?, turnToken: String?, turnTTL: Long?, reconnectToken: String?, reconnectTokenTTL: Long?) -> Unit,
     private val onRoomStateUpdated: (RoomState) -> Unit,
     private val onError: (CallError) -> Unit,
     private val onRoomEnded: () -> Unit,
@@ -97,7 +97,7 @@ internal class SignalingMessageRouter(
         val roomState = if (!hostPeerId.isNullOrBlank()) {
             RoomState(hostCid = hostPeerId, participants = participants, maxParticipants = event.maxParticipants)
         } else null
-        onJoined(cid, roomState?.hostCid, roomState, null, null, null)
+        onJoined(cid, roomState?.hostCid, roomState, null, null, event.reconnectToken, event.reconnectTokenTTLMs)
     }
 
     fun processRoomStateEvent(event: RoomStateEvent) {
@@ -172,7 +172,7 @@ internal class SignalingMessageRouter(
 
         val roomState = parseRoomState(msg.payload)
 
-        onJoined(cid, roomState?.hostCid, roomState, turnToken, turnTTL, reconnectToken)
+        onJoined(cid, roomState?.hostCid, roomState, turnToken, turnTTL, reconnectToken, payload?.reconnectTokenTTLMs)
     }
 
     private fun handleRoomState(msg: SignalingMessage) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
@@ -56,6 +56,11 @@ internal data class NegotiationDirtyPayload(
     val withCid: String,
 )
 
+internal data class ReconnectTokenRefreshedPayload(
+    val reconnectToken: String,
+    val reconnectTokenTTLMs: Long?,
+)
+
 // --- Extension parsers ---
 
 internal fun JSONObject?.toJoinedPayload(): JoinedPayload? {
@@ -113,6 +118,15 @@ internal fun JSONObject?.toNegotiationDirtyPayload(): NegotiationDirtyPayload? {
     this ?: return null
     val withCid = optString("with").ifBlank { return null }
     return NegotiationDirtyPayload(withCid = withCid)
+}
+
+internal fun JSONObject?.toReconnectTokenRefreshedPayload(): ReconnectTokenRefreshedPayload? {
+    this ?: return null
+    val token = optString("reconnectToken").ifBlank { return null }
+    return ReconnectTokenRefreshedPayload(
+        reconnectToken = token,
+        reconnectTokenTTLMs = if (has("reconnectTokenTTLMs")) optLong("reconnectTokenTTLMs", 0).takeIf { it > 0 } else null,
+    )
 }
 
 internal fun JSONObject?.toContentStatePayload(): ContentStatePayload? {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcResilienceConstants.kt
@@ -31,6 +31,10 @@ object WebRtcResilienceConstants {
     const val TURN_REFRESH_TRIGGER_RATIO = 0.8
     val ICE_FETCH_RETRY_DELAYS_MS = longArrayOf(0L, 1_000L, 2_000L, 4_000L)
 
+    // ── Reconnect token ──────────────────────────────────────────────
+    const val RECONNECT_TOKEN_TTL_FALLBACK_MS = 1_200_000L
+    const val RECONNECT_TOKEN_REFRESH_LEEWAY_MS = 600_000L
+
     // ── Snapshot ─────────────────────────────────────────────────────
     const val SNAPSHOT_PREPARE_TIMEOUT_MS = 2_000L
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
@@ -15,8 +15,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -73,6 +75,8 @@ class SerenadaServerProviderTest {
         val peerLeftEvents = mutableListOf<PeerEvent>()
         val peerMessages = mutableListOf<PeerMessage>()
         val roomEndedEvents = mutableListOf<RoomEndedEvent>()
+        val errors = mutableListOf<ErrorEvent>()
+        val reconnectTokenRefreshedEvents = mutableListOf<ReconnectTokenRefreshedEvent>()
 
         override fun onConnected(info: ConnectionInfo) {
             connectionInfos += info
@@ -100,6 +104,14 @@ class SerenadaServerProviderTest {
 
         override fun onRoomEnded(event: RoomEndedEvent) {
             roomEndedEvents += event
+        }
+
+        override fun onError(event: ErrorEvent) {
+            errors += event
+        }
+
+        override fun onReconnectTokenRefreshed(event: ReconnectTokenRefreshedEvent) {
+            reconnectTokenRefreshedEvents += event
         }
     }
 
@@ -184,6 +196,187 @@ class SerenadaServerProviderTest {
         assertEquals("join", rejoin.type)
         assertEquals("server-assigned", rejoin.payload?.optString("reconnectCid"))
         assertEquals("token-xyz", rejoin.payload?.optString("reconnectToken"))
+    }
+
+    @Test
+    fun `reconnect token refresh is scheduled ten minutes before expiry`() {
+        provider.joinRoom(
+            roomId = "room-1",
+            options = JoinOptions(maxParticipants = 4),
+        )
+        signaling.open(activeTransport = "ws")
+
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "server-assigned",
+                to = null,
+                payload = JSONObject().apply {
+                    put("reconnectToken", "token-1")
+                    put("reconnectTokenTTLMs", 1_200_000L)
+                    put(
+                        "participants",
+                        JSONArray().put(JSONObject().apply { put("cid", "server-assigned") }),
+                    )
+                },
+            ),
+        )
+        signaling.sentMessages.clear()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(599_999L, TimeUnit.MILLISECONDS)
+        assertTrue(signaling.sentMessages.none { it.type == "reconnect-token-refresh" })
+
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(1L, TimeUnit.MILLISECONDS)
+        assertEquals(1, signaling.sentMessages.count { it.type == "reconnect-token-refresh" })
+    }
+
+    @Test
+    fun `room ended clears reconnect token refresh timer`() {
+        provider.joinRoom(
+            roomId = "room-1",
+            options = JoinOptions(maxParticipants = 4),
+        )
+        signaling.open(activeTransport = "ws")
+
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "server-assigned",
+                to = null,
+                payload = JSONObject().apply {
+                    put("reconnectToken", "token-1")
+                    put("reconnectTokenTTLMs", 1_200_000L)
+                    put(
+                        "participants",
+                        JSONArray().put(JSONObject().apply { put("cid", "server-assigned") }),
+                    )
+                },
+            ),
+        )
+        signaling.sentMessages.clear()
+
+        signaling.receive(
+            SignalingMessage(
+                type = "room_ended",
+                rid = "room-1",
+                sid = null,
+                cid = null,
+                to = null,
+                payload = JSONObject().apply { put("reason", "host_ended") },
+            ),
+        )
+        signaling.sentMessages.clear()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(600_000L, TimeUnit.MILLISECONDS)
+        assertTrue(signaling.sentMessages.none { it.type == "reconnect-token-refresh" })
+        assertEquals(1, listener.roomEndedEvents.size)
+    }
+
+    @Test
+    fun `reconnect token refreshed updates token used by next auto rejoin`() {
+        provider.joinRoom(
+            roomId = "room-1",
+            options = JoinOptions(maxParticipants = 4),
+        )
+        signaling.open(activeTransport = "ws")
+
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "server-assigned",
+                to = null,
+                payload = JSONObject().apply {
+                    put("reconnectToken", "token-1")
+                    put("reconnectTokenTTLMs", 1_200_000L)
+                    put(
+                        "participants",
+                        JSONArray().put(JSONObject().apply { put("cid", "server-assigned") }),
+                    )
+                },
+            ),
+        )
+
+        signaling.receive(
+            SignalingMessage(
+                type = "reconnect-token-refreshed",
+                rid = "room-1",
+                sid = null,
+                cid = null,
+                to = null,
+                payload = JSONObject().apply {
+                    put("reconnectToken", "token-2")
+                    put("reconnectTokenTTLMs", 1_200_000L)
+                },
+            ),
+        )
+        assertEquals("token-2", listener.reconnectTokenRefreshedEvents.single().reconnectToken)
+        signaling.sentMessages.clear()
+
+        signaling.simulateClosed()
+        signaling.open(activeTransport = "ws")
+
+        val rejoin = signaling.sentMessages.single()
+        assertEquals("server-assigned", rejoin.payload?.optString("reconnectCid"))
+        assertEquals("token-2", rejoin.payload?.optString("reconnectToken"))
+    }
+
+    @Test
+    fun `invalid reconnect token retries as fresh join without surfacing error`() {
+        provider.joinRoom(
+            roomId = "room-1",
+            options = JoinOptions(maxParticipants = 4),
+        )
+        signaling.open(activeTransport = "ws")
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "server-assigned",
+                to = null,
+                payload = JSONObject().apply {
+                    put("reconnectToken", "expired-token")
+                    put("reconnectTokenTTLMs", 1_200_000L)
+                    put(
+                        "participants",
+                        JSONArray().put(JSONObject().apply { put("cid", "server-assigned") }),
+                    )
+                },
+            ),
+        )
+
+        signaling.sentMessages.clear()
+        signaling.simulateClosed()
+        signaling.open(activeTransport = "ws")
+        val reconnectJoin = signaling.sentMessages.single()
+        assertEquals("server-assigned", reconnectJoin.payload?.optString("reconnectCid"))
+        assertEquals("expired-token", reconnectJoin.payload?.optString("reconnectToken"))
+
+        signaling.receive(
+            SignalingMessage(
+                type = "error",
+                rid = "room-1",
+                sid = null,
+                cid = null,
+                to = null,
+                payload = JSONObject().apply {
+                    put("code", "INVALID_RECONNECT_TOKEN")
+                    put("message", "Reconnect token validation failed")
+                },
+            ),
+        )
+
+        val freshJoin = signaling.sentMessages.last()
+        assertEquals("join", freshJoin.type)
+        assertNull(freshJoin.payload?.optString("reconnectCid")?.ifBlank { null })
+        assertNull(freshJoin.payload?.optString("reconnectToken")?.ifBlank { null })
+        assertTrue(listener.errors.isEmpty())
     }
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/SignalingPayloadsTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/SignalingPayloadsTest.kt
@@ -27,6 +27,7 @@ class SignalingPayloadsTest {
             put("turnToken", "tok123")
             put("turnTokenTTLMs", 60000L)
             put("reconnectToken", "rk-abc")
+            put("reconnectTokenTTLMs", 1_200_000L)
             put("maxParticipants", 4)
             put("participants", JSONArray().apply {
                 put(JSONObject().apply { put("cid", "C-host"); put("joinedAt", 1000) })
@@ -39,6 +40,7 @@ class SignalingPayloadsTest {
         assertEquals("tok123", payload.turnToken)
         assertEquals(60000L, payload.turnTokenTTLMs)
         assertEquals("rk-abc", payload.reconnectToken)
+        assertEquals(1_200_000L, payload.reconnectTokenTTLMs)
         assertEquals(4, payload.maxParticipants)
         assertEquals(2, payload.participants.size)
         assertEquals("C-host", payload.participants[0].cid)
@@ -64,6 +66,24 @@ class SignalingPayloadsTest {
         val json = JSONObject().apply { put("turnTokenTTLMs", 0) }
         val payload = json.toJoinedPayload()
         assertNull(payload!!.turnTokenTTLMs)
+    }
+
+    @Test
+    fun toReconnectTokenRefreshedPayload_fullParse() {
+        val json = JSONObject().apply {
+            put("reconnectToken", "rk-new")
+            put("reconnectTokenTTLMs", 1_200_000L)
+        }
+        val payload = json.toReconnectTokenRefreshedPayload()
+        assertNotNull(payload)
+        assertEquals("rk-new", payload!!.reconnectToken)
+        assertEquals(1_200_000L, payload.reconnectTokenTTLMs)
+    }
+
+    @Test
+    fun toReconnectTokenRefreshedPayload_missingTokenReturnsNull() {
+        val json = JSONObject().apply { put("reconnectTokenTTLMs", 1_200_000L) }
+        assertNull(json.toReconnectTokenRefreshedPayload())
     }
 
     // ---------------------------------------------------------------

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcResilienceConstants.swift
@@ -33,6 +33,11 @@ public enum WebRtcResilience {
     public static let turnRefreshTriggerRatio = 0.8
     public static let iceFetchRetryDelaysMs = [0, 1_000, 2_000, 4_000]
 
+    // MARK: - Reconnect Token
+
+    public static let reconnectTokenTtlFallbackMs = 1_200_000
+    public static let reconnectTokenRefreshLeewayMs = 600_000
+
     // MARK: - Snapshot
 
     public static let snapshotPrepareTimeoutMs = 2_000

--- a/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaServerProvider.swift
@@ -13,6 +13,7 @@ internal final class SerenadaServerProvider: SignalingProvider {
     @MainActor private var turnManager: TurnManager?
     @MainActor private var reconnectAttempts = 0
     @MainActor private var reconnectTask: Task<Void, Never>?
+    @MainActor private var reconnectTokenRefreshTask: Task<Void, Never>?
     @MainActor private var currentRoomId: String?
     @MainActor private var currentMaxParticipants = 4
     @MainActor private var currentReconnectPeerId: String?
@@ -20,6 +21,7 @@ internal final class SerenadaServerProvider: SignalingProvider {
     @MainActor private var currentAppPeerId: String?
     @MainActor private var currentTurnToken: String?
     @MainActor private var reconnectToken: String?
+    @MainActor private var reconnectTokenTTLMs: Int64?
     @MainActor private var clientId: String?
     @MainActor private var currentHostPeerId: String?
     @MainActor private var previousParticipants: [String: SignalingProviderParticipant] = [:]
@@ -210,6 +212,9 @@ extension SerenadaServerProvider: SignalingClientListener {
         case "error":
             let payload = ErrorPayload(from: message.payload)
             let code = payload.code ?? "UNKNOWN"
+            if code == "INVALID_RECONNECT_TOKEN", retryFreshJoinAfterInvalidReconnectToken() {
+                return
+            }
             // Terminal codes that invalidate persisted reconnect authority.
             // Drop the stored token so a future join cannot try to reclaim
             // the (gone) slot.
@@ -225,6 +230,18 @@ extension SerenadaServerProvider: SignalingClientListener {
         case "turn-refreshed":
             currentTurnToken = SignalingMessageRouter.turnToken(from: message.payload)
             turnManager?.handleTurnRefreshed(payload: message.payload)
+        case "reconnect-token-refreshed":
+            if let payload = ReconnectTokenRefreshedPayload(from: message.payload) {
+                reconnectToken = payload.reconnectToken
+                reconnectTokenTTLMs = payload.reconnectTokenTTLMs ?? Int64(WebRtcResilience.reconnectTokenTtlFallbackMs)
+                scheduleReconnectTokenRefresh(ttlMs: reconnectTokenTTLMs)
+                delegate?.signalingProviderDidRefreshReconnectToken(
+                    ReconnectTokenRefreshedEvent(
+                        reconnectToken: payload.reconnectToken,
+                        reconnectTokenTTLMs: reconnectTokenTTLMs
+                    )
+                )
+            }
         case "offer", "answer", "ice", "content_state", "participant_media_state":
             emitPeerMessage(message)
         case "negotiation_dirty":
@@ -247,6 +264,7 @@ extension SerenadaServerProvider: SignalingClientListener {
     }
 
     func onClosed(reason: String) {
+        clearReconnectTokenRefresh()
         delegate?.signalingProviderDidDisconnect(reason: reason)
         guard !closedByClient, currentRoomId != nil else { return }
         pendingJoinRoomId = currentRoomId
@@ -271,6 +289,10 @@ private extension SerenadaServerProvider {
         // participant alongside our suspended record.
         currentReconnectPeerId = peerId
         reconnectToken = payload.reconnectToken ?? reconnectToken
+        reconnectTokenTTLMs = payload.reconnectTokenTTLMs.map(Int64.init) ?? reconnectTokenTTLMs
+        if payload.reconnectToken != nil {
+            scheduleReconnectTokenRefresh(ttlMs: reconnectTokenTTLMs ?? Int64(WebRtcResilience.reconnectTokenTtlFallbackMs))
+        }
         currentHostPeerId = payload.hostCid
         currentTurnToken = payload.turnToken
         if let ttl = payload.turnTokenTTLMs {
@@ -434,8 +456,51 @@ private extension SerenadaServerProvider {
         reconnectTask = nil
     }
 
+    func clearReconnectAuthorityForFreshJoin() {
+        clearReconnectTokenRefresh()
+        currentReconnectPeerId = nil
+        reconnectToken = nil
+        reconnectTokenTTLMs = nil
+        clientId = nil
+    }
+
+    func retryFreshJoinAfterInvalidReconnectToken() -> Bool {
+        guard let roomId = currentRoomId else { return false }
+        logger?.log(.warning, tag: "Signaling", "Reconnect token rejected; retrying as a fresh join")
+        clearReconnectAuthorityForFreshJoin()
+        sendJoin(roomId: roomId)
+        return true
+    }
+
+    func scheduleReconnectTokenRefresh(ttlMs: Int64?) {
+        clearReconnectTokenRefresh()
+        let ttl = ttlMs.flatMap { $0 > 0 ? $0 : nil } ?? Int64(WebRtcResilience.reconnectTokenTtlFallbackMs)
+        guard signaling.isConnected(), currentRoomId != nil, reconnectToken?.isEmpty == false else { return }
+        let delayMs: Int64
+        if ttl > Int64(WebRtcResilience.reconnectTokenRefreshLeewayMs) {
+            delayMs = ttl - Int64(WebRtcResilience.reconnectTokenRefreshLeewayMs)
+        } else {
+            delayMs = max(30_000, ttl / 2)
+        }
+        reconnectTokenRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            try? await self.clock.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard self.signaling.isConnected(), self.currentRoomId != nil, self.reconnectToken?.isEmpty == false else { return }
+                self.sendRawMessage(type: "reconnect-token-refresh")
+            }
+        }
+    }
+
+    func clearReconnectTokenRefresh() {
+        reconnectTokenRefreshTask?.cancel()
+        reconnectTokenRefreshTask = nil
+    }
+
     func clearRoomState() {
         clearReconnect()
+        clearReconnectTokenRefresh()
         turnManager?.cancelRefresh()
         currentRoomId = nil
         currentReconnectPeerId = nil
@@ -444,6 +509,7 @@ private extension SerenadaServerProvider {
         previousParticipants = [:]
         clientId = nil
         reconnectToken = nil
+        reconnectTokenTTLMs = nil
     }
 
     func dedupeProviderParticipants(

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -100,6 +100,12 @@ private final class SignalingProviderDelegateProxy: SignalingProviderDelegate {
             session?.handleProviderRelayFailed(event)
         }
     }
+
+    func signalingProviderDidRefreshReconnectToken(_ event: ReconnectTokenRefreshedEvent) {
+        Task { @MainActor [weak session] in
+            session?.handleProviderReconnectTokenRefreshed(event)
+        }
+    }
 }
 
 /// Represents an active call session. Created via ``SerenadaCore/join(url:)`` or ``SerenadaCore/createRoom()``.
@@ -794,6 +800,10 @@ public final class SerenadaSession: ObservableObject {
     fileprivate func handleProviderJoined(_ event: JoinedEvent) {
         currentError = nil
         signalingMessageRouter?.processJoinedEvent(event)
+        persistRecoveryRecord(token: event.reconnectToken, ttlMs: event.reconnectTokenTTLMs)
+    }
+
+    fileprivate func handleProviderReconnectTokenRefreshed(_ event: ReconnectTokenRefreshedEvent) {
         persistRecoveryRecord(token: event.reconnectToken, ttlMs: event.reconnectTokenTTLMs)
     }
 
@@ -1714,9 +1724,8 @@ public final class SerenadaSession: ObservableObject {
         joinedAtMs >= plausibleEpochMs && joinedAtMs <= nowMs + joinedAtFutureSkewMs
     }
 
-    /// Matches the server's `reconnectTokenTTL` (= `suspendHardEvictionTimeout`).
     /// Used when the server did not surface `reconnectTokenTTLMs`.
-    private static let defaultRecoveryTokenTTLMs: Int64 = 10 * 60 * 1000
+    private static let defaultRecoveryTokenTTLMs: Int64 = Int64(WebRtcResilience.reconnectTokenTtlFallbackMs)
     private static let plausibleEpochMs: Int64 = 946_684_800_000
     private static let joinedAtFutureSkewMs: Int64 = 5 * 60 * 1000
 }

--- a/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
@@ -149,6 +149,18 @@ struct NegotiationDirtyPayload {
     }
 }
 
+struct ReconnectTokenRefreshedPayload {
+    let reconnectToken: String
+    let reconnectTokenTTLMs: Int64?
+
+    init?(from payload: JSONValue?) {
+        guard let obj = payload?.objectValue else { return nil }
+        guard let token = obj["reconnectToken"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else { return nil }
+        reconnectToken = token
+        reconnectTokenTTLMs = obj["reconnectTokenTTLMs"]?.intValue.map(Int64.init)
+    }
+}
+
 /// Payload for "error" message — server reports an error.
 struct ErrorPayload {
     let code: String?

--- a/client-ios/SerenadaCore/Sources/SignalingProvider.swift
+++ b/client-ios/SerenadaCore/Sources/SignalingProvider.swift
@@ -224,6 +224,16 @@ public struct RelayFailedEvent: Equatable, Sendable {
     }
 }
 
+public struct ReconnectTokenRefreshedEvent: Equatable, Sendable {
+    public let reconnectToken: String
+    public let reconnectTokenTTLMs: Int64?
+
+    public init(reconnectToken: String, reconnectTokenTTLMs: Int64? = nil) {
+        self.reconnectToken = reconnectToken
+        self.reconnectTokenTTLMs = reconnectTokenTTLMs
+    }
+}
+
 /// Receives provider events. Implementations may invoke these callbacks from
 /// any thread; the SDK session layer hops back to the main actor before
 /// mutating observable SDK state.
@@ -240,6 +250,7 @@ public protocol SignalingProviderDelegate: AnyObject {
     func signalingProviderDidChangeIceServers(_ iceServers: [IceServerConfig])
     func signalingProviderDidReceiveNegotiationDirty(_ event: NegotiationDirtyEvent)
     func signalingProviderDidReceiveRelayFailed(_ event: RelayFailedEvent)
+    func signalingProviderDidRefreshReconnectToken(_ event: ReconnectTokenRefreshedEvent)
 }
 
 public extension SignalingProviderDelegate {
@@ -255,6 +266,7 @@ public extension SignalingProviderDelegate {
     func signalingProviderDidChangeIceServers(_ iceServers: [IceServerConfig]) {}
     func signalingProviderDidReceiveNegotiationDirty(_ event: NegotiationDirtyEvent) {}
     func signalingProviderDidReceiveRelayFailed(_ event: RelayFailedEvent) {}
+    func signalingProviderDidRefreshReconnectToken(_ event: ReconnectTokenRefreshedEvent) {}
 }
 
 /// Transport-agnostic signaling contract for iOS SDK sessions.

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
@@ -11,6 +11,8 @@ final class SerenadaServerProviderTests: XCTestCase {
         var peerLeftEvents: [PeerEvent] = []
         var peerMessages: [PeerMessage] = []
         var roomEndedEvents: [RoomEndedEvent] = []
+        var errorEvents: [ErrorEvent] = []
+        var reconnectTokenRefreshedEvents: [ReconnectTokenRefreshedEvent] = []
 
         func signalingProviderDidConnect(_ info: ConnectionInfo) {
             connectionInfos.append(info)
@@ -39,10 +41,19 @@ final class SerenadaServerProviderTests: XCTestCase {
         func signalingProviderDidEndRoom(_ event: RoomEndedEvent) {
             roomEndedEvents.append(event)
         }
+
+        func signalingProviderDidReceiveError(_ event: ErrorEvent) {
+            errorEvents.append(event)
+        }
+
+        func signalingProviderDidRefreshReconnectToken(_ event: ReconnectTokenRefreshedEvent) {
+            reconnectTokenRefreshedEvents.append(event)
+        }
     }
 
     private var signaling: FakeSessionSignaling!
     private var apiClient: FakeAPIClient!
+    private var fakeClock: FakeSessionClock!
     private var delegate: RecordingDelegate!
     private var provider: SerenadaServerProvider!
 
@@ -50,11 +61,13 @@ final class SerenadaServerProviderTests: XCTestCase {
         super.setUp()
         signaling = FakeSessionSignaling()
         apiClient = FakeAPIClient()
+        fakeClock = FakeSessionClock()
         delegate = RecordingDelegate()
         provider = SerenadaServerProvider(
             serverHost: "serenada.app",
             apiClient: apiClient,
-            signaling: signaling
+            signaling: signaling,
+            clock: fakeClock
         )
         provider.delegate = delegate
     }
@@ -63,6 +76,7 @@ final class SerenadaServerProviderTests: XCTestCase {
         provider.disconnect()
         provider = nil
         delegate = nil
+        fakeClock = nil
         apiClient = nil
         signaling = nil
         super.tearDown()
@@ -116,6 +130,117 @@ final class SerenadaServerProviderTests: XCTestCase {
         XCTAssertEqual(rejoin.type, "join")
         XCTAssertEqual(rejoin.payload?.objectValue?["reconnectCid"]?.stringValue, "server-assigned")
         XCTAssertEqual(rejoin.payload?.objectValue?["reconnectToken"]?.stringValue, "token-xyz")
+    }
+
+    func testReconnectTokenRefreshIsScheduledTenMinutesBeforeExpiry() async throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        signaling.simulateOpen(activeTransport: "ws")
+
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "joined",
+                rid: "room-1",
+                cid: "server-assigned",
+                payload: .object([
+                    "reconnectToken": .string("token-1"),
+                    "reconnectTokenTTLMs": .number(1_200_000),
+                    "participants": .array([
+                        .object(["cid": .string("server-assigned")])
+                    ])
+                ])
+            )
+        )
+        signaling.clearSentMessages()
+        await Task.yield()
+
+        await fakeClock.advance(byMs: 599_999)
+        XCTAssertFalse(signaling.sentMessages.contains { $0.type == "reconnect-token-refresh" })
+
+        await fakeClock.advance(byMs: 1)
+        XCTAssertEqual(signaling.sentMessages.filter { $0.type == "reconnect-token-refresh" }.count, 1)
+    }
+
+    func testReconnectTokenRefreshedUpdatesTokenUsedByNextAutoRejoin() throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        signaling.simulateOpen(activeTransport: "ws")
+
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "joined",
+                rid: "room-1",
+                cid: "server-assigned",
+                payload: .object([
+                    "reconnectToken": .string("token-1"),
+                    "reconnectTokenTTLMs": .number(1_200_000),
+                    "participants": .array([
+                        .object(["cid": .string("server-assigned")])
+                    ])
+                ])
+            )
+        )
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "reconnect-token-refreshed",
+                rid: "room-1",
+                payload: .object([
+                    "reconnectToken": .string("token-2"),
+                    "reconnectTokenTTLMs": .number(1_200_000)
+                ])
+            )
+        )
+        XCTAssertEqual(delegate.reconnectTokenRefreshedEvents.count, 1)
+        XCTAssertEqual(delegate.reconnectTokenRefreshedEvents.first?.reconnectToken, "token-2")
+        signaling.clearSentMessages()
+
+        signaling.simulateClosed()
+        signaling.simulateOpen(activeTransport: "ws")
+
+        let rejoin = try XCTUnwrap(signaling.sentMessages.last)
+        XCTAssertEqual(rejoin.payload?.objectValue?["reconnectCid"]?.stringValue, "server-assigned")
+        XCTAssertEqual(rejoin.payload?.objectValue?["reconnectToken"]?.stringValue, "token-2")
+    }
+
+    func testInvalidReconnectTokenRetriesAsFreshJoinWithoutSurfacingError() throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        signaling.simulateOpen(activeTransport: "ws")
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "joined",
+                rid: "room-1",
+                cid: "server-assigned",
+                payload: .object([
+                    "reconnectToken": .string("expired-token"),
+                    "reconnectTokenTTLMs": .number(1_200_000),
+                    "participants": .array([
+                        .object(["cid": .string("server-assigned")])
+                    ])
+                ])
+            )
+        )
+
+        signaling.clearSentMessages()
+        signaling.simulateClosed()
+        signaling.simulateOpen(activeTransport: "ws")
+        let reconnectJoin = try XCTUnwrap(signaling.sentMessages.last)
+        XCTAssertEqual(reconnectJoin.payload?.objectValue?["reconnectCid"]?.stringValue, "server-assigned")
+        XCTAssertEqual(reconnectJoin.payload?.objectValue?["reconnectToken"]?.stringValue, "expired-token")
+
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "error",
+                rid: "room-1",
+                payload: .object([
+                    "code": .string("INVALID_RECONNECT_TOKEN"),
+                    "message": .string("Reconnect token validation failed")
+                ])
+            )
+        )
+
+        let freshJoin = try XCTUnwrap(signaling.sentMessages.last)
+        XCTAssertEqual(freshJoin.type, "join")
+        XCTAssertNil(freshJoin.payload?.objectValue?["reconnectCid"]?.stringValue)
+        XCTAssertNil(freshJoin.payload?.objectValue?["reconnectToken"]?.stringValue)
+        XCTAssertTrue(delegate.errorEvents.isEmpty)
     }
 
     func testJoinedTurnTokenIsUsedForIceServerFetch() async throws {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SignalingPayloadsTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SignalingPayloadsTests.swift
@@ -11,6 +11,7 @@ final class SignalingPayloadsTests: XCTestCase {
             "turnToken": .string("tok123"),
             "turnTokenTTLMs": .number(60000),
             "reconnectToken": .string("rk-abc"),
+            "reconnectTokenTTLMs": .number(1_200_000),
             "participants": .array([
                 .object(["cid": .string("C-host"), "joinedAt": .number(1000)]),
                 .object(["cid": .string("C-guest")]),
@@ -21,6 +22,7 @@ final class SignalingPayloadsTests: XCTestCase {
         XCTAssertEqual(parsed.turnToken, "tok123")
         XCTAssertEqual(parsed.turnTokenTTLMs, 60000)
         XCTAssertEqual(parsed.reconnectToken, "rk-abc")
+        XCTAssertEqual(parsed.reconnectTokenTTLMs, 1_200_000)
         XCTAssertEqual(parsed.participants?.count, 2)
         XCTAssertEqual(parsed.participants?[0].cid, "C-host")
         XCTAssertEqual(parsed.participants?[0].joinedAt, 1000)
@@ -46,6 +48,23 @@ final class SignalingPayloadsTests: XCTestCase {
         ])
         let parsed = JoinedPayload(from: payload)
         XCTAssertEqual(parsed.participantCount, 1)
+    }
+
+    func testReconnectTokenRefreshedPayloadFullParse() {
+        let payload: JSONValue = .object([
+            "reconnectToken": .string("rk-new"),
+            "reconnectTokenTTLMs": .number(1_200_000),
+        ])
+        let parsed = ReconnectTokenRefreshedPayload(from: payload)
+        XCTAssertEqual(parsed?.reconnectToken, "rk-new")
+        XCTAssertEqual(parsed?.reconnectTokenTTLMs, 1_200_000)
+    }
+
+    func testReconnectTokenRefreshedPayloadMissingTokenReturnsNil() {
+        let payload: JSONValue = .object([
+            "reconnectTokenTTLMs": .number(1_200_000),
+        ])
+        XCTAssertNil(ReconnectTokenRefreshedPayload(from: payload))
     }
 
     func testJoinedPayloadEmptyParticipants() {

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -66,6 +66,8 @@ function mapErrorCode(serverCode: string): CallErrorCode {
             return 'roomFull';
         case 'ROOM_ENDED':
             return 'roomEnded';
+        case 'INVALID_RECONNECT_TOKEN':
+            return 'sessionExpired';
         case 'CONNECTION_FAILED':
             return 'connectionFailed';
         case 'ICE_SERVER_FETCH_FAILED':
@@ -74,7 +76,6 @@ function mapErrorCode(serverCode: string): CallErrorCode {
         case 'UNSUPPORTED_VERSION':
         case 'INVALID_ROOM_ID':
         case 'SERVER_NOT_CONFIGURED':
-        case 'INVALID_RECONNECT_TOKEN':
         case 'TURN_REFRESH_FAILED':
         case 'NOT_IN_ROOM':
         case 'NOT_HOST':

--- a/client/packages/core/src/constants.ts
+++ b/client/packages/core/src/constants.ts
@@ -29,6 +29,10 @@ export const TURN_FETCH_TIMEOUT_MS = 2000;
 export const TURN_REFRESH_TRIGGER_RATIO = 0.8;
 export const ICE_FETCH_RETRY_DELAYS_MS = [0, 1000, 2000, 4000];
 
+// Reconnect token
+export const RECONNECT_TOKEN_TTL_FALLBACK_MS = 1200000;
+export const RECONNECT_TOKEN_REFRESH_LEEWAY_MS = 600000;
+
 // Session
 export const ENDING_SCREEN_MS = 3000;
 

--- a/client/packages/core/src/signaling/SignalingEngine.ts
+++ b/client/packages/core/src/signaling/SignalingEngine.ts
@@ -9,6 +9,7 @@ import {
     parseRoomStatePayload,
     parseErrorPayload,
     parseTurnRefreshedPayload,
+    parseReconnectTokenRefreshedPayload,
     parseRelayFailedPayload,
     parseNegotiationDirtyPayload,
 } from './payloads.js';
@@ -24,7 +25,8 @@ import {
     JOIN_RECOVERY_MS,
     JOIN_HARD_TIMEOUT_MS,
     TURN_REFRESH_TRIGGER_RATIO,
-    SUSPEND_HARD_EVICTION_TIMEOUT_MS,
+    RECONNECT_TOKEN_TTL_FALLBACK_MS,
+    RECONNECT_TOKEN_REFRESH_LEEWAY_MS,
 } from '../constants.js';
 
 export interface SignalingEngineConfig {
@@ -86,6 +88,7 @@ export class SignalingEngine {
     private needsRejoin = false;
     private reconnectToken: string | null = null;
     private reconnectTokenRoomId: string | null = null;
+    private reconnectTokenTTLMs: number | null = null;
     private lastPongAt = Date.now();
     private missedPongs = 0;
     private wsConsecutiveFailures = 0;
@@ -96,6 +99,7 @@ export class SignalingEngine {
     private joinRecoveryTimer: number | null = null;
     private joinHardTimeout: number | null = null;
     private turnRefreshTimer: number | null = null;
+    private reconnectTokenRefreshTimer: number | null = null;
     private pingInterval: number | null = null;
     private reconnectTimeout: number | null = null;
     private reconnectAttempts = 0;
@@ -133,6 +137,7 @@ export class SignalingEngine {
         this.clearJoinTimers();
         this.clearPingInterval();
         this.clearTurnRefreshTimer();
+        this.clearReconnectTokenRefreshTimer();
         this.awaitingPostReconnectSnapshot = false;
         this.epochAtDisconnect = null;
         if (this.transport) {
@@ -251,6 +256,7 @@ export class SignalingEngine {
         this.turnToken = null;
         this.turnTokenTTLMs = null;
         this.turnTokenExpiresAtMs = null;
+        this.clearReconnectTokenRefreshTimer();
         this.lastReconnectOutcome = null;
         this.lastEpoch = null;
         this.awaitingPostReconnectSnapshot = false;
@@ -320,7 +326,9 @@ export class SignalingEngine {
                 if (joined.reconnectToken) {
                     this.reconnectToken = joined.reconnectToken;
                     this.reconnectTokenRoomId = msg.rid || this.currentRoomId;
+                    this.reconnectTokenTTLMs = joined.reconnectTokenTTLMs ?? RECONNECT_TOKEN_TTL_FALLBACK_MS;
                     this.persistReconnectStorage();
+                    this.scheduleReconnectTokenRefresh(this.reconnectTokenTTLMs);
                 }
                 this.persistClientId();
                 if (this.sessionStartTs === null) {
@@ -346,6 +354,19 @@ export class SignalingEngine {
                         this.scheduleTurnRefresh();
                     }
                     this.logger?.log('debug', 'Signaling', 'TURN credentials refreshed');
+                }
+                break;
+            }
+            case 'reconnect-token-refreshed': {
+                const refreshed = parseReconnectTokenRefreshedPayload(msg.payload);
+                if (refreshed) {
+                    this.reconnectToken = refreshed.reconnectToken;
+                    this.reconnectTokenRoomId = msg.rid || this.currentRoomId;
+                    this.reconnectTokenTTLMs = refreshed.reconnectTokenTTLMs ?? RECONNECT_TOKEN_TTL_FALLBACK_MS;
+                    this.persistReconnectStorage();
+                    this.persistRecoveryRecord(this.reconnectTokenTTLMs);
+                    this.scheduleReconnectTokenRefresh(this.reconnectTokenTTLMs);
+                    this.logger?.log('debug', 'Signaling', 'Reconnect token refreshed');
                 }
                 break;
             }
@@ -408,6 +429,9 @@ export class SignalingEngine {
             case 'error': {
                 const errorPayload = parseErrorPayload(msg.payload);
                 if (errorPayload) {
+                    if (errorPayload.code === 'INVALID_RECONNECT_TOKEN' && this.retryFreshJoinAfterInvalidReconnectToken(msg.rid)) {
+                        return;
+                    }
                     this.error = errorPayload;
                     // Terminal errors that invalidate persisted reconnect
                     // state. The session is over for this CID — clear the
@@ -481,6 +505,8 @@ export class SignalingEngine {
                 this.isConnected = false;
                 this.activeTransport = null;
                 this.clearPingInterval();
+                this.clearTurnRefreshTimer();
+                this.clearReconnectTokenRefreshTimer();
                 if (targetKind === 'ws') {
                     this.wsConsecutiveFailures++;
                 }
@@ -657,6 +683,13 @@ export class SignalingEngine {
         if (this.turnRefreshTimer !== null) { window.clearTimeout(this.turnRefreshTimer); this.turnRefreshTimer = null; }
     }
 
+    private clearReconnectTokenRefreshTimer(): void {
+        if (this.reconnectTokenRefreshTimer !== null) {
+            window.clearTimeout(this.reconnectTokenRefreshTimer);
+            this.reconnectTokenRefreshTimer = null;
+        }
+    }
+
     private clearReconnectTimeout(): void {
         if (this.reconnectTimeout !== null) { window.clearTimeout(this.reconnectTimeout); this.reconnectTimeout = null; }
     }
@@ -671,6 +704,7 @@ export class SignalingEngine {
     // server `room_ended`, terminal error codes, etc.
     private resetForTerminal(): void {
         this.clearJoinTimers();
+        this.clearReconnectTokenRefreshTimer();
         this.roomState = null;
         this.currentRoomId = null;
         this.needsRejoin = false;
@@ -729,8 +763,61 @@ export class SignalingEngine {
         }
         this.reconnectToken = null;
         this.reconnectTokenRoomId = null;
+        this.reconnectTokenTTLMs = null;
         this.sessionStartTs = null;
         clearRecoveryRecord();
+    }
+
+    private clearReconnectAuthorityForFreshJoin(): void {
+        this.clearReconnectTokenRefreshTimer();
+        try {
+            window.sessionStorage.removeItem(this.storageKeyClientId);
+            window.sessionStorage.removeItem(this.storageKeyReconnectToken);
+            window.sessionStorage.removeItem(this.storageKeyReconnectTokenRoom);
+        } catch (err) {
+            this.logger?.log('warning', 'Signaling', `Failed to clear reconnect authority: ${err}`);
+        }
+        this.clientId = null;
+        this.lastClientId = null;
+        this.reconnectToken = null;
+        this.reconnectTokenRoomId = null;
+        this.reconnectTokenTTLMs = null;
+        this.sessionStartTs = null;
+        clearRecoveryRecord();
+    }
+
+    private retryFreshJoinAfterInvalidReconnectToken(rid: string | undefined): boolean {
+        const roomId = rid || this.currentRoomId;
+        if (!roomId) {
+            return false;
+        }
+        this.logger?.log('warning', 'Signaling', 'Reconnect token rejected; retrying as a fresh join');
+        this.error = null;
+        this.clearJoinTimers();
+        this.clearReconnectAuthorityForFreshJoin();
+        this.joinRoom(roomId, {
+            createMaxParticipants: this.lastCreateMaxParticipants,
+            displayName: this.lastDisplayName,
+            peerId: this.lastPeerId,
+        });
+        return true;
+    }
+
+    private scheduleReconnectTokenRefresh(ttlMs: number | null | undefined): void {
+        this.clearReconnectTokenRefreshTimer();
+        if (!this.isConnected || !this.currentRoomId || !this.reconnectToken) return;
+
+        const ttl = ttlMs && ttlMs > 0 ? ttlMs : RECONNECT_TOKEN_TTL_FALLBACK_MS;
+        const delay = ttl > RECONNECT_TOKEN_REFRESH_LEEWAY_MS
+            ? ttl - RECONNECT_TOKEN_REFRESH_LEEWAY_MS
+            : Math.max(30_000, ttl / 2);
+        this.logger?.log('debug', 'Signaling', `Scheduling reconnect token refresh in ${Math.round(delay / 1000)}s`);
+        this.reconnectTokenRefreshTimer = window.setTimeout(() => {
+            this.reconnectTokenRefreshTimer = null;
+            if (!this.isConnected || !this.currentRoomId || !this.reconnectToken) return;
+            this.logger?.log('debug', 'Signaling', 'Sending reconnect-token-refresh request');
+            this.sendMessage('reconnect-token-refresh');
+        }, delay);
     }
 
     // Snapshots the in-memory reconnect state into the cross-launch
@@ -741,15 +828,11 @@ export class SignalingEngine {
         if (!this.currentRoomId || !this.clientId || !this.reconnectToken || !this.sessionStartTs) {
             return;
         }
-        // Fall back to the cross-platform suspendHardEvictionTimeout when
-        // the server didn't surface a token TTL. The Go server's reconnect
-        // token TTL is bound to suspendHardEvictionTimeout (see
-        // signaling.go: reconnectTokenTTL = suspendHardEvictionTimeout), so
-        // mirroring that constant keeps Web aligned with iOS/Android and
-        // the server without local drift.
+        // Fall back to the cross-platform reconnect-token TTL when the
+        // server did not surface a token TTL.
         const ttl = reconnectTokenTTLMs && reconnectTokenTTLMs > 0
             ? reconnectTokenTTLMs
-            : SUSPEND_HARD_EVICTION_TIMEOUT_MS;
+            : RECONNECT_TOKEN_TTL_FALLBACK_MS;
         saveRecoveryRecord({
             roomId: this.currentRoomId,
             cid: this.clientId,

--- a/client/packages/core/src/signaling/payloads.ts
+++ b/client/packages/core/src/signaling/payloads.ts
@@ -57,6 +57,11 @@ export interface TurnRefreshedPayload {
     turnTokenTTLMs?: number;
 }
 
+export interface ReconnectTokenRefreshedPayload {
+    reconnectToken: string;
+    reconnectTokenTTLMs?: number;
+}
+
 export interface OfferPayload {
     from: string;
     sdp: string;
@@ -177,6 +182,15 @@ export function parseTurnRefreshedPayload(raw: Record<string, unknown> | undefin
     return {
         turnToken: raw.turnToken,
         turnTokenTTLMs: typeof raw.turnTokenTTLMs === 'number' ? raw.turnTokenTTLMs : undefined,
+    };
+}
+
+export function parseReconnectTokenRefreshedPayload(raw: Record<string, unknown> | undefined): ReconnectTokenRefreshedPayload | null {
+    if (!raw) return null;
+    if (typeof raw.reconnectToken !== 'string') return null;
+    return {
+        reconnectToken: raw.reconnectToken,
+        reconnectTokenTTLMs: typeof raw.reconnectTokenTTLMs === 'number' ? raw.reconnectTokenTTLMs : undefined,
     };
 }
 

--- a/client/packages/core/test/signaling/SignalingEngine.test.ts
+++ b/client/packages/core/test/signaling/SignalingEngine.test.ts
@@ -74,6 +74,16 @@ function lastTransport(): FakeTransport {
     return t;
 }
 
+function advanceTimersWithPongs(transport: FakeTransport, totalMs: number): void {
+    let remaining = totalMs;
+    while (remaining > 0) {
+        const step = Math.min(12_000, remaining);
+        vi.advanceTimersByTime(step);
+        transport.simulateMessage({ v: 1, type: 'pong' });
+        remaining -= step;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 1. Transport fallback — WS never connected → immediate SSE fallback
 // ---------------------------------------------------------------------------
@@ -272,6 +282,99 @@ describe('auto-rejoin on reconnect', () => {
         const joinMsgs2 = ws2.sentMessages.filter(m => m.type === 'join');
         expect(joinMsgs2).toHaveLength(1);
         expect(joinMsgs2[0].rid).toBe('room-abc');
+
+        engine.destroy();
+    });
+
+    it('refreshes reconnect token 10 minutes before expiration', () => {
+        const engine = createEngine(['ws']);
+        engine.connect();
+        const ws = lastTransport();
+        ws.simulateOpen();
+
+        engine.joinRoom('room-abc');
+        ws.simulateMessage({
+            v: 1,
+            type: 'joined',
+            cid: 'c1',
+            rid: 'room-abc',
+            payload: {
+                hostCid: 'c1',
+                participants: [{ cid: 'c1' }],
+                reconnectToken: 'rt-1',
+                reconnectTokenTTLMs: 1_200_000,
+            },
+        });
+
+        advanceTimersWithPongs(ws, 599_999);
+        expect(ws.sentMessages.filter(m => m.type === 'reconnect-token-refresh')).toHaveLength(0);
+
+        advanceTimersWithPongs(ws, 1);
+        expect(ws.sentMessages.filter(m => m.type === 'reconnect-token-refresh')).toHaveLength(1);
+
+        ws.simulateMessage({
+            v: 1,
+            type: 'reconnect-token-refreshed',
+            rid: 'room-abc',
+            payload: {
+                reconnectToken: 'rt-2',
+                reconnectTokenTTLMs: 1_200_000,
+            },
+        });
+
+        advanceTimersWithPongs(ws, 600_000);
+        expect(ws.sentMessages.filter(m => m.type === 'reconnect-token-refresh')).toHaveLength(2);
+
+        engine.destroy();
+    });
+
+    it('retries as a fresh join when reconnect token is rejected', () => {
+        const engine = createEngine(['ws']);
+        engine.connect();
+        const ws1 = lastTransport();
+        ws1.simulateOpen();
+
+        engine.joinRoom('room-abc');
+        ws1.simulateMessage({
+            v: 1,
+            type: 'joined',
+            cid: 'c1',
+            rid: 'room-abc',
+            payload: {
+                hostCid: 'c1',
+                participants: [{ cid: 'c1' }],
+                reconnectToken: 'expired-token',
+                reconnectTokenTTLMs: 1_200_000,
+            },
+        });
+
+        ws1.simulateClose('error');
+        vi.advanceTimersByTime(500);
+        const ws2 = lastTransport();
+        ws2.simulateOpen();
+
+        const reconnectJoin = ws2.sentMessages.find(m => m.type === 'join');
+        expect(reconnectJoin?.payload).toMatchObject({
+            reconnectCid: 'c1',
+            reconnectToken: 'expired-token',
+        });
+
+        ws2.simulateMessage({
+            v: 1,
+            type: 'error',
+            rid: 'room-abc',
+            payload: {
+                code: 'INVALID_RECONNECT_TOKEN',
+                message: 'Reconnect token validation failed',
+            },
+        });
+
+        const joins = ws2.sentMessages.filter(m => m.type === 'join');
+        expect(joins).toHaveLength(2);
+        expect(joins[1].rid).toBe('room-abc');
+        expect(joins[1].payload).not.toHaveProperty('reconnectCid');
+        expect(joins[1].payload).not.toHaveProperty('reconnectToken');
+        expect(engine.error).toBeNull();
 
         engine.destroy();
     });

--- a/client/packages/core/test/signaling/payloads.test.ts
+++ b/client/packages/core/test/signaling/payloads.test.ts
@@ -4,6 +4,7 @@ import {
     parseRoomStatePayload,
     parseErrorPayload,
     parseTurnRefreshedPayload,
+    parseReconnectTokenRefreshedPayload,
     parseOfferPayload,
     parseAnswerPayload,
     parseIceCandidatePayload,
@@ -205,6 +206,26 @@ describe('parseTurnRefreshedPayload', () => {
         expect(parseTurnRefreshedPayload({ turnToken: 't', extra: 1 })).toEqual({
             turnToken: 't',
             turnTokenTTLMs: undefined,
+        });
+    });
+});
+
+describe('parseReconnectTokenRefreshedPayload', () => {
+    it('returns typed object for valid payload', () => {
+        expect(parseReconnectTokenRefreshedPayload({ reconnectToken: 'rt', reconnectTokenTTLMs: 1_200_000 })).toEqual({
+            reconnectToken: 'rt',
+            reconnectTokenTTLMs: 1_200_000,
+        });
+    });
+
+    it('returns null when reconnectToken is missing', () => {
+        expect(parseReconnectTokenRefreshedPayload({ reconnectTokenTTLMs: 1_200_000 })).toBeNull();
+    });
+
+    it('omits reconnectTokenTTLMs when it has wrong type', () => {
+        expect(parseReconnectTokenRefreshedPayload({ reconnectToken: 'rt', reconnectTokenTTLMs: 'bad' })).toEqual({
+            reconnectToken: 'rt',
+            reconnectTokenTTLMs: undefined,
         });
     });
 });

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -172,7 +172,7 @@ Acknowledges join success and provides room state.
     "turnToken": "T-abc123yz...",
     "turnTokenExpiresAt": 1735174800,
     "reconnectToken": "ab12...c3.1735174800",
-    "reconnectTokenTTLMs": 600000,
+    "reconnectTokenTTLMs": 1200000,
     "epoch": 7,
     "reconnect": "reattached"
   }
@@ -186,7 +186,7 @@ Acknowledges join success and provides room state.
 - `turnToken` *(string, optional)*: temporary token for fetching TURN credentials from `/api/turn-credentials`. Only present on successful join.
 - `turnTokenExpiresAt` *(number, optional)*: unix timestamp (seconds) when the token expires.
 - `reconnectToken` *(string, optional)*: opaque proof bound to `(cid, rid, expiresAt)` that the SDK persists and presents on a future `join` to reattach or recover the same CID. Format is implementation-defined; clients should treat it as opaque.
-- `reconnectTokenTTLMs` *(number, optional)*: how long (ms) the server will accept this reconnect token. SDKs that persist the token across launches should clear it once the window has elapsed.
+- `reconnectTokenTTLMs` *(number, optional)*: how long (ms) the server will accept this reconnect token. Current servers issue 20-minute reconnect tokens. SDKs that persist the token across launches should clear it once the window has elapsed.
 - `epoch` *(number, optional)*: monotonic room state epoch advanced by the server on every membership-mutating operation. SDKs gate ICE restart on receiving an authoritative post-reconnect snapshot rather than acting on a stale in-memory peer map.
 - `reconnect` *(string, optional)*: outcome of this join. Values: `"fresh"` (server created a new participant identity — CID may be new), `"reattached"` (server attached the new transport to a still-present participant slot), `"recovered"` (the previous participant record was gone but the reconnect token still validated, so the server recreated the record with the requested CID). Older servers may omit this field; SDKs should treat absent as `"fresh"`.
 
@@ -194,12 +194,40 @@ Acknowledges join success and provides room state.
 - Store `sid`, `cid`, and `turnToken`.
 - Immediately fetch ICE servers using the `turnToken` via the `token` query param on `/api/turn-credentials`.
 - Persist `reconnectToken` (with `reconnectTokenTTLMs`) so a future join can reattach or recover identity.
+- While connected, refresh `reconnectToken` 10 minutes before expiration by sending `reconnect-token-refresh`. This leaves roughly the server suspend window for reconnect if the transport drops just before the scheduled refresh.
 - For `"reattached"`/`"recovered"` outcomes, keep media-active `RTCPeerConnection`s in place; renegotiate only for pairs the server flags via `negotiation_dirty` (section 4.10) or that the SDK considers stale based on local heuristics.
 - For `"fresh"` outcomes, the SDK may treat the call as ground-up new; an existing `RTCPeerConnection` should still only be torn down if no media has flowed recently.
 - Wait for the authoritative `room_state` snapshot the server emits immediately after `joined` before scheduling renegotiation against this transport's view of the peer set.
 - If another participant is already present, proceed to WebRTC negotiation using the rules in section 5.
 
 The server emits an authoritative `room_state` (section 4.3) immediately after every successful `joined`, even when membership did not change during the outage. SDKs use that broadcast as the reliable post-reconnect sync point.
+
+---
+
+### 4.2.1 `reconnect-token-refresh` (client → server) and `reconnect-token-refreshed` (server → client)
+Active participants refresh reconnect authority before the current token expires. This refresh is independent of TURN refresh; TURN refresh may be skipped when all peer paths are direct.
+
+Client request:
+
+```json
+{ "v": 1, "type": "reconnect-token-refresh", "rid": "AbC123", "cid": "C-a1b2..." }
+```
+
+Server response:
+
+```json
+{
+  "v": 1,
+  "type": "reconnect-token-refreshed",
+  "rid": "AbC123",
+  "payload": {
+    "reconnectToken": "de45...f6.1735175400",
+    "reconnectTokenTTLMs": 1200000
+  }
+}
+```
+
+The server only honors this request from the currently attached transport for the participant CID. SDKs should replace their stored reconnect token, update persisted recovery expiry, and schedule the next refresh 10 minutes before the new expiration.
 
 ---
 
@@ -489,7 +517,7 @@ Standard error message.
 - `NOT_HOST` — non-host attempted `end_room`
 - `SERVER_NOT_CONFIGURED` — room ID secret missing on server
 - `INVALID_ROOM_ID` — room ID failed validation
-- `INVALID_RECONNECT_TOKEN` — supplied `reconnectToken` failed signature/expiry validation. SDKs MUST clear persisted reconnect state and surface a dedicated terminal error (e.g. `sessionExpired`) instead of looping reconnect attempts.
+- `INVALID_RECONNECT_TOKEN` — supplied `reconnectToken` failed signature/expiry validation. SDKs MUST clear persisted reconnect state. If the room is still intended to be joined, SDKs SHOULD automatically retry `join` without `reconnectCid`/`reconnectToken`; otherwise they may surface a dedicated terminal error (e.g. `sessionExpired`). When an expired-but-valid token targets a suspended participant, the server removes that stale record before returning this error so the fresh retry does not create a self-ghost.
 - `ROOM_ENDED` — the room was explicitly ended (host `end_room`) within the server-side tombstone window. Returned to a reconnect attempt that presents valid reconnect authority for a now-gone room. Payload may include `"reason": "ended_by_host"`. SDKs MUST treat this as terminal and clear persisted reconnect state.
 - `INTERNAL` — unexpected server error
 
@@ -759,6 +787,11 @@ For `offer`, `answer`, `ice`:
   transport to the existing record. If the window expires, the server
   removes the participant and broadcasts a final `room_state` so peers tear
   down. The recommended hard-eviction window is at least 10 minutes.
+- If every participant in a room is suspended (no active signaling transports
+  remain), the server may delete the room after a short grace period. Current
+  servers use 10 seconds. This prevents ghost-only rooms from holding
+  occupancy for the full hard-eviction window when nobody is alive to observe
+  media liveness.
 - On explicit `leave` or `end_room`: remove the participant immediately (no
   suspend window).
 - If room becomes empty (including after hard eviction): delete room.

--- a/server/resilience_phase1_test.go
+++ b/server/resilience_phase1_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -76,6 +79,12 @@ func joinWithReconnect(rid, cid, token string) []byte {
 	return b
 }
 
+func legacyReconnectToken(secret, cid, rid string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(cid + "|" + rid))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
 // Reconnect outcomes ----------------------------------------------------------
 
 func TestJoinedPayloadIncludesReconnectOutcomeAndEpochOnFreshJoin(t *testing.T) {
@@ -99,6 +108,52 @@ func TestJoinedPayloadIncludesReconnectOutcomeAndEpochOnFreshJoin(t *testing.T) 
 	}
 	if got.ReconnectTokenTTLMs <= 0 {
 		t.Fatalf("expected positive reconnectTokenTTLMs, got %d", got.ReconnectTokenTTLMs)
+	}
+	if got.ReconnectTokenTTLMs != int64(20*time.Minute/time.Millisecond) {
+		t.Fatalf("expected reconnectTokenTTLMs to match 20m TTL, got %d", got.ReconnectTokenTTLMs)
+	}
+}
+
+func TestReconnectTokenRefreshReturnsNewTokenForActiveParticipant(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	refreshMsg := Message{V: 1, Type: "reconnect-token-refresh", RID: rid}
+	refreshBytes, _ := json.Marshal(refreshMsg)
+	hub.handleMessage(a, refreshBytes)
+
+	var sawRefresh bool
+	for _, msg := range drainMessages(a) {
+		if msg.Type != "reconnect-token-refreshed" {
+			continue
+		}
+		var p struct {
+			ReconnectToken      string `json:"reconnectToken"`
+			ReconnectTokenTTLMs int64  `json:"reconnectTokenTTLMs"`
+		}
+		if err := json.Unmarshal(msg.Payload, &p); err != nil {
+			t.Fatalf("parse refresh payload: %v", err)
+		}
+		if p.ReconnectToken == "" {
+			t.Fatal("expected refreshed reconnect token")
+		}
+		if p.ReconnectTokenTTLMs != int64(20*time.Minute/time.Millisecond) {
+			t.Fatalf("expected 20m refreshed reconnectTokenTTLMs, got %d", p.ReconnectTokenTTLMs)
+		}
+		valid, expired := validateReconnectToken(p.ReconnectToken, first.CID, rid)
+		if !valid || expired {
+			t.Fatalf("expected refreshed token to validate, valid=%t expired=%t", valid, expired)
+		}
+		sawRefresh = true
+	}
+	if !sawRefresh {
+		t.Fatal("expected reconnect-token-refreshed message")
 	}
 }
 
@@ -344,6 +399,14 @@ func TestExpiredReconnectTokenIsRejected(t *testing.T) {
 	hub.handleMessage(a, joinPayload(rid, 4, 4))
 	first := captureJoined(t, a)
 
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	second := captureJoined(t, b)
+	if second.CID == "" {
+		t.Fatal("expected second participant to join")
+	}
+
 	// Issue an artificially-expired token bound to (cid, rid).
 	expired := issueReconnectTokenWithExpiry(first.CID, rid, time.Now().Add(-10*time.Minute))
 	if expired == "" {
@@ -373,6 +436,241 @@ func TestExpiredReconnectTokenIsRejected(t *testing.T) {
 	}
 	if !sawRejection {
 		t.Fatal("expected INVALID_RECONNECT_TOKEN for expired token")
+	}
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if room == nil {
+		t.Fatal("expected room to remain while second participant is active")
+	}
+	room.mu.Lock()
+	if p := room.participantByCID(first.CID); p != nil {
+		room.mu.Unlock()
+		t.Fatal("expected expired-token reconnect to evict stale suspended participant")
+	}
+	room.mu.Unlock()
+
+	hub.handleMessage(a2, joinPayload(rid, 4, 4))
+	rejoined := captureJoined(t, a2)
+	if rejoined.CID == first.CID {
+		t.Fatal("expected fresh rejoin to receive a new CID after expired token")
+	}
+	for _, participant := range rejoined.Participants {
+		if participant.CID == first.CID {
+			t.Fatal("expected fresh rejoin snapshot not to include stale suspended CID")
+		}
+	}
+}
+
+func TestLegacyReconnectTokenIsRejectedAndEvictsSuspendedParticipant(t *testing.T) {
+	const secret = "test-reconnect-secret"
+	t.Setenv("TURN_SECRET", secret)
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	captureJoined(t, b)
+
+	legacy := legacyReconnectToken(secret, first.CID, rid)
+	valid, expired := validateReconnectToken(legacy, first.CID, rid)
+	if valid || !expired {
+		t.Fatalf("expected legacy token to be rejected as expired, valid=%t expired=%t", valid, expired)
+	}
+
+	hub.disconnectClient(a)
+
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, legacy))
+
+	var sawRejection bool
+	for _, msg := range drainMessages(a2) {
+		if msg.Type != "error" {
+			continue
+		}
+		var p struct {
+			Code string `json:"code"`
+		}
+		if err := json.Unmarshal(msg.Payload, &p); err != nil {
+			continue
+		}
+		if p.Code == "INVALID_RECONNECT_TOKEN" {
+			sawRejection = true
+		}
+	}
+	if !sawRejection {
+		t.Fatal("expected INVALID_RECONNECT_TOKEN for legacy token")
+	}
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if room == nil {
+		t.Fatal("expected room to remain while second participant is active")
+	}
+	room.mu.Lock()
+	if p := room.participantByCID(first.CID); p != nil {
+		room.mu.Unlock()
+		t.Fatal("expected legacy-token reconnect to evict stale suspended participant")
+	}
+	room.mu.Unlock()
+}
+
+func TestReconnectTokenRefreshNotInRoomUsesAuthoritativeRoomID(t *testing.T) {
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	c := fakeClient(hub)
+	c.rid = rid
+	c.cid = "stale-cid"
+	hub.registerClient(c)
+
+	hub.handleMessage(c, mustMarshal(Message{V: 1, Type: "reconnect-token-refresh", RID: "client-supplied"}))
+
+	var got *Message
+	for _, msg := range drainMessages(c) {
+		if msg.Type == "error" {
+			got = &msg
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("expected NOT_IN_ROOM error")
+	}
+	if got.RID != rid {
+		t.Fatalf("expected error rid to use authoritative client room %q, got %q", rid, got.RID)
+	}
+	var payload struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(got.Payload, &payload); err != nil {
+		t.Fatalf("parse error payload: %v", err)
+	}
+	if payload.Code != "NOT_IN_ROOM" {
+		t.Fatalf("expected NOT_IN_ROOM, got %q", payload.Code)
+	}
+}
+
+func TestNoActiveRoomCleanupDeletesGhostOnlyRoom(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	captureJoined(t, b)
+
+	hub.disconnectClient(a)
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if room == nil {
+		t.Fatal("expected room to exist after first disconnect")
+	}
+	room.mu.Lock()
+	if room.noActiveTimer != nil {
+		room.mu.Unlock()
+		t.Fatal("did not expect no-active cleanup while another participant is active")
+	}
+	room.mu.Unlock()
+
+	hub.disconnectClient(b)
+	room.mu.Lock()
+	if room.noActiveTimer == nil {
+		room.mu.Unlock()
+		t.Fatal("expected no-active cleanup timer after last active participant disconnects")
+	}
+	if got := len(room.byClient); got != 0 {
+		room.mu.Unlock()
+		t.Fatalf("expected no active participants, got %d", got)
+	}
+	if got := room.participantCount(); got != 2 {
+		room.mu.Unlock()
+		t.Fatalf("expected two suspended participants, got %d", got)
+	}
+	room.mu.Unlock()
+
+	hub.cleanupRoomIfNoActive(room)
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if exists {
+		t.Fatal("expected ghost-only room to be deleted by no-active cleanup")
+	}
+}
+
+func TestNoActiveRoomCleanupCancelledByReconnect(t *testing.T) {
+	t.Setenv("TURN_SECRET", "test-reconnect-secret")
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	first := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	captureJoined(t, b)
+
+	hub.disconnectClient(a)
+	hub.disconnectClient(b)
+
+	hub.mu.RLock()
+	room := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if room == nil {
+		t.Fatal("expected room to exist before no-active cleanup fires")
+	}
+	room.mu.Lock()
+	if room.noActiveTimer == nil {
+		room.mu.Unlock()
+		t.Fatal("expected no-active cleanup timer")
+	}
+	room.mu.Unlock()
+
+	a2 := fakeClient(hub)
+	hub.registerClient(a2)
+	hub.handleMessage(a2, joinWithReconnect(rid, first.CID, first.ReconnectToken))
+	rejoined := captureJoined(t, a2)
+	if rejoined.Reconnect != reconnectOutcomeReattached {
+		t.Fatalf("expected reattached outcome before no-active cleanup, got %q", rejoined.Reconnect)
+	}
+
+	room.mu.Lock()
+	if room.noActiveTimer != nil {
+		room.mu.Unlock()
+		t.Fatal("expected reconnect to cancel no-active cleanup timer")
+	}
+	if got := len(room.byClient); got != 1 {
+		room.mu.Unlock()
+		t.Fatalf("expected one active participant after reconnect, got %d", got)
+	}
+	room.mu.Unlock()
+
+	hub.cleanupRoomIfNoActive(room)
+
+	hub.mu.RLock()
+	_, exists := hub.rooms[rid]
+	hub.mu.RUnlock()
+	if !exists {
+		t.Fatal("expected room to survive stale no-active cleanup after reconnect")
 	}
 }
 

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -35,11 +35,17 @@ const turnTokenTTL = 15 * time.Minute
 // timeout the record is evicted and peers tear down.
 const suspendHardEvictionTimeout = 10 * time.Minute
 
+// noActiveRoomTimeout bounds how long a room can contain only suspended
+// participants. With no attached transports left, there is nobody to observe
+// media liveness, so keeping ghost-only rooms around for the full suspend
+// window just leaves stale occupancy visible to watchers.
+const noActiveRoomTimeout = 10 * time.Second
+
 // reconnectTokenTTL bounds how long a reconnect token can be used to reattach
-// or recover a participant identity. Capped at the same window the server
-// preserves participant records so that a token never outlives the slot it can
-// reclaim.
-const reconnectTokenTTL = suspendHardEvictionTimeout
+// or recover a participant identity. It intentionally exceeds the suspend
+// window: active clients refresh before expiry, leaving roughly one suspend
+// window of validity if the transport drops just before the refresh.
+const reconnectTokenTTL = 20 * time.Minute
 
 // roomTombstoneTTL is the window during which an explicitly-ended room is
 // remembered with a structured reason. Reconnect attempts with a valid
@@ -137,8 +143,16 @@ func validateReconnectToken(token, cid, rid string) (ok bool, expired bool) {
 	}
 	dot := strings.LastIndexByte(token, '.')
 	if dot < 0 {
-		// Pre-expiry-format tokens — clients carrying these need to refresh.
-		return false, true
+		// Legacy tokens were HMAC(cid|rid) without an embedded expiry. Accept
+		// them only as expired-but-authentic so the caller can clear the stale
+		// suspended slot without letting the token reattach indefinitely.
+		mac := hmac.New(sha256.New, secret)
+		mac.Write([]byte(cid + "|" + rid))
+		expected := hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(expected), []byte(token)) {
+			return false, true
+		}
+		return false, false
 	}
 	macHex := token[:dot]
 	expStr := token[dot+1:]
@@ -284,7 +298,10 @@ type Room struct {
 	// observe media flowing from suspended CID X" — the trigger for fast-path
 	// ghost eviction.
 	mediaLivenessReporters map[string]int64
-	mu                     sync.Mutex
+	// noActiveTimer fires when every participant in the room is suspended.
+	// It deletes the room if nobody reattaches within noActiveRoomTimeout.
+	noActiveTimer *time.Timer
+	mu            sync.Mutex
 }
 
 // bumpEpoch increments the room state epoch. Caller must hold r.mu. Returns
@@ -473,6 +490,13 @@ func (r *Room) activeClients() []*Client {
 	return out
 }
 
+func (r *Room) cancelNoActiveTimer() {
+	if r.noActiveTimer != nil {
+		r.noActiveTimer.Stop()
+		r.noActiveTimer = nil
+	}
+}
+
 // attachParticipant inserts a new active participant for (cid, client) and
 // stamps JoinedAt. Called only during a fresh join (not a reconnect).
 func (r *Room) attachParticipant(cid string, client *Client, joinedAtMs int64) *roomParticipant {
@@ -483,6 +507,7 @@ func (r *Room) attachParticipant(cid string, client *Client, joinedAtMs int64) *
 	}
 	r.byCID[cid] = p
 	r.byClient[client] = cid
+	r.cancelNoActiveTimer()
 	return p
 }
 
@@ -497,6 +522,7 @@ func (r *Room) reattachClient(p *roomParticipant, client *Client) {
 		p.hardEvictionTimer = nil
 	}
 	r.byClient[client] = p.CID
+	r.cancelNoActiveTimer()
 }
 
 // detachClient detaches the attached *Client from the participant record
@@ -833,6 +859,8 @@ func (h *Hub) handleMessage(c *Client, msgBytes []byte) {
 		h.handleWatchRooms(c, msg)
 	case "turn-refresh":
 		h.handleTurnRefresh(c, msg)
+	case "reconnect-token-refresh":
+		h.handleReconnectTokenRefresh(c, msg)
 	case "offer", "answer", "ice", "content_state":
 		// log.Printf("[%s] Relay from %s to room %s", msg.Type, c.cid, c.rid) // verbose
 		h.handleRelay(c, msg)
@@ -908,6 +936,9 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 		valid, expired := validateReconnectToken(reconnectToken, reconnectCID, rid)
 		if !valid {
 			log.Printf("[JOIN] Invalid reconnectToken for CID %s from client %s (expired=%t)", reconnectCID, c.sid, expired)
+			if expired {
+				h.evictSuspendedParticipantForExpiredReconnect(rid, reconnectCID)
+			}
 			c.sendError(rid, "INVALID_RECONNECT_TOKEN", "Reconnect token validation failed")
 			return
 		}
@@ -1027,6 +1058,7 @@ func (h *Hub) handleJoin(c *Client, msg Message) {
 				p.hardEvictionTimer = time.AfterFunc(suspendHardEvictionTimeout, func() {
 					h.hardEvictSuspended(room, reconnectCID)
 				})
+				h.armNoActiveRoomTimerLocked(room)
 			}
 			// Do not clear c.cid / c.rid: other goroutines read them without
 			// synchronization. The room indexes (byCID / byClient) are the
@@ -1253,6 +1285,91 @@ func (h *Hub) handleTurnRefresh(c *Client, msg Message) {
 	log.Printf("[TURN-REFRESH] Refreshed TURN credentials for client %s (CID: %s) in room %s", c.sid, c.cid, c.rid)
 }
 
+func (h *Hub) handleReconnectTokenRefresh(c *Client, msg Message) {
+	if !h.isActiveParticipant(c) {
+		rid := c.rid
+		if rid == "" {
+			rid = msg.RID
+		}
+		c.sendError(rid, "NOT_IN_ROOM", "Must be in a room to refresh reconnect token")
+		return
+	}
+
+	token := issueReconnectToken(c.cid, c.rid)
+	if token == "" {
+		log.Printf("[RECONNECT-TOKEN-REFRESH] Failed to issue reconnect token for client %s (CID: %s)", c.sid, c.cid)
+		c.sendError(msg.RID, "RECONNECT_TOKEN_REFRESH_FAILED", "Failed to refresh reconnect token")
+		return
+	}
+
+	payload := map[string]interface{}{
+		"reconnectToken":      token,
+		"reconnectTokenTTLMs": int64(reconnectTokenTTL / time.Millisecond),
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	c.sendMessage(Message{
+		V:       1,
+		Type:    "reconnect-token-refreshed",
+		RID:     c.rid,
+		Payload: payloadBytes,
+	})
+	log.Printf("[RECONNECT-TOKEN-REFRESH] Refreshed reconnect token for client %s (CID: %s) in room %s", c.sid, c.cid, c.rid)
+}
+
+// armNoActiveRoomTimerLocked starts the room-level cleanup timer once the last
+// active transport has dropped. Caller must hold room.mu.
+func (h *Hub) armNoActiveRoomTimerLocked(room *Room) {
+	if len(room.byClient) > 0 || len(room.byCID) == 0 || room.noActiveTimer != nil {
+		return
+	}
+	rid := room.RID
+	room.noActiveTimer = time.AfterFunc(noActiveRoomTimeout, func() {
+		h.cleanupRoomIfNoActive(room)
+	})
+	log.Printf("[ROOM_CLEANUP] Room %s has no active participants; deleting in %s if nobody reconnects", rid, noActiveRoomTimeout)
+}
+
+func (h *Hub) cleanupRoomIfNoActive(room *Room) {
+	rid := room.RID
+
+	h.mu.Lock()
+	if h.rooms[rid] != room {
+		h.mu.Unlock()
+		return
+	}
+
+	room.mu.Lock()
+	if len(room.byClient) > 0 {
+		room.noActiveTimer = nil
+		room.mu.Unlock()
+		h.mu.Unlock()
+		return
+	}
+
+	suspendedCount := len(room.byCID)
+	for _, p := range room.byCID {
+		if p.hardEvictionTimer != nil {
+			p.hardEvictionTimer.Stop()
+			p.hardEvictionTimer = nil
+		}
+	}
+	room.cancelNoActiveTimer()
+	delete(h.rooms, rid)
+
+	room.byCID = make(map[string]*roomParticipant)
+	room.byClient = make(map[*Client]string)
+	room.HostCID = ""
+	room.negotiationDirty = nil
+	room.mediaLiveness = nil
+	room.mediaLivenessReporters = nil
+	room.mu.Unlock()
+	h.mu.Unlock()
+
+	log.Printf("[ROOM_CLEANUP] Deleted room %s after %s with no active participants (suspended=%d)", rid, noActiveRoomTimeout, suspendedCount)
+	h.broadcastRoomStatusUpdate(rid)
+}
+
 // isActiveParticipant returns true iff c is the transport currently attached
 // to a participant in c.rid. Protects handlers against stale c.rid / c.cid
 // fields left behind on a rejected reconnect socket — those fields are kept
@@ -1320,6 +1437,7 @@ func (h *Hub) handleEndRoom(c *Client, msg Message) {
 			p.hardEvictionTimer = nil
 		}
 	}
+	room.cancelNoActiveTimer()
 	room.bumpEpoch()
 
 	room.mu.Unlock() // Unlock before sending
@@ -1698,6 +1816,9 @@ func (h *Hub) suspendClientInRoom(c *Client) {
 	})
 
 	activeCount := len(room.byClient)
+	if activeCount == 0 {
+		h.armNoActiveRoomTimerLocked(room)
+	}
 	room.mu.Unlock()
 
 	// Do not clear c.cid / c.rid: other goroutines read them without
@@ -1759,12 +1880,63 @@ func (h *Hub) hardEvictSuspended(room *Room, cid string) {
 	room.bumpEpoch()
 
 	isEmpty := room.participantCount() == 0
+	if !isEmpty && len(room.byClient) == 0 {
+		h.armNoActiveRoomTimerLocked(room)
+	}
 	room.mu.Unlock()
 
 	if isEmpty {
 		log.Printf("[HARD_EVICT] Room %s is now empty. Deleting room.", rid)
 		h.mu.Lock()
 		delete(h.rooms, rid)
+		h.mu.Unlock()
+	} else {
+		h.broadcastRoomState(room)
+	}
+	h.broadcastRoomStatusUpdate(rid)
+}
+
+// evictSuspendedParticipantForExpiredReconnect removes a suspended record
+// when a reconnect attempt proves it belongs to the same CID/RID but its
+// token has aged out. The caller has already validated the token signature;
+// do not call this for malformed or unsigned tokens.
+func (h *Hub) evictSuspendedParticipantForExpiredReconnect(rid, cid string) {
+	if rid == "" || cid == "" {
+		return
+	}
+
+	h.mu.RLock()
+	room, exists := h.rooms[rid]
+	h.mu.RUnlock()
+	if !exists {
+		return
+	}
+
+	room.mu.Lock()
+	p := room.participantByCID(cid)
+	if p == nil || p.Client != nil {
+		room.mu.Unlock()
+		return
+	}
+
+	log.Printf("[RECONNECT] Evicting suspended CID %s in room %s after expired reconnect token", cid, rid)
+	room.removeParticipant(cid)
+	room.dropCIDFromDirty(cid)
+	room.dropMediaLivenessFor(cid)
+	room.transferHostIfNeeded(cid)
+	room.bumpEpoch()
+
+	isEmpty := room.participantCount() == 0
+	if !isEmpty && len(room.byClient) == 0 {
+		h.armNoActiveRoomTimerLocked(room)
+	}
+	room.mu.Unlock()
+
+	if isEmpty {
+		h.mu.Lock()
+		if h.rooms[rid] == room {
+			delete(h.rooms, rid)
+		}
 		h.mu.Unlock()
 	} else {
 		h.broadcastRoomState(room)
@@ -1811,6 +1983,9 @@ func (h *Hub) removeClientFromRoom(c *Client) {
 	room.transferHostIfNeeded(cid)
 
 	isEmpty := room.participantCount() == 0
+	if !isEmpty && len(room.byClient) == 0 {
+		h.armNoActiveRoomTimerLocked(room)
+	}
 	room.mu.Unlock()
 
 	if isEmpty {
@@ -1856,6 +2031,9 @@ func (h *Hub) evictByLeave(rid, cid string) {
 	room.transferHostIfNeeded(cid)
 	room.bumpEpoch()
 	isEmpty := room.participantCount() == 0
+	if !isEmpty && len(room.byClient) == 0 {
+		h.armNoActiveRoomTimerLocked(room)
+	}
 	room.mu.Unlock()
 
 	if attachedClient != nil {


### PR DESCRIPTION
## Summary

Fixes the reconnect-token expiry path that could surface `Session expired` after an active call had been running longer than the original token window and then briefly lost transport connectivity. Also cleans up rooms that contain only suspended participants so ghost-only rooms do not remain visible or hold capacity for the full suspend window.

## Root cause

Reconnect tokens were expiring after the same 10-minute window used for suspended participant hard eviction, and clients never refreshed them while still connected. After roughly 11 minutes, a transport drop could send an expired reconnect token, receive `INVALID_RECONNECT_TOKEN`, clear reconnect state, and surface a terminal session-expired error instead of recovering. A fresh manual rejoin could then coexist with the previous suspended CID long enough to appear as a ghost participant.

Separately, when every live transport dropped from a room, the server suspended each participant independently and kept those records until the 10-minute hard-eviction timers fired. With no active participants left, nobody can report media liveness, so the room is just a ghost-only occupancy record.

## Changes

- Server reconnect tokens are now valid for 20 minutes.
- Added `reconnect-token-refresh` / `reconnect-token-refreshed` signaling so active clients can refresh authority before expiry.
- Web, Android, and iOS schedule refresh 10 minutes before token expiry and persist refreshed recovery expiry.
- Web, Android, and iOS automatically retry a fresh join after `INVALID_RECONNECT_TOKEN` rather than surfacing the terminal error while the call is still intended to be joined.
- Server removes the stale suspended participant when an expired-but-valid token proves the same CID/RID, preventing the fresh retry from leaving a self-ghost.
- Server deletes rooms that have no active participants for 10 seconds, and cancels that cleanup if anyone reconnects first.
- Updated protocol docs and added cross-platform tests.

## Validation

- `tools/worktree-bootstrap.sh .`
- `node scripts/check-resilience-constants.mjs`
- `go test ./...` in `server/`
- `go test -race ./...` in `server/`
- Web targeted signaling tests for `SignalingEngine` and payload parsing
- `npm run build` in `client/`
- Android targeted `:serenada-core:testDebugUnitTest` cases for provider refresh, invalid-token retry, and payload parsing
- iOS `SerenadaCore` source build

Note: iOS package tests were added but not runnable in this local generated scheme/SwiftPM setup: the scheme does not include `SerenadaCoreTests`, and direct SwiftPM test execution targets macOS where the package imports UIKit.
