### PR TITLE
v0.7.0: Frontline call UI, pluggable audio coordinators, WebRTC M149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.7.0] — 2026-05-18
+
+Milestone release: a dedicated Frontline call UI, pluggable audio
+coordinators, and the WebRTC engine upgraded to M149. Minor bump per
+the pre-1.0 policy because the WebRTC upgrade and the new audio
+extension point change behavior existing consumers may depend on.
+
+### Added
+- Android, iOS: **Frontline call UI variant** — an opt-in, glanceable
+  call experience tuned for frontline workers (larger touch targets,
+  simplified more-menu, multiparty local-tile layout fixes). Off by
+  default; existing call UIs are unchanged.
+- Android, iOS: **pluggable audio coordinators**. Host apps can supply
+  their own audio-session coordinator to integrate Serenada calls with
+  app-specific audio routing, ducking, and interruption handling. A
+  default coordinator preserves today's behavior when none is
+  supplied.
+- React UI: `SerenadaCallFlowConfig.videoEnabled` lets host apps start
+  a call with video off without reaching into the session directly.
+
+### Changed
+- Web, Android, iOS: **bundled WebRTC upgraded to M149**
+  (`libwebrtc-7827`). Picks up upstream stability and codec fixes.
+  Android consumers pulling the WebRTC AAR should update the
+  coordinate to `app.serenada:libwebrtc-7827-universal:0.7.0`.
+
+### Fixed
+- SDK: reconnect-token refresh no longer drops the token across a
+  reconnect cycle, so SSE session takeover stays authorized.
+- Server: SSE session takeover is now gated on reconnect-token
+  verification, and snapshot cleanup was optimized.
+- Protocol: `room_ended` broadcast payload now sends the `reason`
+  field matching the v1 spec (was mismatched).
+- Android: peer teardown is guarded against native WebRTC crashes
+  during slot cleanup.
+- React UI: the snapshot button is hidden when the source video is
+  off, so there's no shutter on a black frame.
+- iOS: DocC builds again on Xcode 16; Android Dokka docs generation
+  fixed.
+
 ## [0.6.13] — 2026-05-16
 
 Android build toolchain refresh.

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.6.13`
-- `app.serenada:core:0.6.13`
-- `app.serenada:call-ui:0.6.13`
+- `app.serenada:libwebrtc-7827-universal:0.7.0`
+- `app.serenada:core:0.7.0`
+- `app.serenada:call-ui:0.7.0`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.6.13"
+                version = "0.7.0"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.13"
+val sdkVersion = "0.7.0"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.6.13"
+val sdkVersion = "0.7.0"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -39,7 +39,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.6.13"
+    public static let version = "0.7.0"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.6.13",
-        "@agatx/serenada-react-ui": "0.6.13",
+        "@agatx/serenada-core": "0.7.0",
+        "@agatx/serenada-react-ui": "0.7.0",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.6.13"
+        "@agatx/serenada-core": "0.7.0"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.6.13",
+        "@agatx/serenada-core": "^0.7.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.13",
+  "version": "0.7.0",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.6.13",
-    "@agatx/serenada-react-ui": "0.6.13",
+    "@agatx/serenada-core": "0.7.0",
+    "@agatx/serenada-react-ui": "0.7.0",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.6.13';
+export const SERENADA_CORE_VERSION = '0.7.0';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.6.13",
+    "@agatx/serenada-core": "^0.7.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.6.13"
+    "@agatx/serenada-core": "0.7.0"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.6.13")
-    implementation("app.serenada:call-ui:0.6.13")
+    implementation("app.serenada:core:0.7.0")
+    implementation("app.serenada:call-ui:0.7.0")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.6.13 @agatx/serenada-react-ui@0.6.13 lucide-react
+npm install @agatx/serenada-core@0.7.0 @agatx/serenada-react-ui@0.7.0 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.6.13"
+        "@agatx/serenada-core": "0.7.0"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.6.13",
+        "@agatx/serenada-core": "^0.7.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Minor-bump milestone release (0.6.13 → **0.7.0**) rolling up everything that landed since the 0.6.13 Android-toolchain bump. Minor bump per the pre-1.0 policy because the WebRTC engine upgrade and the new audio extension point change behavior existing consumers may depend on.

This PR is **version-bump + docs only** — the features themselves already merged to main via #105–#112.

### What 0.7.0 captures (since 0.6.13)

**Added**
- **Frontline call UI variant** (Android #105, iOS #107; multiparty fix #108, menu polish #111) — opt-in, glanceable call UI for frontline workers. Off by default; existing call UIs unchanged.
- **Pluggable audio coordinators** (Android + iOS #109) — host apps can inject their own audio-session coordinator for app-specific routing/ducking/interruption handling. Default coordinator preserves current behavior.
- React UI: `SerenadaCallFlowConfig.videoEnabled` (#102) to start a call video-off without touching the session.

**Changed**
- **Bundled WebRTC upgraded to M149** (`libwebrtc-7827`). Android AAR consumers should move to `app.serenada:libwebrtc-7827-universal:0.7.0`.

**Fixed**
- Reconnect-token refresh no longer drops the token across reconnect (#112)
- Server: SSE session takeover gated on reconnect-token verification + snapshot cleanup optimized
- Protocol: `room_ended` payload sends spec-correct `reason`
- Android: peer teardown guarded against native WebRTC crashes (#106)
- React UI: snapshot button hidden when source video is off
- iOS DocC build on Xcode 16; Android Dokka generation

### Version bump scope (14 files)

- 8 SDK sources tracked by `check-version-parity.mjs` → `OK: All 8 version sources match at 0.7.0.`
- `client/package.json` + `client/package-lock.json` (root + workspace entries)
- `samples/web/package-lock.json`
- `docs/sdk/sdk-integration-{web,android}.md` install snippets
- `client-android/README.md` Maven coordinates (core, call-ui, libwebrtc-7827-universal)
- `CHANGELOG.md`

Samples use local `file:`/project/path references, so only the recorded SDK version in `samples/web/package-lock.json` changes; sample app versions (web 0.0.0, android 0.1.0, iOS 0.1.0) are intentionally left on their own cadence.

### Tests (run on this branch)

| Platform | Tests | Result |
|---|---|---|
| Web (Vitest) | 374 / 374 | ✅ |
| Android (`serenada-core`, `--rerun-tasks`) | 288 / 288 | ✅ BUILD SUCCESSFUL |
| iOS (`SerenadaiOSTests` + UI, iPhone 16 sim) | 331 unit + 2 UI (2 UI skipped per env flag) | ✅ TEST SUCCEEDED |

**Total: 995 passing, 0 failures.** (`serenada-call-ui` has no unit tests — NO-SOURCE.)

## After merge

Tag `web-release-0.7.0` at the merge commit to publish both packages to npm via OIDC Trusted Publishing (Node 24 / npm 11 / `--provenance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)