### PR TITLE
Polish Frontline call UX

### DIFF
--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -1878,14 +1878,14 @@ private fun MultiPartyStage(
     }
 }
 
-private data class FitCoverGeometry(
+internal data class FitCoverGeometry(
     val fitWidth: androidx.compose.ui.unit.Dp,
     val fitHeight: androidx.compose.ui.unit.Dp,
     val coverScale: Float,
 )
 
 @Composable
-private fun computeFitCoverGeometry(
+internal fun computeFitCoverGeometry(
     tileWidth: androidx.compose.ui.unit.Dp,
     tileHeight: androidx.compose.ui.unit.Dp,
     videoAspectRatio: Float,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FlashlightOff
 import androidx.compose.material.icons.filled.FlashlightOn
 import androidx.compose.material.icons.filled.FlipCameraIos
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.MoreVert
@@ -61,6 +63,7 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.VideocamOff
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -168,6 +171,8 @@ internal fun FrontlineCallScreen(
     detachRemoteSinkForCid: (String, VideoSink) -> Unit,
     attachRemoteSink: (VideoSink) -> Unit,
     detachRemoteSink: (VideoSink) -> Unit,
+    initialRemoteVideoFitCover: Boolean = true,
+    onRemoteVideoFitChanged: ((Boolean) -> Unit)? = null,
     onSnapshotRequested: ((SnapshotSource) -> Unit)?,
 ) {
     val activity = LocalContext.current as? Activity
@@ -196,6 +201,7 @@ internal fun FrontlineCallScreen(
     var showSnapshotFlash by remember { mutableStateOf(false) }
     var showDebug by rememberSaveable { mutableStateOf(false) }
     var debugTapTimestampMs by remember { mutableStateOf(0L) }
+    var remoteVideoFitCover by rememberSaveable { mutableStateOf(initialRemoteVideoFitCover) }
     var localAspectRatio by remember { mutableStateOf<Float?>(null) }
     val remoteTileAspectRatios = remember { mutableStateMapOf<String, Float>() }
     var pinnedSpotlightId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -223,6 +229,12 @@ internal fun FrontlineCallScreen(
         uiState.phase == CallPhase.InCall || uiState.phase == CallPhase.Waiting
     val remote = uiState.remoteParticipants.firstOrNull()
     val remoteVideoEnabled = remote?.videoEnabled == true
+    val toggleRemoteVideoFit = {
+        val next = !remoteVideoFitCover
+        remoteVideoFitCover = next
+        onRemoteVideoFitChanged?.invoke(next)
+        Unit
+    }
     LaunchedEffect(uiState.localVideoEnabled, remote?.cid, localContentMode) {
         pipSwapped = false
     }
@@ -439,6 +451,8 @@ internal fun FrontlineCallScreen(
                             pinnedSpotlightId = pinnedSpotlightId,
                             selectedSpotlightId = selectedSpotlightId,
                             lastVideoStartedParticipantId = lastVideoStartedParticipantId,
+                            remoteVideoFitCover = remoteVideoFitCover,
+                            onToggleRemoteVideoFit = toggleRemoteVideoFit,
                             onPinnedSpotlightIdChanged = { pinnedSpotlightId = it },
                             onSelectedSpotlightIdChanged = { selectedSpotlightId = it },
                             localZoomTransformState = localZoomTransformState,
@@ -502,6 +516,8 @@ internal fun FrontlineCallScreen(
                             pinnedSpotlightId = pinnedSpotlightId,
                             selectedSpotlightId = selectedSpotlightId,
                             lastVideoStartedParticipantId = lastVideoStartedParticipantId,
+                            remoteVideoFitCover = remoteVideoFitCover,
+                            onToggleRemoteVideoFit = toggleRemoteVideoFit,
                             onPinnedSpotlightIdChanged = { pinnedSpotlightId = it },
                             onSelectedSpotlightIdChanged = { selectedSpotlightId = it },
                             localZoomTransformState = localZoomTransformState,
@@ -700,6 +716,8 @@ private fun FrontlineContentArea(
     pinnedSpotlightId: String?,
     selectedSpotlightId: String?,
     lastVideoStartedParticipantId: String?,
+    remoteVideoFitCover: Boolean,
+    onToggleRemoteVideoFit: () -> Unit,
     onPinnedSpotlightIdChanged: (String?) -> Unit,
     onSelectedSpotlightIdChanged: (String?) -> Unit,
     localZoomTransformState: androidx.compose.foundation.gestures.TransformableState,
@@ -752,6 +770,8 @@ private fun FrontlineContentArea(
                     pinnedSpotlightId = pinnedSpotlightId,
                     selectedSpotlightId = selectedSpotlightId,
                     lastVideoStartedParticipantId = lastVideoStartedParticipantId,
+                    remoteVideoFitCover = remoteVideoFitCover,
+                    onToggleRemoteVideoFit = onToggleRemoteVideoFit,
                     onPinnedSpotlightIdChanged = onPinnedSpotlightIdChanged,
                     onSelectedSpotlightIdChanged = onSelectedSpotlightIdChanged,
                     localZoomTransformState = localZoomTransformState,
@@ -773,6 +793,7 @@ private fun FrontlineContentArea(
                     eglContext = eglContext,
                     localRendererEvents = localRendererEvents,
                     remoteRendererEvents = remoteRendererEvents,
+                    remoteVideoFitCover = remoteVideoFitCover,
                     localZoomTransformState = localZoomTransformState,
                     attachLocalRenderer = attachLocalRenderer,
                     detachLocalRenderer = detachLocalRenderer,
@@ -816,6 +837,25 @@ private fun FrontlineContentArea(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .padding(start = 16.dp, bottom = 16.dp),
+            )
+        }
+
+        if (
+            frontlineShowsRemoteFitButton(
+                isCallSurfacePhase = isCallSurfacePhase,
+                waitingForRemote = waitingForRemote,
+                remoteParticipantCount = uiState.remoteParticipants.size,
+                largeFeedIsRemote = largeFeed == FrontlineFeed.Remote,
+                remoteVideoEnabled = remote?.videoEnabled == true,
+            )
+        ) {
+            FrontlineRemoteFitButton(
+                remoteVideoFitCover = remoteVideoFitCover,
+                strings = strings,
+                onClick = onToggleRemoteVideoFit,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 16.dp, bottom = 16.dp),
             )
         }
 
@@ -881,6 +921,8 @@ private fun FrontlineMultiPartyStage(
     pinnedSpotlightId: String?,
     selectedSpotlightId: String?,
     lastVideoStartedParticipantId: String?,
+    remoteVideoFitCover: Boolean,
+    onToggleRemoteVideoFit: () -> Unit,
     onPinnedSpotlightIdChanged: (String?) -> Unit,
     onSelectedSpotlightIdChanged: (String?) -> Unit,
     localZoomTransformState: androidx.compose.foundation.gestures.TransformableState,
@@ -933,6 +975,9 @@ private fun FrontlineMultiPartyStage(
         contentSource != null &&
             activeContentSpotlightId != null &&
             effectiveSpotlightId == activeContentSpotlightId
+    val spotlightIsRemote =
+        uiState.remoteParticipants.any { it.cid == effectiveSpotlightId } ||
+            (spotlightIsContent && contentSource.ownerParticipantId != localId)
 
     BoxWithConstraints(modifier = modifier) {
         val viewportWidthPx = with(density) { maxWidth.toPx() }
@@ -948,7 +993,9 @@ private fun FrontlineMultiPartyStage(
             activeContentSpotlightId,
             effectiveSpotlightId,
             spotlightIsContent,
+            spotlightIsRemote,
             contentSource,
+            remoteVideoFitCover,
         ) {
             val baseParticipants =
                 uiState.remoteParticipants.map { participant ->
@@ -998,7 +1045,13 @@ private fun FrontlineMultiPartyStage(
                     activeSpeakerId = null,
                     pinnedParticipantId = if (spotlightIsContent) null else effectiveSpotlightId,
                     contentSource = if (spotlightIsContent) contentSource else null,
-                    userPrefs = UserLayoutPrefs(dominantFit = FitMode.COVER),
+                    userPrefs = UserLayoutPrefs(
+                        dominantFit = if (spotlightIsRemote && !remoteVideoFitCover) {
+                            FitMode.CONTAIN
+                        } else {
+                            FitMode.COVER
+                        },
+                    ),
                 )
             )
         }
@@ -1024,6 +1077,11 @@ private fun FrontlineMultiPartyStage(
                     } else {
                         null
                     }
+                    val showRemoteFitButton =
+                        tile.zOrder == 0 &&
+                            remote != null &&
+                            !isLocal &&
+                            (!isContentTile || contentOwnerCid != localId)
                     val tileWidth = with(density) { tile.frame.width.toDp() }
                     val tileHeight = with(density) { tile.frame.height.toDp() }
                     val tileX = with(density) { tile.frame.x.toDp() }
@@ -1054,6 +1112,9 @@ private fun FrontlineMultiPartyStage(
                         contentScale = if (tile.fit == FitMode.CONTAIN) ContentScale.Fit else ContentScale.Crop,
                         cornerRadius = tileCornerRadius,
                         pinned = tileSpotlightId == pinnedSpotlightId,
+                        showRemoteFitButton = showRemoteFitButton,
+                        remoteVideoFitCover = remoteVideoFitCover,
+                        onToggleRemoteVideoFit = onToggleRemoteVideoFit,
                         onSelect = { onSelectedSpotlightIdChanged(tileSpotlightId) },
                         onTogglePinned = {
                             onPinnedSpotlightIdChanged(
@@ -1095,6 +1156,9 @@ private fun FrontlineMultiPartyStage(
                         contentScale = if (pip.fit == FitMode.CONTAIN) ContentScale.Fit else ContentScale.Crop,
                         cornerRadius = pipCornerRadius,
                         pinned = false,
+                        showRemoteFitButton = false,
+                        remoteVideoFitCover = remoteVideoFitCover,
+                        onToggleRemoteVideoFit = onToggleRemoteVideoFit,
                         onSelect = { onSelectedSpotlightIdChanged(pip.participantId) },
                         onTogglePinned = {
                             onPinnedSpotlightIdChanged(
@@ -1134,6 +1198,9 @@ private fun FrontlineLayoutTile(
     contentScale: ContentScale,
     cornerRadius: Dp,
     pinned: Boolean,
+    showRemoteFitButton: Boolean,
+    remoteVideoFitCover: Boolean,
+    onToggleRemoteVideoFit: () -> Unit,
     onSelect: () -> Unit,
     onTogglePinned: () -> Unit,
     strings: Map<SerenadaString, String>?,
@@ -1241,6 +1308,17 @@ private fun FrontlineLayoutTile(
             )
         }
 
+        if (showRemoteFitButton) {
+            FrontlineRemoteFitButton(
+                remoteVideoFitCover = remoteVideoFitCover,
+                strings = strings,
+                onClick = onToggleRemoteVideoFit,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp),
+            )
+        }
+
         if (showLocalVideoAccent) {
             Box(
                 modifier = Modifier
@@ -1286,6 +1364,7 @@ private fun FrontlineLargeSurface(
     eglContext: EglBase.Context,
     localRendererEvents: RendererCommon.RendererEvents,
     remoteRendererEvents: RendererCommon.RendererEvents,
+    remoteVideoFitCover: Boolean,
     localZoomTransformState: androidx.compose.foundation.gestures.TransformableState,
     attachLocalRenderer: (SurfaceViewRenderer, RendererCommon.RendererEvents?) -> Unit,
     detachLocalRenderer: (SurfaceViewRenderer) -> Unit,
@@ -1322,7 +1401,7 @@ private fun FrontlineLargeSurface(
                 onAttach = { renderer -> attachRemoteRenderer(renderer, remoteRendererEvents) },
                 onDetach = detachRemoteRenderer,
                 mirror = false,
-                contentScale = ContentScale.Crop,
+                contentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
                 isMediaOverlay = false,
             )
         }
@@ -2087,6 +2166,27 @@ private fun FrontlineSheetItem(
 }
 
 @Composable
+private fun FrontlineRemoteFitButton(
+    remoteVideoFitCover: Boolean,
+    strings: Map<SerenadaString, String>?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(44.dp)
+            .background(Color.Black.copy(alpha = 0.4f), CircleShape),
+    ) {
+        Icon(
+            imageVector = if (remoteVideoFitCover) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+            contentDescription = resolveString(SerenadaString.CallToggleVideoFit, strings),
+            tint = Color.White,
+        )
+    }
+}
+
+@Composable
 private fun FrontlineNameChip(
     label: String,
     muted: Boolean,
@@ -2235,6 +2335,19 @@ private fun frontlineMoreMenuOpensAudioRouteDirectly(
     screenSharingEnabled: Boolean,
     inviteEnabled: Boolean,
 ): Boolean = showAudioRouteControl && !screenSharingEnabled && !inviteEnabled
+
+private fun frontlineShowsRemoteFitButton(
+    isCallSurfacePhase: Boolean,
+    waitingForRemote: Boolean,
+    remoteParticipantCount: Int,
+    largeFeedIsRemote: Boolean,
+    remoteVideoEnabled: Boolean,
+): Boolean =
+    isCallSurfacePhase &&
+        !waitingForRemote &&
+        remoteParticipantCount <= 1 &&
+        largeFeedIsRemote &&
+        remoteVideoEnabled
 
 private data class FrontlinePipSize(val width: Dp, val height: Dp)
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -10,6 +10,8 @@ import android.view.WindowManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -75,6 +77,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -84,6 +87,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -165,8 +169,6 @@ internal fun FrontlineCallScreen(
     detachLocalRenderer: (SurfaceViewRenderer) -> Unit,
     attachLocalSink: (VideoSink) -> Unit,
     detachLocalSink: (VideoSink) -> Unit,
-    attachRemoteRenderer: (SurfaceViewRenderer, RendererCommon.RendererEvents?) -> Unit,
-    detachRemoteRenderer: (SurfaceViewRenderer) -> Unit,
     attachRemoteSinkForCid: (String, VideoSink) -> Unit,
     detachRemoteSinkForCid: (String, VideoSink) -> Unit,
     attachRemoteSink: (VideoSink) -> Unit,
@@ -242,9 +244,6 @@ internal fun FrontlineCallScreen(
     val mainHandler = remember { Handler(Looper.getMainLooper()) }
     val localRendererEvents = remember {
         aspectRatioRendererEvents(mainHandler) { ratio -> localAspectRatio = ratio }
-    }
-    val remoteRendererEvents = remember {
-        aspectRatioRendererEvents(mainHandler) {}
     }
     val localZoomTransformState = rememberTransformableState { zoomChange, _, _ ->
         if (zoomChange > 0f && abs(zoomChange - 1f) > FRONTLINE_ZOOM_CHANGE_THRESHOLD) {
@@ -444,7 +443,6 @@ internal fun FrontlineCallScreen(
                             isCallSurfacePhase = isCallSurfacePhase,
                             eglContext = eglContext,
                             localRendererEvents = localRendererEvents,
-                            remoteRendererEvents = remoteRendererEvents,
                             localAspectRatio = localAspectRatio ?: 0f,
                             remoteAspectRatios = remoteTileAspectRatios,
                             activeContentSpotlightId = activeContentSpotlightId,
@@ -460,8 +458,8 @@ internal fun FrontlineCallScreen(
                             detachLocalRenderer = detachLocalRenderer,
                             attachLocalSink = attachLocalSink,
                             detachLocalSink = detachLocalSink,
-                            attachRemoteRenderer = attachRemoteRenderer,
-                            detachRemoteRenderer = detachRemoteRenderer,
+                            attachRemoteSink = attachRemoteSink,
+                            detachRemoteSink = detachRemoteSink,
                             attachRemoteSinkForCid = attachRemoteSinkForCid,
                             detachRemoteSinkForCid = detachRemoteSinkForCid,
                             pip = pip,
@@ -509,7 +507,6 @@ internal fun FrontlineCallScreen(
                             isCallSurfacePhase = isCallSurfacePhase,
                             eglContext = eglContext,
                             localRendererEvents = localRendererEvents,
-                            remoteRendererEvents = remoteRendererEvents,
                             localAspectRatio = localAspectRatio ?: 0f,
                             remoteAspectRatios = remoteTileAspectRatios,
                             activeContentSpotlightId = activeContentSpotlightId,
@@ -525,8 +522,8 @@ internal fun FrontlineCallScreen(
                             detachLocalRenderer = detachLocalRenderer,
                             attachLocalSink = attachLocalSink,
                             detachLocalSink = detachLocalSink,
-                            attachRemoteRenderer = attachRemoteRenderer,
-                            detachRemoteRenderer = detachRemoteRenderer,
+                            attachRemoteSink = attachRemoteSink,
+                            detachRemoteSink = detachRemoteSink,
                             attachRemoteSinkForCid = attachRemoteSinkForCid,
                             detachRemoteSinkForCid = detachRemoteSinkForCid,
                             pip = pip,
@@ -709,7 +706,6 @@ private fun FrontlineContentArea(
     isCallSurfacePhase: Boolean,
     eglContext: EglBase.Context,
     localRendererEvents: RendererCommon.RendererEvents,
-    remoteRendererEvents: RendererCommon.RendererEvents,
     localAspectRatio: Float,
     remoteAspectRatios: MutableMap<String, Float>,
     activeContentSpotlightId: String?,
@@ -725,8 +721,8 @@ private fun FrontlineContentArea(
     detachLocalRenderer: (SurfaceViewRenderer) -> Unit,
     attachLocalSink: (VideoSink) -> Unit,
     detachLocalSink: (VideoSink) -> Unit,
-    attachRemoteRenderer: (SurfaceViewRenderer, RendererCommon.RendererEvents?) -> Unit,
-    detachRemoteRenderer: (SurfaceViewRenderer) -> Unit,
+    attachRemoteSink: (VideoSink) -> Unit,
+    detachRemoteSink: (VideoSink) -> Unit,
     attachRemoteSinkForCid: (String, VideoSink) -> Unit,
     detachRemoteSinkForCid: (String, VideoSink) -> Unit,
     pip: @Composable (Modifier) -> Unit,
@@ -792,13 +788,12 @@ private fun FrontlineContentArea(
                     localContentMode = localContentMode,
                     eglContext = eglContext,
                     localRendererEvents = localRendererEvents,
-                    remoteRendererEvents = remoteRendererEvents,
                     remoteVideoFitCover = remoteVideoFitCover,
                     localZoomTransformState = localZoomTransformState,
                     attachLocalRenderer = attachLocalRenderer,
                     detachLocalRenderer = detachLocalRenderer,
-                    attachRemoteRenderer = attachRemoteRenderer,
-                    detachRemoteRenderer = detachRemoteRenderer,
+                    attachRemoteSink = attachRemoteSink,
+                    detachRemoteSink = detachRemoteSink,
                     strings = strings,
                     modifier = Modifier.fillMaxSize(),
                 )
@@ -935,7 +930,6 @@ private fun FrontlineMultiPartyStage(
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
-    val mainHandler = remember { Handler(Looper.getMainLooper()) }
     val localId = uiState.localCid ?: "local"
     val hasLocalContent = localContentMode
     val activeContentOwnerId = activeContentSpotlightId?.removePrefix(FRONTLINE_CONTENT_SPOTLIGHT_PREFIX)
@@ -1098,11 +1092,9 @@ private fun FrontlineMultiPartyStage(
                         localContentMode = localContentMode,
                         localZoomTransformState = localZoomTransformState,
                         localRendererEvents = localRendererEvents,
-                        remoteRendererEvents = remote?.let { participant ->
-                            remember(participant.cid, mainHandler) {
-                                aspectRatioRendererEvents(mainHandler) { ratio ->
-                                    remoteAspectRatios[participant.cid] = clampStageTileAspectRatio(ratio)
-                                }
+                        onRemoteAspectRatioChanged = remote?.let { participant ->
+                            { ratio: Float ->
+                                remoteAspectRatios[participant.cid] = ratio
                             }
                         },
                         attachLocalSink = attachLocalSink,
@@ -1148,7 +1140,7 @@ private fun FrontlineMultiPartyStage(
                         localContentMode = localContentMode,
                         localZoomTransformState = localZoomTransformState,
                         localRendererEvents = localRendererEvents,
-                        remoteRendererEvents = null,
+                        onRemoteAspectRatioChanged = null,
                         attachLocalSink = attachLocalSink,
                         detachLocalSink = detachLocalSink,
                         attachRemoteSinkForCid = attachRemoteSinkForCid,
@@ -1190,7 +1182,7 @@ private fun FrontlineLayoutTile(
     localContentMode: Boolean,
     localZoomTransformState: androidx.compose.foundation.gestures.TransformableState,
     localRendererEvents: RendererCommon.RendererEvents,
-    remoteRendererEvents: RendererCommon.RendererEvents?,
+    onRemoteAspectRatioChanged: ((Float) -> Unit)?,
     attachLocalSink: (VideoSink) -> Unit,
     detachLocalSink: (VideoSink) -> Unit,
     attachRemoteSinkForCid: (String, VideoSink) -> Unit,
@@ -1257,15 +1249,20 @@ private fun FrontlineLayoutTile(
                 }
             }
             remote != null && remote.videoEnabled -> {
-                TextureVideoSurface(
-                    modifier = Modifier.fillMaxSize(),
-                    rendererName = "frontline-remote-stage-${remote.cid}",
-                    eglContext = eglContext,
-                    onAttach = { sink -> attachRemoteSinkForCid(remote.cid, sink) },
-                    onDetach = { sink -> detachRemoteSinkForCid(remote.cid, sink) },
-                    contentScale = contentScale,
-                    rendererEvents = remoteRendererEvents,
-                )
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    FrontlineRemoteVideoSurface(
+                        remote = remote,
+                        width = maxWidth,
+                        height = maxHeight,
+                        rendererName = "frontline-remote-stage-${remote.cid}",
+                        eglContext = eglContext,
+                        contentScale = contentScale,
+                        onAspectRatioChanged = onRemoteAspectRatioChanged ?: {},
+                        onAttach = { sink -> attachRemoteSinkForCid(remote.cid, sink) },
+                        onDetach = { sink -> detachRemoteSinkForCid(remote.cid, sink) },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
             else -> {
                 FrontlineCameraOffTile(
@@ -1356,6 +1353,70 @@ private fun FrontlineCameraOffTile(
 }
 
 @Composable
+private fun FrontlineRemoteVideoSurface(
+    remote: RemoteParticipant,
+    width: Dp,
+    height: Dp,
+    rendererName: String,
+    eglContext: EglBase.Context,
+    contentScale: ContentScale,
+    onAttach: (VideoSink) -> Unit,
+    onDetach: (VideoSink) -> Unit,
+    modifier: Modifier = Modifier,
+    onAspectRatioChanged: (Float) -> Unit = {},
+) {
+    val mainHandler = remember { Handler(Looper.getMainLooper()) }
+    val currentOnAspectRatioChanged = rememberUpdatedState(onAspectRatioChanged)
+    var videoAspectRatio by remember(remote.cid) { mutableStateOf(0f) }
+
+    val rendererEvents = remember(remote.cid, mainHandler) {
+        object : RendererCommon.RendererEvents {
+            override fun onFirstFrameRendered() = Unit
+
+            override fun onFrameResolutionChanged(widthPx: Int, heightPx: Int, rotation: Int) {
+                val rotatedWidth = if (rotation % 180 == 0) widthPx else heightPx
+                val rotatedHeight = if (rotation % 180 == 0) heightPx else widthPx
+                if (rotatedWidth == 0 || rotatedHeight == 0) return
+                val rawRatio = rotatedWidth.toFloat() / rotatedHeight.toFloat()
+                val layoutRatio = clampStageTileAspectRatio(rawRatio)
+                mainHandler.post {
+                    videoAspectRatio = rawRatio
+                    currentOnAspectRatioChanged.value(layoutRatio)
+                }
+            }
+        }
+    }
+    val geometry = computeFitCoverGeometry(width, height, videoAspectRatio)
+    val animatedScale by animateFloatAsState(
+        targetValue = if (contentScale == ContentScale.Crop) geometry.coverScale else 1f,
+        animationSpec = tween(durationMillis = 260),
+        label = "frontline_remote_video_scale",
+    )
+
+    Box(
+        modifier = modifier
+            .background(FrontlineSurface)
+            .clipToBounds(),
+        contentAlignment = Alignment.Center,
+    ) {
+        TextureVideoSurface(
+            modifier = Modifier
+                .size(geometry.fitWidth, geometry.fitHeight)
+                .graphicsLayer {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                },
+            rendererName = rendererName,
+            eglContext = eglContext,
+            onAttach = onAttach,
+            onDetach = onDetach,
+            contentScale = ContentScale.Crop,
+            rendererEvents = rendererEvents,
+        )
+    }
+}
+
+@Composable
 private fun FrontlineLargeSurface(
     feed: FrontlineFeed,
     uiState: CallUiState,
@@ -1363,13 +1424,12 @@ private fun FrontlineLargeSurface(
     localContentMode: Boolean,
     eglContext: EglBase.Context,
     localRendererEvents: RendererCommon.RendererEvents,
-    remoteRendererEvents: RendererCommon.RendererEvents,
     remoteVideoFitCover: Boolean,
     localZoomTransformState: androidx.compose.foundation.gestures.TransformableState,
     attachLocalRenderer: (SurfaceViewRenderer, RendererCommon.RendererEvents?) -> Unit,
     detachLocalRenderer: (SurfaceViewRenderer) -> Unit,
-    attachRemoteRenderer: (SurfaceViewRenderer, RendererCommon.RendererEvents?) -> Unit,
-    detachRemoteRenderer: (SurfaceViewRenderer) -> Unit,
+    attachRemoteSink: (VideoSink) -> Unit,
+    detachRemoteSink: (VideoSink) -> Unit,
     strings: Map<SerenadaString, String>?,
     modifier: Modifier = Modifier,
 ) {
@@ -1395,15 +1455,19 @@ private fun FrontlineLargeSurface(
             }
         }
         feed == FrontlineFeed.Remote && remote?.videoEnabled == true -> {
-            VideoSurface(
-                modifier = modifier.clipToBounds(),
-                viewKey = "frontline-remote-main",
-                onAttach = { renderer -> attachRemoteRenderer(renderer, remoteRendererEvents) },
-                onDetach = detachRemoteRenderer,
-                mirror = false,
-                contentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
-                isMediaOverlay = false,
-            )
+            BoxWithConstraints(modifier = modifier.clipToBounds()) {
+                FrontlineRemoteVideoSurface(
+                    remote = remote,
+                    width = maxWidth,
+                    height = maxHeight,
+                    rendererName = "frontline-remote-main",
+                    eglContext = eglContext,
+                    contentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
+                    onAttach = attachRemoteSink,
+                    onDetach = detachRemoteSink,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
         else -> {
             val waitingForRemote = uiState.isFrontlineWaitingForRemote()

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -280,6 +280,19 @@ internal fun FrontlineCallScreen(
     val showMoreButton =
         isCallSurfacePhase &&
             (showAudioRouteControl || config.screenSharingEnabled || config.inviteControlsEnabled)
+    val moreOpensAudioRouteDirectly =
+        frontlineMoreMenuOpensAudioRouteDirectly(
+            showAudioRouteControl = showAudioRouteControl,
+            screenSharingEnabled = config.screenSharingEnabled,
+            inviteEnabled = config.inviteControlsEnabled,
+        )
+    val openMoreOrAudioRoute = {
+        if (moreOpensAudioRouteDirectly) {
+            isAudioRouteSheetVisible = true
+        } else {
+            isMoreSheetVisible = true
+        }
+    }
     val snapshotSource =
         if (
             config.snapshotEnabled &&
@@ -377,20 +390,11 @@ internal fun FrontlineCallScreen(
                     else -> 260.dp
                 }
                 val pipInPanel = isTabletLandscape && pipFeed != null
-                val pipWidth = when {
-                    pipInPanel -> 220.dp
-                    maxWidth >= 1100.dp -> 172.dp
-                    maxWidth >= 720.dp -> 152.dp
-                    maxWidth >= 480.dp -> 120.dp
-                    else -> 100.dp
-                }
-                val pipHeight = when {
-                    pipInPanel -> 280.dp
-                    maxWidth >= 1100.dp -> 220.dp
-                    maxWidth >= 720.dp -> 196.dp
-                    maxWidth >= 480.dp -> 154.dp
-                    else -> 128.dp
-                }
+                val pipSize = frontlinePipSize(
+                    containerWidth = maxWidth,
+                    containerHeight = maxHeight,
+                    inPanel = pipInPanel,
+                )
                 val pip: @Composable (Modifier) -> Unit = { modifier ->
                     if (pipFeed != null) {
                         FrontlinePip(
@@ -398,8 +402,8 @@ internal fun FrontlineCallScreen(
                             uiState = uiState,
                             remote = remote,
                             eglContext = eglContext,
-                            width = pipWidth,
-                            height = pipHeight,
+                            width = pipSize.width,
+                            height = pipSize.height,
                             showSwapHint = canSwapPip,
                             onClick = {
                                 if (canSwapPip) {
@@ -473,7 +477,7 @@ internal fun FrontlineCallScreen(
                             onFlipCamera = onFlipCamera,
                             onToggleFlashlight = onToggleFlashlight,
                             onSnapshotFlash = { showSnapshotFlash = true },
-                            onMore = { isMoreSheetVisible = true },
+                            onMore = openMoreOrAudioRoute,
                             onEndCall = onEndCall,
                             strings = strings,
                             modifier = Modifier.width(panelWidth).fillMaxHeight(),
@@ -536,7 +540,7 @@ internal fun FrontlineCallScreen(
                             onFlipCamera = onFlipCamera,
                             onToggleFlashlight = onToggleFlashlight,
                             onSnapshotFlash = { showSnapshotFlash = true },
-                            onMore = { isMoreSheetVisible = true },
+                            onMore = openMoreOrAudioRoute,
                             onEndCall = onEndCall,
                             strings = strings,
                             modifier = Modifier.fillMaxWidth(),
@@ -630,7 +634,7 @@ internal fun FrontlineCallScreen(
                 }
 
                 FrontlineMoreSheet(
-                    visible = isMoreSheetVisible,
+                    visible = isMoreSheetVisible && !moreOpensAudioRouteDirectly,
                     audioRouteDevice = currentAudioRoute,
                     audioRouteOptions = audioRouteOptions,
                     screenSharingEnabled = config.screenSharingEnabled,
@@ -1990,6 +1994,7 @@ private fun FrontlineMoreSheet(
                             } else {
                                 resolveString(SerenadaString.FrontlineShareScreen, strings)
                             },
+                            danger = isScreenSharing,
                             onClick = onToggleScreenShare,
                         )
                     }
@@ -2041,8 +2046,10 @@ private fun FrontlineSheetItem(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     title: String,
     onClick: () -> Unit,
+    danger: Boolean = false,
 ) {
     val shape = RoundedCornerShape(16.dp)
+    val background = if (danger) FrontlineDanger else FrontlineSheetRow
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -2052,7 +2059,7 @@ private fun FrontlineSheetItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(shape)
-                .background(FrontlineSheetRow)
+                .background(background)
                 .clickable(onClick = onClick)
                 .padding(horizontal = 18.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -2222,6 +2229,31 @@ private fun frontlineIncludesNormalLocalStageTile(
     activeContentOwnerId: String?,
     contentTileIsSpotlight: Boolean,
 ): Boolean = activeContentOwnerId != localSpotlightId || contentTileIsSpotlight
+
+private fun frontlineMoreMenuOpensAudioRouteDirectly(
+    showAudioRouteControl: Boolean,
+    screenSharingEnabled: Boolean,
+    inviteEnabled: Boolean,
+): Boolean = showAudioRouteControl && !screenSharingEnabled && !inviteEnabled
+
+private data class FrontlinePipSize(val width: Dp, val height: Dp)
+
+private fun frontlinePipSize(
+    containerWidth: Dp,
+    containerHeight: Dp,
+    inPanel: Boolean,
+): FrontlinePipSize {
+    if (inPanel) {
+        return FrontlinePipSize(width = 220.dp, height = 280.dp)
+    }
+    val referenceWidth = if (containerWidth > containerHeight) containerHeight else containerWidth
+    return when {
+        referenceWidth >= 1100.dp -> FrontlinePipSize(width = 172.dp, height = 220.dp)
+        referenceWidth >= 720.dp -> FrontlinePipSize(width = 152.dp, height = 196.dp)
+        referenceWidth >= 480.dp -> FrontlinePipSize(width = 120.dp, height = 154.dp)
+        else -> FrontlinePipSize(width = 100.dp, height = 128.dp)
+    }
+}
 
 private fun String.frontlineContentSpotlightId(): String = "$FRONTLINE_CONTENT_SPOTLIGHT_PREFIX$this"
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -382,6 +382,8 @@ fun SerenadaCallFlow(
             detachRemoteSinkForCid = detachRemoteSinkForCid,
             attachRemoteSink = attachRemoteSink,
             detachRemoteSink = detachRemoteSink,
+            initialRemoteVideoFitCover = initialRemoteVideoFitCover,
+            onRemoteVideoFitChanged = onRemoteVideoFitChanged,
             onSnapshotRequested = onSnapshotRequested,
         )
     } else {

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -376,8 +376,6 @@ fun SerenadaCallFlow(
             detachLocalRenderer = detachLocalRenderer,
             attachLocalSink = attachLocalSink,
             detachLocalSink = detachLocalSink,
-            attachRemoteRenderer = attachRemoteRenderer,
-            detachRemoteRenderer = detachRemoteRenderer,
             attachRemoteSinkForCid = attachRemoteSinkForCid,
             detachRemoteSinkForCid = detachRemoteSinkForCid,
             attachRemoteSink = attachRemoteSink,

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -13,6 +13,7 @@ private let frontlineDim = Color(red: 0xA1 / 255, green: 0xA1 / 255, blue: 0xAA 
 private let frontlineSheet = Color(red: 0x15 / 255, green: 0x16 / 255, blue: 0x1A / 255)
 private let frontlineSheetRow = Color.white.opacity(0.09)
 private let frontlineContentSpotlightPrefix = "content:"
+private let frontlineSheetAnimation = Animation.interactiveSpring(response: 0.32, dampingFraction: 0.9, blendDuration: 0.05)
 private let frontlineMoreButtonHeightToWidthRatio: CGFloat = 1.62
 private let frontlineLargeVideoAccentLineWidth: CGFloat = 3
 private let frontlinePipVideoAccentLineWidth: CGFloat = 2.5
@@ -66,6 +67,14 @@ func frontlineIncludesNormalLocalStageTile(
     contentTileIsSpotlight: Bool
 ) -> Bool {
     activeContentOwnerId != localSpotlightId || contentTileIsSpotlight
+}
+
+func frontlineMoreMenuOpensAudioRouteDirectly(
+    showsAudioRoute: Bool,
+    screenSharingEnabled: Bool,
+    inviteEnabled: Bool
+) -> Bool {
+    showsAudioRoute && !screenSharingEnabled && !inviteEnabled
 }
 
 struct FrontlineCallScreenView: View {
@@ -150,7 +159,7 @@ struct FrontlineCallScreenView: View {
             let panelWidth = isLandscape ? (geometry.size.width >= 720 ? 320.0 : 260.0) : geometry.size.width
             let pipFeed = pipFeed
             let pipInPanel = isTabletLandscape && pipFeed != nil
-            let pipSize = frontlinePipSize(containerWidth: geometry.size.width, inPanel: pipInPanel)
+            let pipSize = frontlinePipSize(containerSize: geometry.size, inPanel: pipInPanel)
 
             ZStack {
                 frontlineBlack.ignoresSafeArea()
@@ -303,6 +312,14 @@ struct FrontlineCallScreenView: View {
 
     private var shouldShowMoreButton: Bool {
         isCallSurfacePhase && (showsAudioRoute || config.screenSharingEnabled || config.inviteControlsEnabled)
+    }
+
+    private var moreOpensAudioRouteDirectly: Bool {
+        frontlineMoreMenuOpensAudioRouteDirectly(
+            showsAudioRoute: showsAudioRoute,
+            screenSharingEnabled: config.screenSharingEnabled,
+            inviteEnabled: config.inviteControlsEnabled
+        )
     }
 
     @ViewBuilder
@@ -529,7 +546,7 @@ struct FrontlineCallScreenView: View {
             onFlipCamera: onFlipCamera,
             onToggleFlashlight: onToggleFlashlight,
             onSnapshotFlash: { showSnapshotFlash = true },
-            onMore: { isMoreSheetVisible = true },
+            onMore: openMoreOrAudioRoute,
             onEndCall: onEndCall
         )
     }
@@ -590,62 +607,58 @@ struct FrontlineCallScreenView: View {
     }
 
     private var moreSheet: some View {
-        Group {
-            if isMoreSheetVisible && shouldShowMoreButton {
-                FrontlineMoreSheet(
-                    showsAudioRoute: showsAudioRoute,
-                    audioRouteDevice: currentAudioRoute,
-                    screenSharingEnabled: config.screenSharingEnabled,
-                    inviteEnabled: config.inviteControlsEnabled,
-                    shareEnabled: config.inviteControlsEnabled && roomShareURL != nil,
-                    isScreenSharing: uiState.isScreenSharing,
-                    screenShareExtensionBundleId: screenShareExtensionBundleId,
-                    broadcastTriggerCount: $broadcastTriggerCount,
-                    strings: strings,
-                    onDismiss: { isMoreSheetVisible = false },
-                    onAudioRoute: {
-                        isMoreSheetVisible = false
-                        isAudioRouteSheetVisible = true
-                    },
-                    onToggleScreenShare: {
-                        isMoreSheetVisible = false
-                        onToggleScreenShare()
-                    },
-                    onStartBroadcastPicker: {
-                        onToggleScreenShare()
-                        broadcastTriggerCount += 1
-                        DispatchQueue.main.async {
-                            isMoreSheetVisible = false
-                        }
-                    },
-                    onInvite: {
-                        isMoreSheetVisible = false
-                        Task { _ = await onInviteToRoom() }
-                    },
-                    onShare: {
-                        isMoreSheetVisible = false
-                        showShareSheet = true
-                    }
-                )
+        FrontlineMoreSheet(
+            visible: isMoreSheetVisible && shouldShowMoreButton && !moreOpensAudioRouteDirectly,
+            showsAudioRoute: showsAudioRoute,
+            audioRouteDevice: currentAudioRoute,
+            screenSharingEnabled: config.screenSharingEnabled,
+            inviteEnabled: config.inviteControlsEnabled,
+            shareEnabled: config.inviteControlsEnabled && roomShareURL != nil,
+            isScreenSharing: uiState.isScreenSharing,
+            screenShareExtensionBundleId: screenShareExtensionBundleId,
+            broadcastTriggerCount: $broadcastTriggerCount,
+            strings: strings,
+            onDismiss: { setMoreSheetVisible(false) },
+            onAudioRoute: {
+                withAnimation(frontlineSheetAnimation) {
+                    isMoreSheetVisible = false
+                    isAudioRouteSheetVisible = true
+                }
+            },
+            onToggleScreenShare: {
+                setMoreSheetVisible(false)
+                onToggleScreenShare()
+            },
+            onStartBroadcastPicker: {
+                onToggleScreenShare()
+                broadcastTriggerCount += 1
+                DispatchQueue.main.async {
+                    setMoreSheetVisible(false)
+                }
+            },
+            onInvite: {
+                setMoreSheetVisible(false)
+                Task { _ = await onInviteToRoom() }
+            },
+            onShare: {
+                setMoreSheetVisible(false)
+                showShareSheet = true
             }
-        }
+        )
     }
 
     private var audioRouteSheet: some View {
-        Group {
-            if isAudioRouteSheetVisible {
-                FrontlineAudioRouteSheet(
-                    devices: audioRouteOptions,
-                    currentDevice: currentAudioRoute,
-                    strings: strings,
-                    onDismiss: { isAudioRouteSheetVisible = false },
-                    onSelect: { device in
-                        isAudioRouteSheetVisible = false
-                        onSelectAudioDevice(device)
-                    }
-                )
+        FrontlineAudioRouteSheet(
+            visible: isAudioRouteSheetVisible,
+            devices: audioRouteOptions,
+            currentDevice: currentAudioRoute,
+            strings: strings,
+            onDismiss: { setAudioRouteSheetVisible(false) },
+            onSelect: { device in
+                setAudioRouteSheetVisible(false)
+                onSelectAudioDevice(device)
             }
-        }
+        )
     }
 
     private var localDisplayName: String {
@@ -664,6 +677,28 @@ struct FrontlineCallScreenView: View {
         }
     }
 
+    private func openMoreOrAudioRoute() {
+        withAnimation(frontlineSheetAnimation) {
+            if moreOpensAudioRouteDirectly {
+                isAudioRouteSheetVisible = true
+            } else {
+                isMoreSheetVisible = true
+            }
+        }
+    }
+
+    private func setMoreSheetVisible(_ visible: Bool) {
+        withAnimation(frontlineSheetAnimation) {
+            isMoreSheetVisible = visible
+        }
+    }
+
+    private func setAudioRouteSheetVisible(_ visible: Bool) {
+        withAnimation(frontlineSheetAnimation) {
+            isAudioRouteSheetVisible = visible
+        }
+    }
+
     private func updateLastVideoStartedParticipant() {
         let next = Dictionary(uniqueKeysWithValues: uiState.remoteParticipants.map { ($0.cid, $0.videoEnabled) })
         if !previousRemoteVideoEnabled.isEmpty {
@@ -675,11 +710,12 @@ struct FrontlineCallScreenView: View {
     }
 }
 
-private func frontlinePipSize(containerWidth: CGFloat, inPanel: Bool) -> CGSize {
+func frontlinePipSize(containerSize: CGSize, inPanel: Bool) -> CGSize {
     if inPanel { return CGSize(width: 220, height: 280) }
-    if containerWidth >= 1100 { return CGSize(width: 172, height: 220) }
-    if containerWidth >= 720 { return CGSize(width: 152, height: 196) }
-    if containerWidth >= 480 { return CGSize(width: 120, height: 154) }
+    let referenceWidth = containerSize.width > containerSize.height ? containerSize.height : containerSize.width
+    if referenceWidth >= 1100 { return CGSize(width: 172, height: 220) }
+    if referenceWidth >= 720 { return CGSize(width: 152, height: 196) }
+    if referenceWidth >= 480 { return CGSize(width: 120, height: 154) }
     return CGSize(width: 100, height: 128)
 }
 
@@ -1142,7 +1178,36 @@ private struct FrontlineEndButton: View {
     }
 }
 
+private struct FrontlineBottomSheetContainer<Content: View>: View {
+    let visible: Bool
+    let onDismiss: () -> Void
+    private let content: Content
+
+    init(visible: Bool, onDismiss: @escaping () -> Void, @ViewBuilder content: () -> Content) {
+        self.visible = visible
+        self.onDismiss = onDismiss
+        self.content = content()
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            if visible {
+                Color.black.opacity(0.5)
+                    .ignoresSafeArea()
+                    .onTapGesture(perform: onDismiss)
+                    .transition(.opacity)
+
+                content
+                    .transition(.move(edge: .bottom))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .allowsHitTesting(visible)
+    }
+}
+
 private struct FrontlineMoreSheet: View {
+    let visible: Bool
     let showsAudioRoute: Bool
     let audioRouteDevice: AudioDevice?
     let screenSharingEnabled: Bool
@@ -1160,11 +1225,7 @@ private struct FrontlineMoreSheet: View {
     let onShare: () -> Void
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            Color.black.opacity(0.5)
-                .ignoresSafeArea()
-                .onTapGesture(perform: onDismiss)
-
+        FrontlineBottomSheetContainer(visible: visible, onDismiss: onDismiss) {
             VStack(spacing: 0) {
                 Capsule()
                     .fill(Color.white.opacity(0.24))
@@ -1188,6 +1249,7 @@ private struct FrontlineMoreSheet: View {
                         title: isScreenSharing
                             ? resolveString(.frontlineStopScreenShare, overrides: strings)
                             : resolveString(.frontlineShareScreen, overrides: strings),
+                        danger: isScreenSharing,
                         onClick: screenShareAction
                     )
                     .overlay {
@@ -1240,7 +1302,6 @@ private struct FrontlineMoreSheet: View {
             .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
             .ignoresSafeArea(edges: .bottom)
         }
-        .transition(.opacity)
     }
 
     private func screenShareAction() {
@@ -1253,6 +1314,7 @@ private struct FrontlineMoreSheet: View {
 }
 
 private struct FrontlineAudioRouteSheet: View {
+    let visible: Bool
     let devices: [AudioDevice]
     let currentDevice: AudioDevice?
     let strings: [SerenadaString: String]?
@@ -1260,11 +1322,7 @@ private struct FrontlineAudioRouteSheet: View {
     let onSelect: (AudioDevice) -> Void
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            Color.black.opacity(0.5)
-                .ignoresSafeArea()
-                .onTapGesture(perform: onDismiss)
-
+        FrontlineBottomSheetContainer(visible: visible, onDismiss: onDismiss) {
             VStack(spacing: 0) {
                 Capsule()
                     .fill(Color.white.opacity(0.24))
@@ -1307,7 +1365,6 @@ private struct FrontlineAudioRouteSheet: View {
             .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
             .ignoresSafeArea(edges: .bottom)
         }
-        .transition(.opacity)
     }
 
     private func isSelected(_ device: AudioDevice) -> Bool {
@@ -1359,6 +1416,7 @@ private struct FrontlineAudioRouteItem: View {
 private struct FrontlineSheetItem: View {
     let systemImage: String
     let title: String
+    var danger = false
     let onClick: () -> Void
 
     var body: some View {
@@ -1378,7 +1436,7 @@ private struct FrontlineSheetItem: View {
             .padding(.horizontal, 18)
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
-            .background(frontlineSheetRow)
+            .background(danger ? frontlineDanger : frontlineSheetRow)
             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
             .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         }

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -77,6 +77,20 @@ func frontlineMoreMenuOpensAudioRouteDirectly(
     showsAudioRoute && !screenSharingEnabled && !inviteEnabled
 }
 
+func frontlineShowsRemoteFitButton(
+    isCallSurfacePhase: Bool,
+    waitingForRemote: Bool,
+    remoteParticipantCount: Int,
+    largeFeedIsRemote: Bool,
+    remoteVideoEnabled: Bool
+) -> Bool {
+    isCallSurfacePhase &&
+        !waitingForRemote &&
+        remoteParticipantCount <= 1 &&
+        largeFeedIsRemote &&
+        remoteVideoEnabled
+}
+
 struct FrontlineCallScreenView: View {
     let roomId: String
     let uiState: CallUiState
@@ -102,10 +116,12 @@ struct FrontlineCallScreenView: View {
     let onDismiss: (() -> Void)?
     let onSnapshotRequested: ((SnapshotSource) -> Void)?
     let rendererProvider: CallRendererProvider
+    let onRemoteVideoFitChanged: ((Bool) -> Void)?
 
     @State private var pipSwapped = false
     @State private var isMoreSheetVisible = false
     @State private var isAudioRouteSheetVisible = false
+    @State private var remoteVideoFitCover: Bool
     @State private var showShareSheet = false
     @State private var showSnapshotFlash = false
     @State private var showDebugPanel = false
@@ -117,6 +133,62 @@ struct FrontlineCallScreenView: View {
     @State private var lastVideoStartedParticipantId: String?
     @State private var previousRemoteVideoEnabled: [String: Bool] = [:]
     @State private var broadcastTriggerCount = 0
+
+    init(
+        roomId: String,
+        uiState: CallUiState,
+        sessionPhase: SerenadaCallPhase,
+        roomShareURL: URL?,
+        screenShareExtensionBundleId: String?,
+        roomName: String?,
+        config: SerenadaCallFlowConfig,
+        strings: [SerenadaString: String]?,
+        availableAudioDevices: [AudioDevice],
+        currentAudioDevice: AudioDevice?,
+        onToggleAudio: @escaping () -> Void,
+        onSelectAudioDevice: @escaping (AudioDevice) -> Void,
+        onToggleVideo: @escaping () -> Void,
+        onFlipCamera: @escaping () -> Void,
+        onToggleScreenShare: @escaping () -> Void,
+        onAdjustCameraZoom: @escaping (CGFloat) -> Void,
+        onResetCameraZoom: @escaping () -> Void,
+        onToggleFlashlight: @escaping () -> Void,
+        onEndCall: @escaping () -> Void,
+        onInviteToRoom: @escaping () async -> Result<Void, Error>,
+        onRequestPermissions: @escaping () -> Void,
+        onDismiss: (() -> Void)?,
+        onSnapshotRequested: ((SnapshotSource) -> Void)?,
+        rendererProvider: CallRendererProvider,
+        initialRemoteVideoFitCover: Bool = true,
+        onRemoteVideoFitChanged: ((Bool) -> Void)? = nil
+    ) {
+        self.roomId = roomId
+        self.uiState = uiState
+        self.sessionPhase = sessionPhase
+        self.roomShareURL = roomShareURL
+        self.screenShareExtensionBundleId = screenShareExtensionBundleId
+        self.roomName = roomName
+        self.config = config
+        self.strings = strings
+        self.availableAudioDevices = availableAudioDevices
+        self.currentAudioDevice = currentAudioDevice
+        self.onToggleAudio = onToggleAudio
+        self.onSelectAudioDevice = onSelectAudioDevice
+        self.onToggleVideo = onToggleVideo
+        self.onFlipCamera = onFlipCamera
+        self.onToggleScreenShare = onToggleScreenShare
+        self.onAdjustCameraZoom = onAdjustCameraZoom
+        self.onResetCameraZoom = onResetCameraZoom
+        self.onToggleFlashlight = onToggleFlashlight
+        self.onEndCall = onEndCall
+        self.onInviteToRoom = onInviteToRoom
+        self.onRequestPermissions = onRequestPermissions
+        self.onDismiss = onDismiss
+        self.onSnapshotRequested = onSnapshotRequested
+        self.rendererProvider = rendererProvider
+        self.onRemoteVideoFitChanged = onRemoteVideoFitChanged
+        _remoteVideoFitCover = State(initialValue: initialRemoteVideoFitCover)
+    }
 
     private func str(_ key: SerenadaString) -> String {
         resolveString(key, overrides: strings)
@@ -328,6 +400,13 @@ struct FrontlineCallScreenView: View {
         pipInPanel: Bool,
         pipSize: CGSize
     ) -> some View {
+        let showRemoteFitButton = frontlineShowsRemoteFitButton(
+            isCallSurfacePhase: isCallSurfacePhase,
+            waitingForRemote: frontlineIsWaitingForRemote(uiState),
+            remoteParticipantCount: uiState.remoteParticipants.count,
+            largeFeedIsRemote: largeFeed == .remote,
+            remoteVideoEnabled: remote?.videoEnabled == true
+        )
         ZStack {
             if !isCallSurfacePhase {
                 FrontlinePhaseSurface(
@@ -364,6 +443,17 @@ struct FrontlineCallScreenView: View {
                 .padding(.leading, 16)
                 .padding(.bottom, 16)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            }
+
+            if showRemoteFitButton {
+                FrontlineRemoteFitButton(
+                    remoteVideoFitCover: remoteVideoFitCover,
+                    strings: strings,
+                    onClick: toggleRemoteVideoFit
+                )
+                .padding(.trailing, 16)
+                .padding(.bottom, 16)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
 
             if isCallSurfacePhase,
@@ -437,7 +527,7 @@ struct FrontlineCallScreenView: View {
             WebRTCVideoView(
                 kind: remote.map { .remoteForCid($0.cid) } ?? .remote,
                 rendererProvider: rendererProvider,
-                videoContentMode: .scaleAspectFill
+                videoContentMode: remoteVideoFitCover ? .scaleAspectFill : .scaleAspectFit
             )
             .ignoresSafeArea()
         default:
@@ -459,9 +549,11 @@ struct FrontlineCallScreenView: View {
             pinnedSpotlightId: $pinnedSpotlightId,
             selectedSpotlightId: $selectedSpotlightId,
             lastVideoStartedParticipantId: lastVideoStartedParticipantId,
+            remoteVideoFitCover: $remoteVideoFitCover,
             rendererProvider: rendererProvider,
             strings: strings,
-            onAdjustCameraZoom: onAdjustCameraZoom
+            onAdjustCameraZoom: onAdjustCameraZoom,
+            onRemoteVideoFitChanged: onRemoteVideoFitChanged
         )
     }
 
@@ -697,6 +789,13 @@ struct FrontlineCallScreenView: View {
         withAnimation(frontlineSheetAnimation) {
             isAudioRouteSheetVisible = visible
         }
+    }
+
+    private func toggleRemoteVideoFit() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            remoteVideoFitCover.toggle()
+        }
+        onRemoteVideoFitChanged?(remoteVideoFitCover)
     }
 
     private func updateLastVideoStartedParticipant() {
@@ -1178,6 +1277,30 @@ private struct FrontlineEndButton: View {
     }
 }
 
+private struct FrontlineRemoteFitButton: View {
+    let remoteVideoFitCover: Bool
+    let strings: [SerenadaString: String]?
+    let onClick: () -> Void
+
+    var body: some View {
+        Button(action: onClick) {
+            Image(systemName: remoteVideoFitCover
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(Color.black.opacity(0.4))
+                .clipShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(resolveString(
+            remoteVideoFitCover ? .callA11yVideoFit : .callA11yVideoFill,
+            overrides: strings
+        ))
+    }
+}
+
 private struct FrontlineBottomSheetContainer<Content: View>: View {
     let visible: Bool
     let onDismiss: () -> Void
@@ -1583,9 +1706,11 @@ private struct FrontlineMultiPartyStage: View {
     @Binding var pinnedSpotlightId: String?
     @Binding var selectedSpotlightId: String?
     let lastVideoStartedParticipantId: String?
+    @Binding var remoteVideoFitCover: Bool
     let rendererProvider: CallRendererProvider
     let strings: [SerenadaString: String]?
     let onAdjustCameraZoom: (CGFloat) -> Void
+    let onRemoteVideoFitChanged: ((Bool) -> Void)?
 
     @State private var lastMagnificationValue: CGFloat = 1
     @State private var localAspectRatio: CGFloat?
@@ -1620,7 +1745,10 @@ private struct FrontlineMultiPartyStage: View {
                         onLocalVideoSizeChanged: { localAspectRatio = quantizedFrontlineAspectRatio($0) },
                         onRemoteVideoSizeChanged: { _, _ in },
                         localZoomEnabled: false,
-                        localZoomGesture: localZoomGesture(enabled: false)
+                        localZoomGesture: localZoomGesture(enabled: false),
+                        showRemoteFitButton: false,
+                        remoteVideoFitCover: remoteVideoFitCover,
+                        onToggleRemoteVideoFit: toggleRemoteVideoFit
                     )
                     .frame(width: pip.frame.width, height: pip.frame.height)
                     .clipShape(RoundedRectangle(cornerRadius: pip.cornerRadius))
@@ -1646,6 +1774,9 @@ private struct FrontlineMultiPartyStage: View {
             ?? selectedSpotlightId.flatMap { availableIds.contains($0) ? $0 : nil }
             ?? defaultPrimary
         let spotlightIsContent = contentSource != nil && activeContentSpotlightId != nil && effectiveSpotlight == activeContentSpotlightId
+        let spotlightIsRemote =
+            uiState.remoteParticipants.contains { $0.cid == effectiveSpotlight } ||
+            (spotlightIsContent && contentSource?.ownerParticipantId != localSpotlightId)
 
         var participants = uiState.remoteParticipants.map {
             SceneParticipant(
@@ -1689,7 +1820,7 @@ private struct FrontlineMultiPartyStage: View {
             activeSpeakerId: nil,
             pinnedParticipantId: spotlightIsContent ? nil : effectiveSpotlight,
             contentSource: spotlightIsContent ? contentSource : nil,
-            userPrefs: UserLayoutPrefs(dominantFit: .cover)
+            userPrefs: UserLayoutPrefs(dominantFit: spotlightIsRemote && !remoteVideoFitCover ? .contain : .cover)
         ))
     }
 
@@ -1717,6 +1848,11 @@ private struct FrontlineMultiPartyStage: View {
             }
             return nil
         }()
+        let showRemoteFitButton =
+            tile.zOrder == 0 &&
+            remote != nil &&
+            !isLocal &&
+            (!isContentTile || contentOwnerCid != localSpotlightId)
 
         FrontlineLayoutTile(
             tileId: tile.id,
@@ -1736,8 +1872,18 @@ private struct FrontlineMultiPartyStage: View {
             onLocalVideoSizeChanged: { localAspectRatio = quantizedFrontlineAspectRatio($0) },
             onRemoteVideoSizeChanged: { cid, size in remoteTileAspectRatios[cid] = quantizedFrontlineAspectRatio(size) },
             localZoomEnabled: localZoomEnabled,
-            localZoomGesture: localZoomGesture(enabled: localZoomEnabled)
+            localZoomGesture: localZoomGesture(enabled: localZoomEnabled),
+            showRemoteFitButton: showRemoteFitButton,
+            remoteVideoFitCover: remoteVideoFitCover,
+            onToggleRemoteVideoFit: toggleRemoteVideoFit
         )
+    }
+
+    private func toggleRemoteVideoFit() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            remoteVideoFitCover.toggle()
+        }
+        onRemoteVideoFitChanged?(remoteVideoFitCover)
     }
 
     private var activeContentSource: ContentSource? {
@@ -1794,6 +1940,9 @@ private struct FrontlineLayoutTile<ZoomGesture: Gesture>: View {
     let onRemoteVideoSizeChanged: (String, CGSize) -> Void
     let localZoomEnabled: Bool
     let localZoomGesture: ZoomGesture
+    let showRemoteFitButton: Bool
+    let remoteVideoFitCover: Bool
+    let onToggleRemoteVideoFit: () -> Void
 
     var body: some View {
         let displayName = isLocal
@@ -1857,6 +2006,16 @@ private struct FrontlineLayoutTile<ZoomGesture: Gesture>: View {
             if !isContentTile {
                 FrontlineNameChip(label: displayName, muted: muted, audioLevel: audioLevel, compact: true)
                     .padding(6)
+            }
+
+            if showRemoteFitButton {
+                FrontlineRemoteFitButton(
+                    remoteVideoFitCover: remoteVideoFitCover,
+                    strings: strings,
+                    onClick: onToggleRemoteVideoFit
+                )
+                .padding(8)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
         }
         .clipShape(tileShape)

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -366,7 +366,9 @@ private struct SessionFirstCallFlow: View {
             onRequestPermissions: { requestPermissions(state: state) },
             onDismiss: onDismiss,
             onSnapshotRequested: makeSnapshotHandler(),
-            rendererProvider: session
+            rendererProvider: session,
+            initialRemoteVideoFitCover: params.initialRemoteVideoFitCover,
+            onRemoteVideoFitChanged: params.onRemoteVideoFitChanged
         )
     }
 

--- a/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
+++ b/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
@@ -258,6 +258,45 @@ final class CallScreenStateTests: XCTestCase {
         )
     }
 
+    func testFrontlineRemoteFitButtonShowsOnlyForSingleRemoteLargePreview() {
+        XCTAssertTrue(
+            frontlineShowsRemoteFitButton(
+                isCallSurfacePhase: true,
+                waitingForRemote: false,
+                remoteParticipantCount: 1,
+                largeFeedIsRemote: true,
+                remoteVideoEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            frontlineShowsRemoteFitButton(
+                isCallSurfacePhase: true,
+                waitingForRemote: false,
+                remoteParticipantCount: 1,
+                largeFeedIsRemote: false,
+                remoteVideoEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            frontlineShowsRemoteFitButton(
+                isCallSurfacePhase: true,
+                waitingForRemote: false,
+                remoteParticipantCount: 2,
+                largeFeedIsRemote: true,
+                remoteVideoEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            frontlineShowsRemoteFitButton(
+                isCallSurfacePhase: true,
+                waitingForRemote: false,
+                remoteParticipantCount: 1,
+                largeFeedIsRemote: true,
+                remoteVideoEnabled: false
+            )
+        )
+    }
+
     func testFrontlineWaitingOnlyWhenCallSurfaceHasNoRemoteParticipants() {
         var state = CallUiState()
         state.phase = .waiting

--- a/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
+++ b/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
@@ -209,6 +209,55 @@ final class CallScreenStateTests: XCTestCase {
         )
     }
 
+    func testFrontlineMoreOpensAudioRouteDirectlyOnlyWhenAudioIsOnlyItem() {
+        XCTAssertTrue(
+            frontlineMoreMenuOpensAudioRouteDirectly(
+                showsAudioRoute: true,
+                screenSharingEnabled: false,
+                inviteEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            frontlineMoreMenuOpensAudioRouteDirectly(
+                showsAudioRoute: false,
+                screenSharingEnabled: false,
+                inviteEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            frontlineMoreMenuOpensAudioRouteDirectly(
+                showsAudioRoute: true,
+                screenSharingEnabled: true,
+                inviteEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            frontlineMoreMenuOpensAudioRouteDirectly(
+                showsAudioRoute: true,
+                screenSharingEnabled: false,
+                inviteEnabled: true
+            )
+        )
+    }
+
+    func testFrontlinePipSizeUsesShorterDimensionInLandscape() {
+        XCTAssertEqual(
+            frontlinePipSize(containerSize: CGSize(width: 390, height: 844), inPanel: false),
+            CGSize(width: 100, height: 128)
+        )
+        XCTAssertEqual(
+            frontlinePipSize(containerSize: CGSize(width: 844, height: 390), inPanel: false),
+            CGSize(width: 100, height: 128)
+        )
+    }
+
+    func testFrontlinePipSizeKeepsPanelSize() {
+        XCTAssertEqual(
+            frontlinePipSize(containerSize: CGSize(width: 1366, height: 1024), inPanel: true),
+            CGSize(width: 220, height: 280)
+        )
+    }
+
     func testFrontlineWaitingOnlyWhenCallSurfaceHasNoRemoteParticipants() {
         var state = CallUiState()
         state.phase = .waiting


### PR DESCRIPTION
## Summary
- Streamlines the Frontline More menu by opening Audio directly when it is the only available menu item.
- Highlights active screen-sharing stop action as a destructive row.
- Keeps phone landscape PIP sizing in the phone-size bucket while preserving tablet panel sizing.
- Smooths iOS bottom-sheet presentation to match Android's fade + bottom slide behavior.
- Adds the remote fit/cover toggle to Frontline large remote previews, using the existing Standard call-screen fit-cover state and callback plumbing.

## Validation
- `git diff --check`
- `xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'platform=iOS Simulator,id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' -only-testing:SerenadaiOSTests/CallScreenStateTests test`
- `./gradlew :serenada-call-ui:compileDebugKotlin --console=plain --rerun-tasks`