### PR TITLE
Fix video calls stuck in "Reconnecting" (renegotiation races)

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -142,12 +142,22 @@ class SerenadaSession internal constructor(
     /** Whether the microphone is muted specifically because external audio, such as push-to-talk, is active. */
     val isMicMutedByExternalAudio: StateFlow<Boolean> = _isMicMutedByExternalAudio.asStateFlow()
 
+    // Latched true once the call's media has connected at least once. A "network-online"
+    // ICE restart is a recovery mechanism for an established call; firing it during initial
+    // setup is never useful and is actively harmful: registerNetworkCallback replays
+    // onAvailable for every already-connected network right after registration, and that
+    // replay would otherwise schedule an ICE restart mid-first-offer, forcing a redundant
+    // renegotiation the moment the first answer lands (observed as a "pending-retry").
+    private var hasEverConnectedPeer = false
+
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
             handler.post {
                 if (_state.value.phase == CallPhase.InCall) {
                     if (isConnectionDegraded()) markConnectionDegraded()
-                    peerNegotiationEngine.scheduleIceRestart("network-online", 0)
+                    if (hasEverConnectedPeer) {
+                        peerNegotiationEngine.scheduleIceRestart("network-online", 0)
+                    }
                 }
             }
         }
@@ -489,6 +499,7 @@ class SerenadaSession internal constructor(
             sendMessage = { type: String, payload: org.json.JSONObject?, to: String? -> sendMessage(type, payload, to) },
             onRemoteParticipantsChanged = { refreshRemoteParticipants() },
             onAggregatePeerStateChanged = { ice: IceConnectionState, conn: PeerConnectionState, sig: RtcSignalingState ->
+                if (conn == PeerConnectionState.CONNECTED) hasEverConnectedPeer = true
                 val current = _diagnostics.value
                 val next = current.copy(
                     iceConnectionState = ice,
@@ -1085,6 +1096,7 @@ class SerenadaSession internal constructor(
         iceFetchGeneration += 1
         startAudioCoordinatorCollectors()
         localMediaReadyForNegotiation = false
+        hasEverConnectedPeer = false
         if (webRtcStatsExecutor == null) {
             webRtcStatsExecutor = newWebRtcStatsExecutor()
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -481,12 +481,20 @@ internal class PeerNegotiationEngine(
             handler.post {
                 settingRemoteAnswerCids.remove(remoteCid)
                 if (success) {
-                    val completedOfferId = pendingLocalOfferIds.remove(remoteCid) ?: offerId
-                    currentNegotiationIds[remoteCid] = completedOfferId
+                    // We just completed the offer identified by `offerId` (validated above).
+                    // Only clear the pending entry if it still refers to that same offer: a
+                    // renegotiation offer (e.g. a "pending-retry" ICE restart fired synchronously
+                    // from the STABLE signaling callback) can replace it with a newer offerId
+                    // before this async callback runs. Clobbering that newer id would make us
+                    // drop the new offer's answer as a "stale offerId" and stall in Reconnecting.
+                    if (pendingLocalOfferIds[remoteCid] == offerId) {
+                        pendingLocalOfferIds.remove(remoteCid)
+                    }
+                    currentNegotiationIds[remoteCid] = offerId
                     ignoredOfferIds.remove(remoteCid)
                     clearOfferTimeout(remoteCid)
                     slot.clearPendingIceRestart()
-                    flushPendingRemoteIce(remoteCid, completedOfferId, slot)
+                    flushPendingRemoteIce(remoteCid, offerId, slot)
                     updateAggregatePeerState()
                     onConnectionStatusUpdate()
                 } else if (shouldIOffer(remoteCid)) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -481,20 +481,24 @@ internal class PeerNegotiationEngine(
             handler.post {
                 settingRemoteAnswerCids.remove(remoteCid)
                 if (success) {
-                    // We just completed the offer identified by `offerId` (validated above).
-                    // Only clear the pending entry if it still refers to that same offer: a
-                    // renegotiation offer (e.g. a "pending-retry" ICE restart fired synchronously
-                    // from the STABLE signaling callback) can replace it with a newer offerId
-                    // before this async callback runs. Clobbering that newer id would make us
-                    // drop the new offer's answer as a "stale offerId" and stall in Reconnecting.
-                    if (pendingLocalOfferIds[remoteCid] == offerId) {
+                    // The offer this answer completes is whatever was pending when we validated
+                    // it above; `pendingOfferId` also covers the legacy/no-offerId path, where
+                    // `offerId` is the sentinel rather than our real local id.
+                    val completedOfferId = pendingOfferId ?: offerId
+                    // Finalize negotiation state only while the slot's pending offer is still the
+                    // one we completed. A renegotiation offer (e.g. a "pending-retry" ICE restart
+                    // fired from the STABLE signaling callback) can replace it during this async
+                    // setRemoteDescription; finalizing then would clobber the newer offer's id and
+                    // cancel its per-peer offer-timeout / pending-retry, stranding it in
+                    // HAVE_LOCAL_OFFER if its answer is lost.
+                    if (pendingLocalOfferIds[remoteCid] == completedOfferId) {
                         pendingLocalOfferIds.remove(remoteCid)
+                        currentNegotiationIds[remoteCid] = completedOfferId
+                        ignoredOfferIds.remove(remoteCid)
+                        clearOfferTimeout(remoteCid)
+                        slot.clearPendingIceRestart()
                     }
-                    currentNegotiationIds[remoteCid] = offerId
-                    ignoredOfferIds.remove(remoteCid)
-                    clearOfferTimeout(remoteCid)
-                    slot.clearPendingIceRestart()
-                    flushPendingRemoteIce(remoteCid, offerId, slot)
+                    flushPendingRemoteIce(remoteCid, completedOfferId, slot)
                     updateAggregatePeerState()
                     onConnectionStatusUpdate()
                 } else if (shouldIOffer(remoteCid)) {

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -559,12 +559,20 @@ final class PeerNegotiationEngine {
                 self.settingRemoteAnswerCids.remove(remoteCid)
                 guard let slot else { return }
                 if success {
-                    let completedOfferId = self.pendingLocalOfferIds.removeValue(forKey: remoteCid) ?? offerId
-                    self.currentNegotiationIds[remoteCid] = completedOfferId
+                    // We just completed the offer identified by `offerId` (validated above).
+                    // Only clear the pending entry if it still refers to that same offer: a
+                    // renegotiation offer (e.g. a "pending-retry" ICE restart fired synchronously
+                    // from the STABLE signaling callback) can replace it with a newer offerId
+                    // before this async callback runs. Clobbering that newer id would make us
+                    // drop the new offer's answer as a "stale offerId" and stall in Reconnecting.
+                    if self.pendingLocalOfferIds[remoteCid] == offerId {
+                        self.pendingLocalOfferIds.removeValue(forKey: remoteCid)
+                    }
+                    self.currentNegotiationIds[remoteCid] = offerId
                     self.ignoredOfferIds.removeValue(forKey: remoteCid)
                     self.clearOfferTimeout(remoteCid: remoteCid)
                     slot.clearPendingIceRestart()
-                    self.flushPendingRemoteIce(remoteCid: remoteCid, offerId: completedOfferId, slot: slot)
+                    self.flushPendingRemoteIce(remoteCid: remoteCid, offerId: offerId, slot: slot)
                     self.updateAggregatePeerState()
                     self.onConnectionStatusUpdate()
                 } else if self.shouldIOffer(remoteCid: remoteCid) {

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -559,20 +559,23 @@ final class PeerNegotiationEngine {
                 self.settingRemoteAnswerCids.remove(remoteCid)
                 guard let slot else { return }
                 if success {
-                    // We just completed the offer identified by `offerId` (validated above).
-                    // Only clear the pending entry if it still refers to that same offer: a
-                    // renegotiation offer (e.g. a "pending-retry" ICE restart fired synchronously
-                    // from the STABLE signaling callback) can replace it with a newer offerId
-                    // before this async callback runs. Clobbering that newer id would make us
-                    // drop the new offer's answer as a "stale offerId" and stall in Reconnecting.
-                    if self.pendingLocalOfferIds[remoteCid] == offerId {
+                    // The offer this answer completes is whatever was pending when we validated
+                    // it above; `pendingOfferId` also covers the legacy/no-offerId path, where
+                    // `offerId` is the sentinel rather than our real local id.
+                    let completedOfferId = pendingOfferId ?? offerId
+                    // Finalize negotiation state only while the slot's pending offer is still the
+                    // one we completed. A renegotiation offer (e.g. a "pending-retry" ICE restart
+                    // from the STABLE signaling callback) can replace it during this async
+                    // setRemoteDescription; finalizing then would clobber the newer offer's id and
+                    // cancel its per-peer offer-timeout / pending-retry.
+                    if self.pendingLocalOfferIds[remoteCid] == completedOfferId {
                         self.pendingLocalOfferIds.removeValue(forKey: remoteCid)
+                        self.currentNegotiationIds[remoteCid] = completedOfferId
+                        self.ignoredOfferIds.removeValue(forKey: remoteCid)
+                        self.clearOfferTimeout(remoteCid: remoteCid)
+                        slot.clearPendingIceRestart()
                     }
-                    self.currentNegotiationIds[remoteCid] = offerId
-                    self.ignoredOfferIds.removeValue(forKey: remoteCid)
-                    self.clearOfferTimeout(remoteCid: remoteCid)
-                    slot.clearPendingIceRestart()
-                    self.flushPendingRemoteIce(remoteCid: remoteCid, offerId: offerId, slot: slot)
+                    self.flushPendingRemoteIce(remoteCid: remoteCid, offerId: completedOfferId, slot: slot)
                     self.updateAggregatePeerState()
                     self.onConnectionStatusUpdate()
                 } else if self.shouldIOffer(remoteCid: remoteCid) {

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -168,6 +168,11 @@ public final class SerenadaSession: ObservableObject {
     private var routeInputAvailable = true
     private var sessionActivated = false
     private var localMediaReadyForNegotiation = false
+    // Latched true once the call's media has connected at least once. The network monitor
+    // below only restarts ICE for an established call: NWPathMonitor delivers the current
+    // path once at start(), and treating that initial callback as a network change would
+    // otherwise force a redundant renegotiation during the first offer (a "pending-retry").
+    private var hasEverConnectedPeer = false
     private let apiClient: SessionAPIClient
     private let clock: SessionClock
     private let config: SerenadaConfig
@@ -786,6 +791,7 @@ public final class SerenadaSession: ObservableObject {
 
         startCoordinatorTasks()
         localMediaReadyForNegotiation = false
+        hasEverConnectedPeer = false
         let videoCaptureSupported = !availableCameraModes.isEmpty
         let shouldEnableAudio = config.defaultAudioEnabled
         let shouldEnableVideo = videoCaptureSupported && config.defaultVideoEnabled
@@ -1873,6 +1879,7 @@ public final class SerenadaSession: ObservableObject {
             sendMessage: { [weak self] type, payload, to in self?.sendMessage(type: type, payload: payload, to: to) },
             onRemoteParticipantsChanged: { [weak self] in self?.refreshRemoteParticipants() },
             onAggregatePeerStateChanged: { [weak self] ice, conn, sig in
+                if conn == .connected { self?.hasEverConnectedPeer = true }
                 self?.commitSnapshot { _, d in d.iceConnectionState = ice; d.peerConnectionState = conn; d.rtcSignalingState = sig }
             },
             onConnectionStatusUpdate: { [weak self] in self?.connectionStatusTracker?.update() },
@@ -1929,7 +1936,11 @@ public final class SerenadaSession: ObservableObject {
             Task { @MainActor in
                 guard self.internalPhase == .inCall else { return }
                 if self.connectionStatusTracker?.isConnectionDegraded() == true { self.connectionStatusTracker?.update() }
-                if path.status == .satisfied { self.peerNegotiationEngine?.scheduleIceRestart(reason: "network-online", delayMs: 0) }
+                // Skip until the call has connected once; the initial NWPathMonitor callback
+                // at start() is the baseline network, not a handover (see hasEverConnectedPeer).
+                if path.status == .satisfied && self.hasEverConnectedPeer {
+                    self.peerNegotiationEngine?.scheduleIceRestart(reason: "network-online", delayMs: 0)
+                }
             }
         }
         pathMonitor.start(queue: pathMonitorQueue)

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -1005,13 +1005,16 @@ export class MediaEngine {
             peer.isSettingRemoteAnswerPending = true;
             await peer.pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp }));
             peer.isSettingRemoteAnswerPending = false;
-            const completedOfferId = peer.pendingLocalOfferId ?? offerId;
-            peer.pendingLocalOfferId = null;
-            peer.currentNegotiationId = completedOfferId;
+            // Only clear the pending offer we actually completed. The await above yields to
+            // the event loop, so a renegotiation offer (e.g. an ICE restart) can reassign
+            // pendingLocalOfferId before this runs; clobbering it would later drop that
+            // offer's answer as a "stale offerId" and stall renegotiation.
+            if (peer.pendingLocalOfferId === offerId) peer.pendingLocalOfferId = null;
+            peer.currentNegotiationId = offerId;
             peer.ignoredOfferId = null;
             if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
             peer.pendingIceRestart = false;
-            await this.flushPendingRemoteIce(peer, completedOfferId);
+            await this.flushPendingRemoteIce(peer, offerId);
         } catch (err) {
             const peer = this.peers.get(fromCid);
             if (peer) peer.isSettingRemoteAnswerPending = false;

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -994,27 +994,35 @@ export class MediaEngine {
         try {
             const peer = this.peers.get(fromCid);
             if (!peer) return;
+            // Snapshot the pending offer id before the await; it identifies the offer this
+            // answer completes (and covers the legacy/no-offerId path, where `offerId` is the
+            // sentinel rather than our real local id).
+            const pendingOfferId = peer.pendingLocalOfferId;
             if (peer.pc.signalingState !== 'have-local-offer') {
                 this.logger?.log('debug', 'WebRTC', `[${fromCid}] Dropping stale answer in ${peer.pc.signalingState}`);
                 return;
             }
-            if (offerId !== LEGACY_OFFER_ID && peer.pendingLocalOfferId !== offerId) {
+            if (offerId !== LEGACY_OFFER_ID && pendingOfferId !== offerId) {
                 this.logger?.log('debug', 'WebRTC', `[${fromCid}] Dropping answer for stale offerId=${offerId}`);
                 return;
             }
             peer.isSettingRemoteAnswerPending = true;
             await peer.pc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp }));
             peer.isSettingRemoteAnswerPending = false;
-            // Only clear the pending offer we actually completed. The await above yields to
-            // the event loop, so a renegotiation offer (e.g. an ICE restart) can reassign
-            // pendingLocalOfferId before this runs; clobbering it would later drop that
-            // offer's answer as a "stale offerId" and stall renegotiation.
-            if (peer.pendingLocalOfferId === offerId) peer.pendingLocalOfferId = null;
-            peer.currentNegotiationId = offerId;
-            peer.ignoredOfferId = null;
-            if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
-            peer.pendingIceRestart = false;
-            await this.flushPendingRemoteIce(peer, offerId);
+            const completedOfferId = pendingOfferId ?? offerId;
+            // Finalize negotiation state only while the pending offer is still the one we
+            // completed. The await above yields to the event loop, so a renegotiation offer
+            // (e.g. an ICE restart) can reassign pendingLocalOfferId; finalizing then would
+            // clobber the newer offer's id and cancel its offer-timeout / pending-retry,
+            // leaving it stuck in have-local-offer if its answer is lost.
+            if (peer.pendingLocalOfferId === completedOfferId) {
+                peer.pendingLocalOfferId = null;
+                peer.currentNegotiationId = completedOfferId;
+                peer.ignoredOfferId = null;
+                if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
+                peer.pendingIceRestart = false;
+            }
+            await this.flushPendingRemoteIce(peer, completedOfferId);
         } catch (err) {
             const peer = this.peers.get(fromCid);
             if (peer) peer.isSettingRemoteAnswerPending = false;


### PR DESCRIPTION
## Summary

Two test devices got stuck in **"Reconnecting"** on 1:1 video calls with Serenada 0.7.0. Two independent bugs in the new `PeerNegotiationEngine` flow combined so the call never connected. This fixes both, across Android, iOS, and web.

## Root cause

On call start the offerer sends its first offer, then a `pending-retry` ICE restart immediately fires a second offer. Two things go wrong:

1. **offerId clobber (commit 1).** The answer-success path cleared the pending local offerId unconditionally. The renegotiation offer reassigns that id before the first answer's `setRemoteDescription` callback runs, so the clear clobbers the *new* offer's id, and the new offer's answer is then dropped as a `stale offerId`. ICE tears down with no completed negotiation → permanent reconnect loop.
2. **spurious pending-retry (commit 2).** That second offer should never have fired. `registerNetworkCallback` (Android) / `NWPathMonitor.start()` (iOS) replay the current network as an initial `onAvailable` / `.satisfied` callback right after registration. The session treated that baseline as a handover and scheduled a `network-online` ICE restart mid-first-offer. Deferred while `HAVE_LOCAL_OFFER`, it replayed as `pending-retry` the instant the first answer landed.

Bug 1 made bug 2 fatal. With both fixed, the call connects with a single offer/answer.

## Fixes

- **Drop the offerId clobber** — only clear the pending entry when it still matches the offerId we completed. (`PeerNegotiationEngine.kt` / `.swift`, `MediaEngine.ts`)
- **Gate the `network-online` restart** behind a `hasEverConnectedPeer` latch (set on first `CONNECTED`, reset per call) so the registration-replay baseline can't trigger it. (`SerenadaSession.kt` / `.swift`)

Web needs only the first fix: `window 'online'` / `connection 'change'` fire on real transitions, not on registration, so it has no spurious startup restart.

## Verification

- **Android** — built locally, installed on two devices. Before: stuck Reconnecting. After fix 1 only: connects but with a wasteful extra renegotiation. After both: single offer/answer, both peers reach `CONNECTED`, **0 stale-offer drops, 0 ICE failures** across repeated calls.
- **Web** — `tsc --noEmit` clean; all **368 core tests pass** (incl. 23 `MediaEngine` tests).
- **iOS** — edits applied for parity but **not compiled or device-tested** in this environment. Please build + smoke a call before merge.

## Out of scope

Separate, pre-existing issue observed in the same logs: LAN-direct envelope sends fail and fall back to relay (adds latency, not a call blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
