### PR TITLE
v0.7.1: reconnect renegotiation-race fix + Frontline UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.7.1] — 2026-05-26
+
+### Fixed
+- Web, Android, iOS: 1:1 video calls no longer get stuck in
+  "Reconnecting" after a renegotiation. Two independent races were
+  fixed: (1) the answer-success path cleared the pending local
+  `offerId` unconditionally, so a renegotiation offer's id got
+  clobbered and its answer dropped as a stale offer — the SDK now
+  finalizes against the offer id captured before `setRemoteDescription`
+  and only while it is still pending; (2) on Android/iOS the network
+  callback replays the current network at registration, which the
+  session mistook for a handover and used to restart ICE mid-first-
+  offer — that path is now gated behind a `hasEverConnectedPeer` latch.
+
+### Changed
+- Android, iOS: Frontline call UX polish, including a remote video
+  fit (fill / fit) toggle in the Frontline call screen.
+
 ## [0.7.0] — 2026-05-18
 
 Milestone release: a dedicated Frontline call UI, pluggable audio

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.7.0`
-- `app.serenada:core:0.7.0`
-- `app.serenada:call-ui:0.7.0`
+- `app.serenada:libwebrtc-7827-universal:0.7.1`
+- `app.serenada:core:0.7.1`
+- `app.serenada:call-ui:0.7.1`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.7.0"
+                version = "0.7.1"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.7.0"
+val sdkVersion = "0.7.1"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.7.0"
+val sdkVersion = "0.7.1"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -39,7 +39,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.7.0"
+    public static let version = "0.7.1"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.7.0",
-        "@agatx/serenada-react-ui": "0.7.0",
+        "@agatx/serenada-core": "0.7.1",
+        "@agatx/serenada-react-ui": "0.7.1",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.7.0"
+        "@agatx/serenada-core": "0.7.1"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.7.0",
+        "@agatx/serenada-core": "^0.7.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.7.0",
-    "@agatx/serenada-react-ui": "0.7.0",
+    "@agatx/serenada-core": "0.7.1",
+    "@agatx/serenada-react-ui": "0.7.1",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.7.0';
+export const SERENADA_CORE_VERSION = '0.7.1';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.7.0",
+    "@agatx/serenada-core": "^0.7.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.7.0"
+    "@agatx/serenada-core": "0.7.1"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.7.0")
-    implementation("app.serenada:call-ui:0.7.0")
+    implementation("app.serenada:core:0.7.1")
+    implementation("app.serenada:call-ui:0.7.1")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.7.0 @agatx/serenada-react-ui@0.7.0 lucide-react
+npm install @agatx/serenada-core@0.7.1 @agatx/serenada-react-ui@0.7.1 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.7.0"
+        "@agatx/serenada-core": "0.7.1"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.7.0",
+        "@agatx/serenada-core": "^0.7.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Patch bump (0.7.0 → **0.7.1**) rolling up the two commits since 0.7.0. Version-bump + docs only — the fixes themselves already merged via #115/#116.

### What 0.7.1 captures

**Fixed**
- **1:1 video calls stuck in "Reconnecting"** (#116) — two renegotiation races, fixed on web, Android, iOS:
  - `offerId` clobber: the answer-success path cleared the pending local `offerId` unconditionally, so a renegotiation offer's id got clobbered and its answer dropped as stale. Now finalizes against the id captured before `setRemoteDescription`, only while still pending.
  - Spurious network-online ICE restart: the network callback replays the current network at registration; the session mistook that baseline for a handover and restarted ICE mid-first-offer. Now gated behind a `hasEverConnectedPeer` latch.

**Changed**
- **Frontline call UX polish** (#115) — including a remote video fit (fill / fit) toggle in the Frontline call screen (Android + iOS).

### Version bump scope (14 files)

- 8 SDK sources tracked by `check-version-parity.mjs` → `OK: All 8 version sources match at 0.7.1.`
- `client/package.json` + `client/package-lock.json`
- `samples/web/package-lock.json`
- `docs/sdk/sdk-integration-{web,android}.md`
- `client-android/README.md` Maven coordinates
- `CHANGELOG.md`

Host app versions (Android 0.4.x, iOS 0.4.x) left untouched — not part of this bump.

### Tests

Bump is version-string-only on top of CI-green main (#115/#116 passed their own checks at merge). The publish workflow re-runs web `check-version-parity` + tests + build before publishing, so npm release is gated regardless.

## After merge

Tag `web-release-0.7.1` at the merge commit to publish both packages to npm via OIDC Trusted Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)