### PR TITLE
[codex] Add mobile system picture in picture

### DIFF
--- a/client-android/app/src/main/AndroidManifest.xml
+++ b/client-android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,9 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:supportsPictureInPicture="true"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/client-android/app/src/main/java/app/serenada/android/ui/SerenadaAppRoot.kt
+++ b/client-android/app/src/main/java/app/serenada/android/ui/SerenadaAppRoot.kt
@@ -355,6 +355,7 @@ fun SerenadaAppRoot(
                                 inviteControlsEnabled = true,
                                 debugOverlayEnabled = true,
                                 snapshotEnabled = true,
+                                systemPictureInPictureEnabled = true,
                             ),
                             strings = buildSerenadaCallStrings(context),
                             onSnapshotCaptured = { result ->

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -260,13 +260,8 @@ internal fun CallScreen(
             )
         }
 
-    val isCallChromeVisible = !isSystemPictureInPicture
-    val areControlsActuallyVisible = areControlsVisible && isCallChromeVisible
-
     val toggleControlsVisibility: () -> Unit = {
-        if (isSystemPictureInPicture) {
-            Unit
-        } else if (areControlsVisible) {
+        if (areControlsVisible) {
             areControlsVisible = false
             wereControlsLastHiddenByAutoHide = false
         } else {
@@ -280,7 +275,7 @@ internal fun CallScreen(
 
     // Auto-hide controls
     LaunchedEffect(areControlsVisible, uiState.phase, isControlsAutoHideEnabled) {
-        if (areControlsActuallyVisible && uiState.phase == CallPhase.InCall && isControlsAutoHideEnabled) {
+        if (areControlsVisible && uiState.phase == CallPhase.InCall && isControlsAutoHideEnabled) {
             delay(8000)
             wereControlsLastHiddenByAutoHide = true
             areControlsVisible = false
@@ -308,11 +303,15 @@ internal fun CallScreen(
     SerenadaTheme(theme) {
       androidx.compose.runtime.CompositionLocalProvider(LocalAvatarCache provides avatarCache) {
         if (isSystemPictureInPicture) {
+            val systemPipRemoteCid =
+                pinnedParticipantId?.takeIf { pinned ->
+                    uiState.remoteParticipants.any { participant -> participant.cid == pinned }
+                } ?: uiState.remoteParticipants.firstOrNull()?.cid
             val feed =
                 selectSystemPictureInPictureFeed(
                     localIsLarge = effectiveLocalLarge,
                     localVideoEnabled = uiState.localVideoEnabled,
-                    hasRemote = uiState.remoteParticipants.isNotEmpty(),
+                    remoteCid = systemPipRemoteCid,
                 )
             SystemPictureInPictureContent(
                 uiState = uiState,
@@ -322,8 +321,8 @@ internal fun CallScreen(
                 remoteContentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
                 attachLocalSink = attachLocalSink,
                 detachLocalSink = detachLocalSink,
-                attachRemoteSink = attachRemoteSink,
-                detachRemoteSink = detachRemoteSink,
+                attachRemoteSinkForCid = attachRemoteSinkForCid,
+                detachRemoteSinkForCid = detachRemoteSinkForCid,
             )
         } else {
         BoxWithConstraints(
@@ -353,7 +352,7 @@ internal fun CallScreen(
                         uiState.connectionState == "CONNECTED")
         val animatedPipBottomPadding by
         animateDpAsState(
-            targetValue = if (areControlsActuallyVisible) 130.dp else 48.dp,
+            targetValue = if (areControlsVisible) 130.dp else 48.dp,
             animationSpec = tween(durationMillis = controlsAnimationDuration),
             label = "pip_bottom_padding"
         )
@@ -366,7 +365,7 @@ internal fun CallScreen(
         val pipInnerCornerRadius =
             if (pipCornerRadius > pipContentPadding) pipCornerRadius - pipContentPadding else 0.dp
         val mainVideoBottomPadding by animateDpAsState(
-            targetValue = if (areControlsActuallyVisible) 134.dp else 0.dp,
+            targetValue = if (areControlsVisible) 134.dp else 0.dp,
             animationSpec = tween(durationMillis = controlsAnimationDuration),
             label = "main_video_bottom_padding"
         )
@@ -637,7 +636,7 @@ internal fun CallScreen(
         }
 
         // Debug tap target — only when debug overlay is enabled via config
-        if (config.debugOverlayEnabled && isCallChromeVisible) {
+        if (config.debugOverlayEnabled) {
             Box(
                 modifier =
                     Modifier.align(Alignment.TopStart)
@@ -674,7 +673,7 @@ internal fun CallScreen(
         }
 
         // Waiting State Overlay
-        if (uiState.phase == CallPhase.Waiting && !effectiveLocalLarge && isCallChromeVisible) {
+        if (uiState.phase == CallPhase.Waiting && !effectiveLocalLarge) {
             WaitingOverlay(
                 roomShareUrl = roomShareUrl,
                 onInviteToRoom = onInviteToRoom,
@@ -686,7 +685,7 @@ internal fun CallScreen(
 
         // Reconnecting Indicator
         AnimatedVisibility(
-            visible = showReconnectingBadge && isCallChromeVisible,
+            visible = showReconnectingBadge,
             enter = fadeIn(),
             exit = fadeOut(),
             modifier = Modifier.align(Alignment.TopCenter).padding(top = 64.dp)
@@ -745,9 +744,9 @@ internal fun CallScreen(
         }
         val snapshotHandler = onSnapshotRequested
         val showSnapshotButton =
-            snapshotSource != null && snapshotHandler != null && areControlsActuallyVisible
+            snapshotSource != null && snapshotHandler != null && areControlsVisible
 
-        if (isCallChromeVisible && (showFlashButton || showRemoteFitButton || showSnapshotButton)) {
+        if (showFlashButton || showRemoteFitButton || showSnapshotButton) {
             val configuration = androidx.compose.ui.platform.LocalConfiguration.current
             val isLandscape = configuration.orientation ==
                 android.content.res.Configuration.ORIENTATION_LANDSCAPE
@@ -797,18 +796,22 @@ internal fun CallScreen(
             }
 
             val snapshotIcon: @Composable () -> Unit = {
-                if (showSnapshotButton && snapshotHandler != null && snapshotSource != null) {
-                    IconButton(
-                        onClick = { snapshotHandler(snapshotSource) },
-                        modifier = Modifier.size(44.dp)
-                            .background(Color.Black.copy(alpha = 0.4f), CircleShape)
-                            .testTag("call.takeSnapshot")
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.PhotoCamera,
-                            contentDescription = resolveString(SerenadaString.CallTakeSnapshot, strings),
-                            tint = Color.White
-                        )
+                if (areControlsVisible) {
+                    snapshotHandler?.let { handler ->
+                        snapshotSource?.let { source ->
+                            IconButton(
+                                onClick = { handler(source) },
+                                modifier = Modifier.size(44.dp)
+                                    .background(Color.Black.copy(alpha = 0.4f), CircleShape)
+                                    .testTag("call.takeSnapshot")
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.PhotoCamera,
+                                    contentDescription = resolveString(SerenadaString.CallTakeSnapshot, strings),
+                                    tint = Color.White
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -838,7 +841,7 @@ internal fun CallScreen(
 
         // Controls Bar
         AnimatedVisibility(
-            visible = areControlsActuallyVisible,
+            visible = areControlsVisible,
             enter =
                 fadeIn(animationSpec = tween(durationMillis = controlsAnimationDuration)) +
                         slideInVertically(
@@ -1540,7 +1543,7 @@ private fun MultiPartyStage(
                 val topChromePx = with(density) { 20.dp.toPx() }
                 val bottomChromePx = with(density) { (bottomPadding + 4.dp).toPx() }
 
-                if (useComputedLayout && localCid != null) {
+                if (useComputedLayout) {
                 // Focus/content mode: use computeLayout for primary + filmstrip rendering
                 val contentSource = if (hasLocalContent) {
                     val type = when {

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -309,12 +309,11 @@ internal fun CallScreen(
       androidx.compose.runtime.CompositionLocalProvider(LocalAvatarCache provides avatarCache) {
         if (isSystemPictureInPicture) {
             val feed =
-                when {
-                    effectiveLocalLarge && uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
-                    uiState.remoteParticipants.firstOrNull() != null -> SystemPictureInPictureFeed.Remote
-                    uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
-                    else -> SystemPictureInPictureFeed.Remote
-                }
+                selectSystemPictureInPictureFeed(
+                    localIsLarge = effectiveLocalLarge,
+                    localVideoEnabled = uiState.localVideoEnabled,
+                    hasRemote = uiState.remoteParticipants.isNotEmpty(),
+                )
             SystemPictureInPictureContent(
                 uiState = uiState,
                 feed = feed,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/CallScreen.kt
@@ -119,6 +119,7 @@ internal fun CallScreen(
     config: SerenadaCallFlowConfig = SerenadaCallFlowConfig(),
     theme: SerenadaCallFlowTheme = SerenadaCallFlowTheme(),
     strings: Map<SerenadaString, String>? = null,
+    isSystemPictureInPicture: Boolean = false,
     onToggleAudio: () -> Unit,
     onToggleVideo: () -> Unit,
     onFlipCamera: () -> Unit,
@@ -259,8 +260,13 @@ internal fun CallScreen(
             )
         }
 
+    val isCallChromeVisible = !isSystemPictureInPicture
+    val areControlsActuallyVisible = areControlsVisible && isCallChromeVisible
+
     val toggleControlsVisibility: () -> Unit = {
-        if (areControlsVisible) {
+        if (isSystemPictureInPicture) {
+            Unit
+        } else if (areControlsVisible) {
             areControlsVisible = false
             wereControlsLastHiddenByAutoHide = false
         } else {
@@ -274,7 +280,7 @@ internal fun CallScreen(
 
     // Auto-hide controls
     LaunchedEffect(areControlsVisible, uiState.phase, isControlsAutoHideEnabled) {
-        if (areControlsVisible && uiState.phase == CallPhase.InCall && isControlsAutoHideEnabled) {
+        if (areControlsActuallyVisible && uiState.phase == CallPhase.InCall && isControlsAutoHideEnabled) {
             delay(8000)
             wereControlsLastHiddenByAutoHide = true
             areControlsVisible = false
@@ -294,12 +300,33 @@ internal fun CallScreen(
     // remote-as-large so the user doesn't see a giant "Camera off" placeholder.
     // The user's swap preference (`isLocalLarge`) is preserved and reapplied
     // automatically when video comes back on.
-    val effectiveLocalLarge = isLocalLarge && uiState.localVideoEnabled
+    val effectiveLocalLarge =
+        isLocalLarge && uiState.localVideoEnabled
 
     val avatarCache = rememberAvatarCache(config.avatarProvider)
 
     SerenadaTheme(theme) {
       androidx.compose.runtime.CompositionLocalProvider(LocalAvatarCache provides avatarCache) {
+        if (isSystemPictureInPicture) {
+            val feed =
+                when {
+                    effectiveLocalLarge && uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
+                    uiState.remoteParticipants.firstOrNull() != null -> SystemPictureInPictureFeed.Remote
+                    uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
+                    else -> SystemPictureInPictureFeed.Remote
+                }
+            SystemPictureInPictureContent(
+                uiState = uiState,
+                feed = feed,
+                eglContext = eglContext,
+                localContentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop,
+                remoteContentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
+                attachLocalSink = attachLocalSink,
+                detachLocalSink = detachLocalSink,
+                attachRemoteSink = attachRemoteSink,
+                detachRemoteSink = detachRemoteSink,
+            )
+        } else {
         BoxWithConstraints(
             modifier =
                 Modifier.fillMaxSize().background(theme.backgroundColor)
@@ -327,7 +354,7 @@ internal fun CallScreen(
                         uiState.connectionState == "CONNECTED")
         val animatedPipBottomPadding by
         animateDpAsState(
-            targetValue = if (areControlsVisible) 130.dp else 48.dp,
+            targetValue = if (areControlsActuallyVisible) 130.dp else 48.dp,
             animationSpec = tween(durationMillis = controlsAnimationDuration),
             label = "pip_bottom_padding"
         )
@@ -340,7 +367,7 @@ internal fun CallScreen(
         val pipInnerCornerRadius =
             if (pipCornerRadius > pipContentPadding) pipCornerRadius - pipContentPadding else 0.dp
         val mainVideoBottomPadding by animateDpAsState(
-            targetValue = if (areControlsVisible) 134.dp else 0.dp,
+            targetValue = if (areControlsActuallyVisible) 134.dp else 0.dp,
             animationSpec = tween(durationMillis = controlsAnimationDuration),
             label = "main_video_bottom_padding"
         )
@@ -611,7 +638,7 @@ internal fun CallScreen(
         }
 
         // Debug tap target — only when debug overlay is enabled via config
-        if (config.debugOverlayEnabled) {
+        if (config.debugOverlayEnabled && isCallChromeVisible) {
             Box(
                 modifier =
                     Modifier.align(Alignment.TopStart)
@@ -648,7 +675,7 @@ internal fun CallScreen(
         }
 
         // Waiting State Overlay
-        if (uiState.phase == CallPhase.Waiting && !effectiveLocalLarge) {
+        if (uiState.phase == CallPhase.Waiting && !effectiveLocalLarge && isCallChromeVisible) {
             WaitingOverlay(
                 roomShareUrl = roomShareUrl,
                 onInviteToRoom = onInviteToRoom,
@@ -660,7 +687,7 @@ internal fun CallScreen(
 
         // Reconnecting Indicator
         AnimatedVisibility(
-            visible = showReconnectingBadge,
+            visible = showReconnectingBadge && isCallChromeVisible,
             enter = fadeIn(),
             exit = fadeOut(),
             modifier = Modifier.align(Alignment.TopCenter).padding(top = 64.dp)
@@ -719,9 +746,9 @@ internal fun CallScreen(
         }
         val snapshotHandler = onSnapshotRequested
         val showSnapshotButton =
-            snapshotSource != null && snapshotHandler != null && areControlsVisible
+            snapshotSource != null && snapshotHandler != null && areControlsActuallyVisible
 
-        if (showFlashButton || showRemoteFitButton || showSnapshotButton) {
+        if (isCallChromeVisible && (showFlashButton || showRemoteFitButton || showSnapshotButton)) {
             val configuration = androidx.compose.ui.platform.LocalConfiguration.current
             val isLandscape = configuration.orientation ==
                 android.content.res.Configuration.ORIENTATION_LANDSCAPE
@@ -812,7 +839,7 @@ internal fun CallScreen(
 
         // Controls Bar
         AnimatedVisibility(
-            visible = areControlsVisible,
+            visible = areControlsActuallyVisible,
             enter =
                 fadeIn(animationSpec = tween(durationMillis = controlsAnimationDuration)) +
                         slideInVertically(
@@ -921,6 +948,7 @@ internal fun CallScreen(
             }
         }
 
+        }
         }
       }
     }

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -444,12 +444,11 @@ internal fun FrontlineCallScreen(
                 if (isSystemPictureInPicture) {
                     SystemPictureInPictureContent(
                         uiState = uiState,
-                        feed = when {
-                            largeFeed == FrontlineFeed.Local && uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
-                            remote != null -> SystemPictureInPictureFeed.Remote
-                            uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
-                            else -> SystemPictureInPictureFeed.Remote
-                        },
+                        feed = selectSystemPictureInPictureFeed(
+                            localIsLarge = largeFeed == FrontlineFeed.Local,
+                            localVideoEnabled = uiState.localVideoEnabled,
+                            hasRemote = remote != null,
+                        ),
                         eglContext = eglContext,
                         localContentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop,
                         remoteContentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -442,20 +442,35 @@ internal fun FrontlineCallScreen(
                 }
 
                 if (isSystemPictureInPicture) {
+                    val remoteCids = uiState.remoteParticipants.map { it.cid }.toSet()
+                    val systemPipRemoteCid =
+                        listOf(pinnedSpotlightId, selectedSpotlightId, lastVideoStartedParticipantId)
+                            .firstNotNullOfOrNull { spotlightId ->
+                                when {
+                                    spotlightId == null -> null
+                                    spotlightId in remoteCids -> spotlightId
+                                    spotlightId.isFrontlineContentSpotlightId() -> {
+                                        spotlightId
+                                            .removePrefix(FRONTLINE_CONTENT_SPOTLIGHT_PREFIX)
+                                            .takeIf { it in remoteCids }
+                                    }
+                                    else -> null
+                                }
+                            } ?: remote?.cid
                     SystemPictureInPictureContent(
                         uiState = uiState,
                         feed = selectSystemPictureInPictureFeed(
                             localIsLarge = largeFeed == FrontlineFeed.Local,
                             localVideoEnabled = uiState.localVideoEnabled,
-                            hasRemote = remote != null,
+                            remoteCid = systemPipRemoteCid,
                         ),
                         eglContext = eglContext,
                         localContentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop,
                         remoteContentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
                         attachLocalSink = attachLocalSink,
                         detachLocalSink = detachLocalSink,
-                        attachRemoteSink = attachRemoteSink,
-                        detachRemoteSink = detachRemoteSink,
+                        attachRemoteSinkForCid = attachRemoteSinkForCid,
+                        detachRemoteSinkForCid = detachRemoteSinkForCid,
                     )
                 } else if (isLandscape) {
                     Row(Modifier.fillMaxSize()) {

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -154,6 +154,7 @@ internal fun FrontlineCallScreen(
     strings: Map<SerenadaString, String>?,
     availableAudioDevices: List<AudioDevice>,
     currentAudioDevice: AudioDevice?,
+    isSystemPictureInPicture: Boolean = false,
     onToggleAudio: () -> Unit,
     onToggleVideo: () -> Unit,
     onFlipCamera: () -> Unit,
@@ -259,6 +260,7 @@ internal fun FrontlineCallScreen(
         }
     val largeFeed = if (localIsLarge) FrontlineFeed.Local else FrontlineFeed.Remote
     val pipFeed = when {
+        isSystemPictureInPicture -> null
         !uiState.localVideoEnabled && !remoteVideoEnabled -> null
         largeFeed == FrontlineFeed.Local -> FrontlineFeed.Remote
         else -> FrontlineFeed.Local
@@ -290,6 +292,7 @@ internal fun FrontlineCallScreen(
     val showAudioRouteControl = currentAudioRoute != null || audioRouteOptions.isNotEmpty()
     val showMoreButton =
         isCallSurfacePhase &&
+            !isSystemPictureInPicture &&
             (showAudioRouteControl || config.screenSharingEnabled || config.inviteControlsEnabled)
     val moreOpensAudioRouteDirectly =
         frontlineMoreMenuOpensAudioRouteDirectly(
@@ -322,6 +325,13 @@ internal fun FrontlineCallScreen(
     val showReconnectingBadge =
         uiState.phase == CallPhase.InCall &&
             uiState.connectionStatus != ConnectionStatus.Connected
+    LaunchedEffect(isSystemPictureInPicture) {
+        if (isSystemPictureInPicture) {
+            isMoreSheetVisible = false
+            isAudioRouteSheetVisible = false
+            showDebug = false
+        }
+    }
     LaunchedEffect(activeContentSpotlightId) {
         if (activeContentSpotlightId != null) {
             selectedSpotlightId = activeContentSpotlightId
@@ -431,7 +441,24 @@ internal fun FrontlineCallScreen(
                     }
                 }
 
-                if (isLandscape) {
+                if (isSystemPictureInPicture) {
+                    SystemPictureInPictureContent(
+                        uiState = uiState,
+                        feed = when {
+                            largeFeed == FrontlineFeed.Local && uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
+                            remote != null -> SystemPictureInPictureFeed.Remote
+                            uiState.localVideoEnabled -> SystemPictureInPictureFeed.Local
+                            else -> SystemPictureInPictureFeed.Remote
+                        },
+                        eglContext = eglContext,
+                        localContentScale = if (uiState.isScreenSharing) ContentScale.Fit else ContentScale.Crop,
+                        remoteContentScale = if (remoteVideoFitCover) ContentScale.Crop else ContentScale.Fit,
+                        attachLocalSink = attachLocalSink,
+                        detachLocalSink = detachLocalSink,
+                        attachRemoteSink = attachRemoteSink,
+                        detachRemoteSink = detachRemoteSink,
+                    )
+                } else if (isLandscape) {
                     Row(Modifier.fillMaxSize()) {
                         FrontlineContentArea(
                             uiState = uiState,
@@ -562,7 +589,7 @@ internal fun FrontlineCallScreen(
                 }
 
                 AnimatedVisibility(
-                    visible = showReconnectingBadge,
+                    visible = showReconnectingBadge && !isSystemPictureInPicture,
                     enter = fadeIn(),
                     exit = fadeOut(),
                     modifier = Modifier
@@ -596,7 +623,7 @@ internal fun FrontlineCallScreen(
                     }
                 }
 
-                if (showSnapshotFlash) {
+                if (showSnapshotFlash && !isSystemPictureInPicture) {
                     LaunchedEffect(Unit) {
                         delay(220)
                         showSnapshotFlash = false
@@ -609,7 +636,7 @@ internal fun FrontlineCallScreen(
                     )
                 }
 
-                if (config.debugOverlayEnabled) {
+                if (config.debugOverlayEnabled && !isSystemPictureInPicture) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopStart)

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -375,8 +375,8 @@ fun SerenadaCallFlow(
                     )
             }
 
-    if (config.uiVariant == SerenadaCallUiVariant.Frontline) {
-        androidx.compose.foundation.layout.Box(modifier = systemPipModifier) {
+    androidx.compose.foundation.layout.Box(modifier = systemPipModifier) {
+        if (config.uiVariant == SerenadaCallUiVariant.Frontline) {
             FrontlineCallScreen(
                 uiState = uiState,
                 roomShareUrl = roomShareUrl,
@@ -410,9 +410,7 @@ fun SerenadaCallFlow(
                 onRemoteVideoFitChanged = onRemoteVideoFitChanged,
                 onSnapshotRequested = onSnapshotRequested,
             )
-        }
-    } else {
-        androidx.compose.foundation.layout.Box(modifier = systemPipModifier) {
+        } else {
             CallScreen(
                 uiState = uiState,
                 roomShareUrl = roomShareUrl,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -2,6 +2,7 @@ package app.serenada.callui
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Rect
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,9 +13,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
 import app.serenada.core.CallDiagnostics
 import app.serenada.core.CallState
 import app.serenada.core.SerenadaConfig
@@ -32,6 +35,7 @@ import org.webrtc.EglBase
 import org.webrtc.RendererCommon
 import org.webrtc.SurfaceViewRenderer
 import org.webrtc.VideoSink
+import kotlin.math.roundToInt
 
 private val FRONTLINE_CAMERA_MODES =
     listOf(LocalCameraMode.WORLD, LocalCameraMode.SELFIE, LocalCameraMode.COMPOSITE)
@@ -351,71 +355,97 @@ fun SerenadaCallFlow(
     onSnapshotRequested: ((SnapshotSource) -> Unit)? = null,
     onDismiss: () -> Unit = {},
 ) {
+    var systemPipSourceRect by remember { mutableStateOf<Rect?>(null) }
+    val isSystemPictureInPicture =
+        rememberSystemPictureInPictureMode(
+            enabled = config.systemPictureInPictureEnabled,
+            uiState = uiState,
+            sourceRect = systemPipSourceRect,
+        )
+    val systemPipModifier =
+        androidx.compose.ui.Modifier
+            .onGloballyPositioned { coordinates ->
+                val bounds = coordinates.boundsInWindow()
+                systemPipSourceRect =
+                    Rect(
+                        bounds.left.roundToInt(),
+                        bounds.top.roundToInt(),
+                        bounds.right.roundToInt(),
+                        bounds.bottom.roundToInt(),
+                    )
+            }
+
     if (config.uiVariant == SerenadaCallUiVariant.Frontline) {
-        FrontlineCallScreen(
-            uiState = uiState,
-            roomShareUrl = roomShareUrl,
-            eglContext = eglContext,
-            config = config,
-            theme = theme,
-            strings = strings,
-            availableAudioDevices = availableAudioDevices,
-            currentAudioDevice = currentAudioDevice,
-            onToggleAudio = onToggleAudio,
-            onToggleVideo = onToggleVideo,
-            onFlipCamera = onFlipCamera,
-            onToggleFlashlight = onToggleFlashlight,
-            onLocalPinchZoom = onLocalPinchZoom,
-            onEndCall = onEndCall,
-            onSelectAudioDevice = onSelectAudioDevice,
-            onShareLink = onShareLink,
-            onInviteToRoom = onInviteToRoom,
-            onStartScreenShare = onStartScreenShare,
-            onStopScreenShare = onStopScreenShare,
-            attachLocalRenderer = attachLocalRenderer,
-            detachLocalRenderer = detachLocalRenderer,
-            attachLocalSink = attachLocalSink,
-            detachLocalSink = detachLocalSink,
-            attachRemoteSinkForCid = attachRemoteSinkForCid,
-            detachRemoteSinkForCid = detachRemoteSinkForCid,
-            attachRemoteSink = attachRemoteSink,
-            detachRemoteSink = detachRemoteSink,
-            initialRemoteVideoFitCover = initialRemoteVideoFitCover,
-            onRemoteVideoFitChanged = onRemoteVideoFitChanged,
-            onSnapshotRequested = onSnapshotRequested,
-        )
+        androidx.compose.foundation.layout.Box(modifier = systemPipModifier) {
+            FrontlineCallScreen(
+                uiState = uiState,
+                roomShareUrl = roomShareUrl,
+                eglContext = eglContext,
+                config = config,
+                theme = theme,
+                strings = strings,
+                availableAudioDevices = availableAudioDevices,
+                currentAudioDevice = currentAudioDevice,
+                isSystemPictureInPicture = isSystemPictureInPicture,
+                onToggleAudio = onToggleAudio,
+                onToggleVideo = onToggleVideo,
+                onFlipCamera = onFlipCamera,
+                onToggleFlashlight = onToggleFlashlight,
+                onLocalPinchZoom = onLocalPinchZoom,
+                onEndCall = onEndCall,
+                onSelectAudioDevice = onSelectAudioDevice,
+                onShareLink = onShareLink,
+                onInviteToRoom = onInviteToRoom,
+                onStartScreenShare = onStartScreenShare,
+                onStopScreenShare = onStopScreenShare,
+                attachLocalRenderer = attachLocalRenderer,
+                detachLocalRenderer = detachLocalRenderer,
+                attachLocalSink = attachLocalSink,
+                detachLocalSink = detachLocalSink,
+                attachRemoteSinkForCid = attachRemoteSinkForCid,
+                detachRemoteSinkForCid = detachRemoteSinkForCid,
+                attachRemoteSink = attachRemoteSink,
+                detachRemoteSink = detachRemoteSink,
+                initialRemoteVideoFitCover = initialRemoteVideoFitCover,
+                onRemoteVideoFitChanged = onRemoteVideoFitChanged,
+                onSnapshotRequested = onSnapshotRequested,
+            )
+        }
     } else {
-        CallScreen(
-            uiState = uiState,
-            roomShareUrl = roomShareUrl,
-            eglContext = eglContext,
-            initialRemoteVideoFitCover = initialRemoteVideoFitCover,
-            config = config,
-            theme = theme,
-            strings = strings,
-            onToggleAudio = onToggleAudio,
-            onToggleVideo = onToggleVideo,
-            onFlipCamera = onFlipCamera,
-            onToggleFlashlight = onToggleFlashlight,
-            onLocalPinchZoom = onLocalPinchZoom,
-            onEndCall = onEndCall,
-            onShareLink = onShareLink,
-            onInviteToRoom = onInviteToRoom,
-            onRemoteVideoFitChanged = onRemoteVideoFitChanged,
-            onStartScreenShare = onStartScreenShare,
-            onStopScreenShare = onStopScreenShare,
-            attachLocalRenderer = attachLocalRenderer,
-            detachLocalRenderer = detachLocalRenderer,
-            attachLocalSink = attachLocalSink,
-            detachLocalSink = detachLocalSink,
-            attachRemoteRenderer = attachRemoteRenderer,
-            detachRemoteRenderer = detachRemoteRenderer,
-            attachRemoteSinkForCid = attachRemoteSinkForCid,
-            detachRemoteSinkForCid = detachRemoteSinkForCid,
-            attachRemoteSink = attachRemoteSink,
-            detachRemoteSink = detachRemoteSink,
-            onSnapshotRequested = onSnapshotRequested,
-        )
+        androidx.compose.foundation.layout.Box(modifier = systemPipModifier) {
+            CallScreen(
+                uiState = uiState,
+                roomShareUrl = roomShareUrl,
+                eglContext = eglContext,
+                initialRemoteVideoFitCover = initialRemoteVideoFitCover,
+                config = config,
+                theme = theme,
+                strings = strings,
+                isSystemPictureInPicture = isSystemPictureInPicture,
+                onToggleAudio = onToggleAudio,
+                onToggleVideo = onToggleVideo,
+                onFlipCamera = onFlipCamera,
+                onToggleFlashlight = onToggleFlashlight,
+                onLocalPinchZoom = onLocalPinchZoom,
+                onEndCall = onEndCall,
+                onShareLink = onShareLink,
+                onInviteToRoom = onInviteToRoom,
+                onRemoteVideoFitChanged = onRemoteVideoFitChanged,
+                onStartScreenShare = onStartScreenShare,
+                onStopScreenShare = onStopScreenShare,
+                attachLocalRenderer = attachLocalRenderer,
+                detachLocalRenderer = detachLocalRenderer,
+                attachLocalSink = attachLocalSink,
+                detachLocalSink = detachLocalSink,
+                attachRemoteRenderer = attachRemoteRenderer,
+                detachRemoteRenderer = detachRemoteRenderer,
+                attachRemoteSinkForCid = attachRemoteSinkForCid,
+                detachRemoteSinkForCid = detachRemoteSinkForCid,
+                attachRemoteSink = attachRemoteSink,
+                detachRemoteSink = detachRemoteSink,
+                onSnapshotRequested = onSnapshotRequested,
+            )
+        }
     }
 }
 

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -361,6 +361,7 @@ fun SerenadaCallFlow(
             enabled = config.systemPictureInPictureEnabled,
             uiState = uiState,
             sourceRect = systemPipSourceRect,
+            onPictureInPictureDismissRequested = onDismiss,
         )
     val systemPipModifier =
         androidx.compose.ui.Modifier

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlowConfig.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlowConfig.kt
@@ -40,4 +40,14 @@ data class SerenadaCallFlowConfig(
      * to the `SerenadaConfig` used to build the session.
      */
     val videoEnabled: Boolean = true,
+    /**
+     * Enables Android system Picture-in-Picture while a call is active.
+     *
+     * Host apps must also mark their call activity with
+     * `android:supportsPictureInPicture="true"` and appropriate
+     * `android:configChanges` entries. When enabled, the call UI configures
+     * the host activity's PiP params, auto-enters PiP on Home/gesture leave
+     * where supported, and shows only the active video/avatar surface.
+     */
+    val systemPictureInPictureEnabled: Boolean = false,
 )

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
@@ -44,9 +44,10 @@ import kotlin.math.roundToInt
 import org.webrtc.EglBase
 import org.webrtc.VideoSink
 
-internal enum class SystemPictureInPictureFeed {
-    Local,
-    Remote,
+internal sealed interface SystemPictureInPictureFeed {
+    object Local : SystemPictureInPictureFeed
+
+    data class Remote(val cid: String?) : SystemPictureInPictureFeed
 }
 
 /**
@@ -58,13 +59,13 @@ internal enum class SystemPictureInPictureFeed {
 internal fun selectSystemPictureInPictureFeed(
     localIsLarge: Boolean,
     localVideoEnabled: Boolean,
-    hasRemote: Boolean,
+    remoteCid: String?,
 ): SystemPictureInPictureFeed =
     when {
         localIsLarge && localVideoEnabled -> SystemPictureInPictureFeed.Local
-        hasRemote -> SystemPictureInPictureFeed.Remote
+        remoteCid != null -> SystemPictureInPictureFeed.Remote(remoteCid)
         localVideoEnabled -> SystemPictureInPictureFeed.Local
-        else -> SystemPictureInPictureFeed.Remote
+        else -> SystemPictureInPictureFeed.Remote(null)
     }
 
 @Composable
@@ -72,6 +73,7 @@ internal fun rememberSystemPictureInPictureMode(
     enabled: Boolean,
     uiState: CallUiState,
     sourceRect: Rect?,
+    onPictureInPictureDismissRequested: () -> Unit,
 ): Boolean {
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
@@ -82,12 +84,11 @@ internal fun rememberSystemPictureInPictureMode(
             activity?.packageManager?.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) == true
     val shouldEnter = supported && uiState.phase.isSystemPipPhase()
     val latestShouldEnter by rememberUpdatedState(shouldEnter)
+    val latestOnPictureInPictureDismissRequested by rememberUpdatedState(onPictureInPictureDismissRequested)
     val latestParams = remember { mutableStateOf<PictureInPictureParams?>(null) }
     var isInPictureInPicture by remember(activity) {
         mutableStateOf(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true)
     }
-    val latestIsInPictureInPicture by rememberUpdatedState(isInPictureInPicture)
-
     DisposableEffect(componentActivity) {
         if (componentActivity == null) return@DisposableEffect onDispose {}
         val listener = Consumer<PictureInPictureModeChangedInfo> { info ->
@@ -115,7 +116,13 @@ internal fun rememberSystemPictureInPictureMode(
     }
 
     DisposableEffect(componentActivity, supported) {
-        if (!supported || componentActivity == null) return@DisposableEffect onDispose {}
+        if (
+            !supported ||
+            componentActivity == null ||
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            return@DisposableEffect onDispose {}
+        }
         val listener = Runnable {
             val params = latestParams.value ?: return@Runnable
             if (latestShouldEnter) {
@@ -130,15 +137,7 @@ internal fun rememberSystemPictureInPictureMode(
 
     LaunchedEffect(activity, supported, isInPictureInPicture, shouldEnter) {
         if (supported && isInPictureInPicture && !shouldEnter) {
-            runCatching { activity.finish() }
-        }
-    }
-
-    DisposableEffect(activity, supported) {
-        onDispose {
-            if (supported && latestIsInPictureInPicture) {
-                runCatching { activity.finish() }
-            }
+            latestOnPictureInPictureDismissRequested()
         }
     }
 
@@ -171,12 +170,19 @@ internal fun SystemPictureInPictureContent(
     remoteContentScale: ContentScale,
     attachLocalSink: (VideoSink) -> Unit,
     detachLocalSink: (VideoSink) -> Unit,
-    attachRemoteSink: (VideoSink) -> Unit,
-    detachRemoteSink: (VideoSink) -> Unit,
+    attachRemoteSinkForCid: (String, VideoSink) -> Unit,
+    detachRemoteSinkForCid: (String, VideoSink) -> Unit,
 ) {
-    val remote = uiState.remoteParticipants.firstOrNull()
+    val remote =
+        when (feed) {
+            SystemPictureInPictureFeed.Local -> null
+            is SystemPictureInPictureFeed.Remote -> {
+                feed.cid?.let { cid -> uiState.remoteParticipants.firstOrNull { it.cid == cid } }
+                    ?: uiState.remoteParticipants.firstOrNull()
+            }
+        }
     val showLocalVideo = feed == SystemPictureInPictureFeed.Local && uiState.localVideoEnabled
-    val showRemoteVideo = feed == SystemPictureInPictureFeed.Remote && remote?.videoEnabled == true
+    val showRemoteVideo = feed is SystemPictureInPictureFeed.Remote && remote?.videoEnabled == true
 
     Box(
         modifier = Modifier.fillMaxSize().background(Color.Black),
@@ -199,8 +205,12 @@ internal fun SystemPictureInPictureContent(
                     modifier = Modifier.fillMaxSize(),
                     rendererName = "system-pip-remote-${remote.cid}",
                     eglContext = eglContext,
-                    onAttach = attachRemoteSink,
-                    onDetach = detachRemoteSink,
+                    onAttach = { sink ->
+                        remote.cid.let { cid -> attachRemoteSinkForCid(cid, sink) }
+                    },
+                    onDetach = { sink ->
+                        remote.cid.let { cid -> detachRemoteSinkForCid(cid, sink) }
+                    },
                     mirror = false,
                     contentScale = remoteContentScale,
                 )

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
@@ -105,7 +105,7 @@ internal fun rememberSystemPictureInPictureMode(
             latestParams.value = null
             return@LaunchedEffect
         }
-        val hostActivity = activity
+        val hostActivity = activity ?: return@LaunchedEffect
         val params =
             buildSystemPictureInPictureParams(
                 sourceRect = sourceRect,

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
@@ -1,0 +1,280 @@
+package app.serenada.callui
+
+import android.app.Activity
+import android.app.PictureInPictureParams
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.pm.PackageManager
+import android.graphics.Rect
+import android.os.Build
+import android.util.Rational
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+import androidx.core.app.PictureInPictureModeChangedInfo
+import androidx.core.util.Consumer
+import app.serenada.core.call.CallPhase
+import app.serenada.core.call.RemoteParticipant
+import kotlin.math.roundToInt
+import org.webrtc.EglBase
+import org.webrtc.VideoSink
+
+internal enum class SystemPictureInPictureFeed {
+    Local,
+    Remote,
+}
+
+@Composable
+internal fun rememberSystemPictureInPictureMode(
+    enabled: Boolean,
+    uiState: CallUiState,
+    sourceRect: Rect?,
+): Boolean {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    val componentActivity = activity as? ComponentActivity
+    val supported =
+        enabled &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            activity?.packageManager?.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) == true
+    val shouldEnter = supported && uiState.phase.isSystemPipPhase()
+    val latestShouldEnter by rememberUpdatedState(shouldEnter)
+    val latestParams = remember { mutableStateOf<PictureInPictureParams?>(null) }
+    var isInPictureInPicture by remember(activity) {
+        mutableStateOf(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true)
+    }
+    val latestIsInPictureInPicture by rememberUpdatedState(isInPictureInPicture)
+
+    DisposableEffect(componentActivity) {
+        if (componentActivity == null) return@DisposableEffect onDispose {}
+        val listener = Consumer<PictureInPictureModeChangedInfo> { info ->
+            isInPictureInPicture = info.isInPictureInPictureMode
+        }
+        componentActivity.addOnPictureInPictureModeChangedListener(listener)
+        onDispose {
+            componentActivity.removeOnPictureInPictureModeChangedListener(listener)
+        }
+    }
+
+    LaunchedEffect(activity, supported, shouldEnter, sourceRect) {
+        if (!supported) {
+            latestParams.value = null
+            return@LaunchedEffect
+        }
+        val hostActivity = activity
+        val params =
+            buildSystemPictureInPictureParams(
+                sourceRect = sourceRect,
+                autoEnter = shouldEnter,
+            )
+        latestParams.value = params
+        runCatching { hostActivity.setPictureInPictureParams(params) }
+    }
+
+    DisposableEffect(componentActivity, supported) {
+        if (!supported || componentActivity == null) return@DisposableEffect onDispose {}
+        val listener = Runnable {
+            val params = latestParams.value ?: return@Runnable
+            if (latestShouldEnter) {
+                runCatching { componentActivity.enterPictureInPictureMode(params) }
+            }
+        }
+        componentActivity.addOnUserLeaveHintListener(listener)
+        onDispose {
+            componentActivity.removeOnUserLeaveHintListener(listener)
+        }
+    }
+
+    LaunchedEffect(activity, supported, isInPictureInPicture, shouldEnter) {
+        if (supported && isInPictureInPicture && !shouldEnter) {
+            runCatching { activity.finish() }
+        }
+    }
+
+    DisposableEffect(activity, supported) {
+        onDispose {
+            if (supported && latestIsInPictureInPicture) {
+                runCatching { activity.finish() }
+            }
+        }
+    }
+
+    return isInPictureInPicture
+}
+
+private fun buildSystemPictureInPictureParams(
+    sourceRect: Rect?,
+    autoEnter: Boolean,
+): PictureInPictureParams {
+    val builder =
+        PictureInPictureParams.Builder()
+            .setAspectRatio(sourceRect.toPipAspectRatio())
+    if (sourceRect != null && !sourceRect.isEmpty) {
+        builder.setSourceRectHint(sourceRect)
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        builder.setAutoEnterEnabled(autoEnter)
+        builder.setSeamlessResizeEnabled(false)
+    }
+    return builder.build()
+}
+
+@Composable
+internal fun SystemPictureInPictureContent(
+    uiState: CallUiState,
+    feed: SystemPictureInPictureFeed,
+    eglContext: EglBase.Context,
+    localContentScale: ContentScale,
+    remoteContentScale: ContentScale,
+    attachLocalSink: (VideoSink) -> Unit,
+    detachLocalSink: (VideoSink) -> Unit,
+    attachRemoteSink: (VideoSink) -> Unit,
+    detachRemoteSink: (VideoSink) -> Unit,
+) {
+    val remote = uiState.remoteParticipants.firstOrNull()
+    val showLocalVideo = feed == SystemPictureInPictureFeed.Local && uiState.localVideoEnabled
+    val showRemoteVideo = feed == SystemPictureInPictureFeed.Remote && remote?.videoEnabled == true
+
+    Box(
+        modifier = Modifier.fillMaxSize().background(Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        when {
+            showLocalVideo -> {
+                TextureVideoSurface(
+                    modifier = Modifier.fillMaxSize(),
+                    rendererName = "system-pip-local",
+                    eglContext = eglContext,
+                    onAttach = attachLocalSink,
+                    onDetach = detachLocalSink,
+                    mirror = uiState.isFrontCamera && !uiState.isScreenSharing,
+                    contentScale = localContentScale,
+                )
+            }
+            showRemoteVideo -> {
+                TextureVideoSurface(
+                    modifier = Modifier.fillMaxSize(),
+                    rendererName = "system-pip-remote-${remote.cid}",
+                    eglContext = eglContext,
+                    onAttach = attachRemoteSink,
+                    onDetach = detachRemoteSink,
+                    mirror = false,
+                    contentScale = remoteContentScale,
+                )
+            }
+            else -> {
+                SystemPictureInPictureAvatar(
+                    participant = remote,
+                    displayName = if (feed == SystemPictureInPictureFeed.Local) {
+                        uiState.localDisplayName
+                    } else {
+                        remote?.displayName
+                    },
+                    peerId = if (feed == SystemPictureInPictureFeed.Local) {
+                        uiState.localCid
+                    } else {
+                        remote?.peerId
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SystemPictureInPictureAvatar(
+    participant: RemoteParticipant?,
+    displayName: String?,
+    peerId: String?,
+) {
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize().background(Color(0xFF111111)),
+        contentAlignment = Alignment.Center,
+    ) {
+        val minDimension = minOf(maxWidth, maxHeight)
+        val avatarSize = (minDimension * 0.46f).coerceIn(42.dp, 108.dp)
+        val avatarFontSize = (avatarSize.value * 0.38f).sp
+        val showName = maxHeight >= 150.dp && !displayName.isNullOrBlank()
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        ) {
+            RemoteAvatar(
+                peerId = peerId ?: participant?.peerId,
+                displayName = displayName ?: participant?.displayName,
+                size = avatarSize,
+                fontSize = avatarFontSize,
+            )
+            if (showName) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = displayName.orEmpty(),
+                    color = Color.White.copy(alpha = 0.82f),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun androidx.compose.ui.unit.Dp.coerceIn(
+    minimumValue: androidx.compose.ui.unit.Dp,
+    maximumValue: androidx.compose.ui.unit.Dp,
+): androidx.compose.ui.unit.Dp =
+    when {
+        this < minimumValue -> minimumValue
+        this > maximumValue -> maximumValue
+        else -> this
+    }
+
+private fun Rect?.toPipAspectRatio(): Rational {
+    if (this != null && width() > 0 && height() > 0) {
+        return boundedRational(width().toFloat() / height().toFloat())
+    }
+    return Rational(9, 16)
+}
+
+private fun boundedRational(ratio: Float): Rational {
+    val bounded = ratio.coerceIn(1f / 2.39f, 2.39f)
+    return Rational((bounded * 1_000).roundToInt().coerceAtLeast(1), 1_000)
+}
+
+private fun CallPhase.isSystemPipPhase(): Boolean =
+    this == CallPhase.Waiting || this == CallPhase.InCall
+
+private tailrec fun Context.findActivity(): Activity? =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SystemPictureInPicture.kt
@@ -49,6 +49,24 @@ internal enum class SystemPictureInPictureFeed {
     Remote,
 }
 
+/**
+ * Chooses which feed system PiP should surface. Shared by [CallScreen] and
+ * [FrontlineCallScreen] so the priority order stays in one place: prefer the
+ * local camera when it is the large feed, otherwise a present remote, then any
+ * enabled local camera, falling back to remote.
+ */
+internal fun selectSystemPictureInPictureFeed(
+    localIsLarge: Boolean,
+    localVideoEnabled: Boolean,
+    hasRemote: Boolean,
+): SystemPictureInPictureFeed =
+    when {
+        localIsLarge && localVideoEnabled -> SystemPictureInPictureFeed.Local
+        hasRemote -> SystemPictureInPictureFeed.Remote
+        localVideoEnabled -> SystemPictureInPictureFeed.Local
+        else -> SystemPictureInPictureFeed.Remote
+    }
+
 @Composable
 internal fun rememberSystemPictureInPictureMode(
     enabled: Boolean,
@@ -246,16 +264,6 @@ private fun SystemPictureInPictureAvatar(
         }
     }
 }
-
-private fun androidx.compose.ui.unit.Dp.coerceIn(
-    minimumValue: androidx.compose.ui.unit.Dp,
-    maximumValue: androidx.compose.ui.unit.Dp,
-): androidx.compose.ui.unit.Dp =
-    when {
-        this < minimumValue -> minimumValue
-        this > maximumValue -> maximumValue
-        else -> this
-    }
 
 private fun Rect?.toPipAspectRatio(): Rational {
     if (this != null && width() > 0 && height() > 0) {

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -270,6 +270,8 @@ struct CallScreenView: View {
     let rendererProvider: CallRendererProvider
     let initialRemoteVideoFitCover: Bool
     let onRemoteVideoFitChanged: ((Bool) -> Void)?
+    let onSystemPictureInPictureSourceChanged: ((SystemPictureInPictureSource) -> Void)?
+    let onSystemPictureInPictureSourceFrameChanged: ((CGRect?) -> Void)?
 
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var areControlsVisible = true
@@ -306,7 +308,9 @@ struct CallScreenView: View {
         onSnapshotRequested: ((SnapshotSource) -> Void)? = nil,
         rendererProvider: CallRendererProvider,
         initialRemoteVideoFitCover: Bool = true,
-        onRemoteVideoFitChanged: ((Bool) -> Void)? = nil
+        onRemoteVideoFitChanged: ((Bool) -> Void)? = nil,
+        onSystemPictureInPictureSourceChanged: ((SystemPictureInPictureSource) -> Void)? = nil,
+        onSystemPictureInPictureSourceFrameChanged: ((CGRect?) -> Void)? = nil
     ) {
         self.roomId = roomId
         self.uiState = uiState
@@ -328,6 +332,8 @@ struct CallScreenView: View {
         self.rendererProvider = rendererProvider
         self.initialRemoteVideoFitCover = initialRemoteVideoFitCover
         self.onRemoteVideoFitChanged = onRemoteVideoFitChanged
+        self.onSystemPictureInPictureSourceChanged = onSystemPictureInPictureSourceChanged
+        self.onSystemPictureInPictureSourceFrameChanged = onSystemPictureInPictureSourceFrameChanged
         _remoteVideoFitCover = State(initialValue: initialRemoteVideoFitCover)
         _isControlsAutoHideEnabled = State(initialValue: config.autoHideControls)
         _areControlsVisible = State(initialValue: true)
@@ -355,6 +361,9 @@ struct CallScreenView: View {
             localCameraMode: uiState.localCameraMode
         )
         let shouldRunAutoHideTask = areControlsVisible && uiState.phase == .inCall && isControlsAutoHideEnabled
+        let systemPictureInPictureSource = currentSystemPictureInPictureSource(
+            showLocalAsPrimarySurface: showLocalAsPrimarySurface
+        )
 
         ZStack {
             Color.black.ignoresSafeArea()
@@ -362,8 +371,10 @@ struct CallScreenView: View {
             if uiState.phase == .waiting {
                 if showLocalAsPrimarySurface {
                     largeLocalView
+                        .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
                 } else {
                     waitingMainSurface
+                        .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
                     smallLocalView
                 }
             } else if isMultiParty {
@@ -401,8 +412,10 @@ struct CallScreenView: View {
                         }
                     }
                 )
+                .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
             } else if showLocalAsPrimarySurface {
                 largeLocalView
+                    .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
                 smallRemoteView
             } else {
                 let inCall = uiState.phase == .inCall
@@ -426,6 +439,7 @@ struct CallScreenView: View {
                     )
                 }
                 .padding(.bottom, areControlsVisible ? pipBottomPadding(isLandscape: isLandscape, areControlsVisible: true) + 4 : 0)
+                .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
                 smallLocalView
             }
 
@@ -467,6 +481,9 @@ struct CallScreenView: View {
         }
         .onChange(of: remoteVideoFitCover) { value in
             onRemoteVideoFitChanged?(value)
+        }
+        .task(id: systemPictureInPictureSource) {
+            onSystemPictureInPictureSourceChanged?(systemPictureInPictureSource)
         }
         .task(id: uiState.connectionStatus == .recovering && uiState.phase == .inCall) {
             guard uiState.connectionStatus == .recovering, uiState.phase == .inCall else { return }
@@ -697,6 +714,32 @@ struct CallScreenView: View {
             return .remote(cid: remote.cid)
         }
         return nil
+    }
+
+    private func currentSystemPictureInPictureSource(
+        showLocalAsPrimarySurface: Bool
+    ) -> SystemPictureInPictureSource {
+        if isMultiParty {
+            if let pinned = pinnedParticipantId {
+                if pinned == uiState.localCid {
+                    return .local
+                }
+                if let remote = uiState.remoteParticipants.first(where: { $0.cid == pinned }) {
+                    return .remote(cid: remote.cid)
+                }
+            }
+            return .remote(cid: uiState.remoteParticipants.first?.cid)
+        }
+        if showLocalAsPrimarySurface {
+            return .local
+        }
+        if let remote = uiState.remoteParticipants.first {
+            return .remote(cid: remote.cid)
+        }
+        if uiState.localVideoEnabled {
+            return .local
+        }
+        return .remote(cid: nil)
     }
 
     private var hasOtherTopRightCornerButtons: Bool {

--- a/client-ios/SerenadaCallUI/Sources/CallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/CallScreen.swift
@@ -361,8 +361,12 @@ struct CallScreenView: View {
             localCameraMode: uiState.localCameraMode
         )
         let shouldRunAutoHideTask = areControlsVisible && uiState.phase == .inCall && isControlsAutoHideEnabled
-        let systemPictureInPictureSource = currentSystemPictureInPictureSource(
-            showLocalAsPrimarySurface: showLocalAsPrimarySurface
+        let systemPictureInPictureSource = selectSystemPictureInPictureSource(
+            localSourceId: uiState.localCid,
+            localIsPrimary: !isMultiParty && showLocalAsPrimarySurface,
+            localVideoEnabled: uiState.localVideoEnabled,
+            remoteParticipants: uiState.remoteParticipants,
+            preferredSourceIds: isMultiParty ? [pinnedParticipantId] : []
         )
 
         ZStack {
@@ -714,32 +718,6 @@ struct CallScreenView: View {
             return .remote(cid: remote.cid)
         }
         return nil
-    }
-
-    private func currentSystemPictureInPictureSource(
-        showLocalAsPrimarySurface: Bool
-    ) -> SystemPictureInPictureSource {
-        if isMultiParty {
-            if let pinned = pinnedParticipantId {
-                if pinned == uiState.localCid {
-                    return .local
-                }
-                if let remote = uiState.remoteParticipants.first(where: { $0.cid == pinned }) {
-                    return .remote(cid: remote.cid)
-                }
-            }
-            return .remote(cid: uiState.remoteParticipants.first?.cid)
-        }
-        if showLocalAsPrimarySurface {
-            return .local
-        }
-        if let remote = uiState.remoteParticipants.first {
-            return .remote(cid: remote.cid)
-        }
-        if uiState.localVideoEnabled {
-            return .local
-        }
-        return .remote(cid: nil)
     }
 
     private var hasOtherTopRightCornerButtons: Bool {

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -957,6 +957,12 @@ private struct FrontlineAudioLarge: View {
     }
 }
 
+func formatCallElapsed(startedAtMs: Int64?, fallbackStartedAtMs: Int64, nowMs: Int64) -> String {
+    let startedAt = startedAtMs ?? fallbackStartedAtMs
+    let elapsedSeconds = max(0, (nowMs - startedAt) / 1000)
+    return String(format: "%02lld:%02lld", elapsedSeconds / 60, elapsedSeconds % 60)
+}
+
 private struct FrontlineTimerLabel: View {
     let startedAtMs: Int64?
     @State private var nowMs = Int64(Date().timeIntervalSince1970 * 1000)
@@ -977,9 +983,11 @@ private struct FrontlineTimerLabel: View {
     }
 
     private var elapsedLabel: String {
-        let startedAt = startedAtMs ?? fallbackStartedAtMs
-        let elapsedSeconds = max(0, (nowMs - startedAt) / 1000)
-        return String(format: "%02lld:%02lld", elapsedSeconds / 60, elapsedSeconds % 60)
+        formatCallElapsed(
+            startedAtMs: startedAtMs,
+            fallbackStartedAtMs: fallbackStartedAtMs,
+            nowMs: nowMs
+        )
     }
 }
 

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -117,6 +117,8 @@ struct FrontlineCallScreenView: View {
     let onSnapshotRequested: ((SnapshotSource) -> Void)?
     let rendererProvider: CallRendererProvider
     let onRemoteVideoFitChanged: ((Bool) -> Void)?
+    let onSystemPictureInPictureSourceChanged: ((SystemPictureInPictureSource) -> Void)?
+    let onSystemPictureInPictureSourceFrameChanged: ((CGRect?) -> Void)?
 
     @State private var pipSwapped = false
     @State private var isMoreSheetVisible = false
@@ -160,7 +162,9 @@ struct FrontlineCallScreenView: View {
         onSnapshotRequested: ((SnapshotSource) -> Void)?,
         rendererProvider: CallRendererProvider,
         initialRemoteVideoFitCover: Bool = true,
-        onRemoteVideoFitChanged: ((Bool) -> Void)? = nil
+        onRemoteVideoFitChanged: ((Bool) -> Void)? = nil,
+        onSystemPictureInPictureSourceChanged: ((SystemPictureInPictureSource) -> Void)? = nil,
+        onSystemPictureInPictureSourceFrameChanged: ((CGRect?) -> Void)? = nil
     ) {
         self.roomId = roomId
         self.uiState = uiState
@@ -187,6 +191,8 @@ struct FrontlineCallScreenView: View {
         self.onSnapshotRequested = onSnapshotRequested
         self.rendererProvider = rendererProvider
         self.onRemoteVideoFitChanged = onRemoteVideoFitChanged
+        self.onSystemPictureInPictureSourceChanged = onSystemPictureInPictureSourceChanged
+        self.onSystemPictureInPictureSourceFrameChanged = onSystemPictureInPictureSourceFrameChanged
         _remoteVideoFitCover = State(initialValue: initialRemoteVideoFitCover)
     }
 
@@ -222,6 +228,31 @@ struct FrontlineCallScreenView: View {
             localVideoEnabled: uiState.localVideoEnabled,
             remoteParticipants: uiState.remoteParticipants
         )
+    }
+
+    private var currentSystemPictureInPictureSource: SystemPictureInPictureSource {
+        if uiState.remoteParticipants.count > 1 {
+            let spotlightId = pinnedSpotlightId ?? selectedSpotlightId ?? lastVideoStartedParticipantId
+            if spotlightId == localSpotlightId {
+                return .local
+            }
+            if let remote = uiState.remoteParticipants.first(where: { remote in
+                spotlightId == remote.cid || spotlightId == remote.cid.frontlineContentSpotlightId
+            }) {
+                return .remote(cid: remote.cid)
+            }
+            return .remote(cid: uiState.remoteParticipants.first?.cid)
+        }
+        if largeFeed == .local && uiState.localVideoEnabled {
+            return .local
+        }
+        if let remote {
+            return .remote(cid: remote.cid)
+        }
+        if uiState.localVideoEnabled {
+            return .local
+        }
+        return .remote(cid: nil)
     }
 
     var body: some View {
@@ -293,6 +324,9 @@ struct FrontlineCallScreenView: View {
         }
         .onChange(of: uiState.localVideoEnabled) { _ in pipSwapped = false }
         .onChange(of: uiState.localCameraMode) { _ in pipSwapped = false }
+        .task(id: currentSystemPictureInPictureSource) {
+            onSystemPictureInPictureSourceChanged?(currentSystemPictureInPictureSource)
+        }
         .onChange(of: uiState.remoteParticipants.map { $0.cid }) { activeCids in
             let active = Set(activeCids)
             remoteTileAspectRatios = remoteTileAspectRatios.filter { active.contains($0.key) }
@@ -418,8 +452,10 @@ struct FrontlineCallScreenView: View {
                 )
             } else if frontlineIsWaitingForRemote(uiState) {
                 waitingSurface
+                    .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
             } else if uiState.remoteParticipants.count > 1 {
                 multiPartyStage
+                    .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
             } else {
                 largeSurface(feed: largeFeed)
             }
@@ -523,6 +559,7 @@ struct FrontlineCallScreenView: View {
                 localVideoView(contentMode: uiState.isScreenSharing ? .scaleAspectFit : .scaleAspectFill)
                 localZoomInteractionLayer(enabled: isLocalCameraZoomEnabled)
             }
+            .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
         case .remote where remote?.videoEnabled == true:
             WebRTCVideoView(
                 kind: remote.map { .remoteForCid($0.cid) } ?? .remote,
@@ -530,11 +567,13 @@ struct FrontlineCallScreenView: View {
                 videoContentMode: remoteVideoFitCover ? .scaleAspectFill : .scaleAspectFit
             )
             .ignoresSafeArea()
+            .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
         default:
             FrontlineAudioLarge(
                 remote: remote,
                 startedAtMs: uiState.callStartedAtMs,
-                strings: strings
+                strings: strings,
+                onSystemPictureInPictureSourceFrameChanged: onSystemPictureInPictureSourceFrameChanged
             )
         }
     }
@@ -887,6 +926,7 @@ private struct FrontlineAudioLarge: View {
     let remote: RemoteParticipant?
     let startedAtMs: Int64?
     let strings: [SerenadaString: String]?
+    let onSystemPictureInPictureSourceFrameChanged: ((CGRect?) -> Void)?
 
     var body: some View {
         let name = remoteDisplayName(remote)
@@ -910,6 +950,7 @@ private struct FrontlineAudioLarge: View {
             Spacer().frame(height: 10)
             FrontlineTimerLabel(startedAtMs: startedAtMs)
         }
+        .systemPictureInPictureSourceFrame(onChange: onSystemPictureInPictureSourceFrameChanged)
         .padding(.horizontal, 24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(frontlineBlack)

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -231,28 +231,20 @@ struct FrontlineCallScreenView: View {
     }
 
     private var currentSystemPictureInPictureSource: SystemPictureInPictureSource {
-        if uiState.remoteParticipants.count > 1 {
-            let spotlightId = pinnedSpotlightId ?? selectedSpotlightId ?? lastVideoStartedParticipantId
-            if spotlightId == localSpotlightId {
-                return .local
+        selectSystemPictureInPictureSource(
+            localSourceId: localSpotlightId,
+            localIsPrimary: uiState.remoteParticipants.count <= 1 && largeFeed == .local,
+            localVideoEnabled: uiState.localVideoEnabled,
+            remoteParticipants: uiState.remoteParticipants,
+            preferredSourceIds: uiState.remoteParticipants.count > 1
+                ? [pinnedSpotlightId, selectedSpotlightId, lastVideoStartedParticipantId]
+                : [],
+            sourceIdForPreferredSourceId: { sourceId in
+                sourceId.isFrontlineContentSpotlightId
+                    ? sourceId.removingFrontlineContentSpotlightPrefix
+                    : sourceId
             }
-            if let remote = uiState.remoteParticipants.first(where: { remote in
-                spotlightId == remote.cid || spotlightId == remote.cid.frontlineContentSpotlightId
-            }) {
-                return .remote(cid: remote.cid)
-            }
-            return .remote(cid: uiState.remoteParticipants.first?.cid)
-        }
-        if largeFeed == .local && uiState.localVideoEnabled {
-            return .local
-        }
-        if let remote {
-            return .remote(cid: remote.cid)
-        }
-        if uiState.localVideoEnabled {
-            return .local
-        }
-        return .remote(cid: nil)
+        )
     }
 
     var body: some View {

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -215,6 +215,8 @@ private struct SessionFirstCallFlow: View {
     let onSnapshotError: ((SnapshotError) -> Void)?
 
     @ObservedObject private var session: SerenadaSession
+    @State private var systemPictureInPictureSource: SystemPictureInPictureSource = .remote(cid: nil)
+    @State private var systemPictureInPictureSourceFrame: CGRect?
 
     init(
         params: SerenadaCallFlow.SessionParams,
@@ -238,12 +240,13 @@ private struct SessionFirstCallFlow: View {
     var body: some View {
         let state = session.state
         let phase = state.phase
+        let callUiState = mapSessionToUiState(session)
 
         Group {
             switch phase {
             case .idle, .joining:
                 if config.uiVariant == .frontline {
-                    frontlineCallScreen(state: state)
+                    frontlineCallScreen(state: state, callUiState: callUiState)
                 } else {
                     VStack(spacing: 16) {
                         ProgressView()
@@ -256,7 +259,7 @@ private struct SessionFirstCallFlow: View {
 
             case .awaitingPermissions:
                 if config.uiVariant == .frontline {
-                    frontlineCallScreen(state: state)
+                    frontlineCallScreen(state: state, callUiState: callUiState)
                 } else {
                     VStack(spacing: 16) {
                         Text(resolveString(.callPermissionsRequired, overrides: strings))
@@ -273,12 +276,12 @@ private struct SessionFirstCallFlow: View {
 
             case .waiting, .inCall:
                 if config.uiVariant == .frontline {
-                    frontlineCallScreen(state: state)
+                    frontlineCallScreen(state: state, callUiState: callUiState)
                 } else {
                     // Session-first mode renders through bridge using session as renderer provider
                     CallScreenView(
                         roomId: session.roomId,
-                        uiState: mapSessionToUiState(session),
+                        uiState: callUiState,
                         roomShareURL: session.roomUrl,
                         screenShareExtensionBundleId: session.screenShareExtensionBundleId,
                         roomName: params.roomName,
@@ -296,13 +299,15 @@ private struct SessionFirstCallFlow: View {
                         onSnapshotRequested: makeSnapshotHandler(),
                         rendererProvider: session,
                         initialRemoteVideoFitCover: params.initialRemoteVideoFitCover,
-                        onRemoteVideoFitChanged: params.onRemoteVideoFitChanged
+                        onRemoteVideoFitChanged: params.onRemoteVideoFitChanged,
+                        onSystemPictureInPictureSourceChanged: { systemPictureInPictureSource = $0 },
+                        onSystemPictureInPictureSourceFrameChanged: { systemPictureInPictureSourceFrame = $0 }
                     )
                 }
 
             case .ending:
                 if config.uiVariant == .frontline {
-                    frontlineCallScreen(state: state)
+                    frontlineCallScreen(state: state, callUiState: callUiState)
                         .onAppear {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                                 onDismiss?()
@@ -324,7 +329,7 @@ private struct SessionFirstCallFlow: View {
 
             case .error:
                 if config.uiVariant == .frontline {
-                    frontlineCallScreen(state: state)
+                    frontlineCallScreen(state: state, callUiState: callUiState)
                 } else {
                     VStack(spacing: 16) {
                         Text(resolveString(.callErrorGeneric, overrides: strings))
@@ -339,12 +344,24 @@ private struct SessionFirstCallFlow: View {
                 }
             }
         }
+        .coordinateSpace(name: SystemPictureInPictureCoordinateSpace.name)
+        .overlay {
+            if config.systemPictureInPictureEnabled {
+                SystemPictureInPictureLayer(
+                    enabled: true,
+                    uiState: callUiState,
+                    source: systemPictureInPictureSource,
+                    sourceFrame: systemPictureInPictureSourceFrame,
+                    rendererProvider: session
+                )
+            }
+        }
     }
 
-    private func frontlineCallScreen(state: CallState) -> some View {
+    private func frontlineCallScreen(state: CallState, callUiState: CallUiState) -> some View {
         FrontlineCallScreenView(
             roomId: session.roomId,
-            uiState: mapSessionToUiState(session),
+            uiState: callUiState,
             sessionPhase: state.phase,
             roomShareURL: session.roomUrl,
             screenShareExtensionBundleId: session.screenShareExtensionBundleId,
@@ -368,7 +385,9 @@ private struct SessionFirstCallFlow: View {
             onSnapshotRequested: makeSnapshotHandler(),
             rendererProvider: session,
             initialRemoteVideoFitCover: params.initialRemoteVideoFitCover,
-            onRemoteVideoFitChanged: params.onRemoteVideoFitChanged
+            onRemoteVideoFitChanged: params.onRemoteVideoFitChanged,
+            onSystemPictureInPictureSourceChanged: { systemPictureInPictureSource = $0 },
+            onSystemPictureInPictureSourceFrameChanged: { systemPictureInPictureSourceFrame = $0 }
         )
     }
 

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlowConfig.swift
@@ -48,6 +48,12 @@ public struct SerenadaCallFlowConfig {
     /// standard call UI.
     public var uiVariant: SerenadaCallUiVariant
 
+    /// Enables system Picture in Picture for active calls when the host app
+    /// has the required iOS background modes/capabilities. iOS video-call PiP
+    /// provides system return controls but does not allow custom in-window
+    /// buttons such as End Call.
+    public var systemPictureInPictureEnabled: Bool
+
     public init(
         screenSharingEnabled: Bool = true,
         inviteControlsEnabled: Bool = true,
@@ -56,7 +62,8 @@ public struct SerenadaCallFlowConfig {
         snapshotEnabled: Bool = false,
         avatarProvider: AvatarProvider? = nil,
         videoEnabled: Bool = true,
-        uiVariant: SerenadaCallUiVariant = .standard
+        uiVariant: SerenadaCallUiVariant = .standard,
+        systemPictureInPictureEnabled: Bool = false
     ) {
         self.screenSharingEnabled = screenSharingEnabled
         self.inviteControlsEnabled = inviteControlsEnabled
@@ -66,5 +73,6 @@ public struct SerenadaCallFlowConfig {
         self.avatarProvider = avatarProvider
         self.videoEnabled = videoEnabled
         self.uiVariant = uiVariant
+        self.systemPictureInPictureEnabled = systemPictureInPictureEnabled
     }
 }

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -684,6 +684,12 @@ private final class SystemPictureInPictureVideoView: UIView, RTCVideoRenderer {
         layer as! AVSampleBufferDisplayLayer
     }
 
+    private static let pixelBufferAttributes: CFDictionary = [
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        kCVPixelBufferCGImageCompatibilityKey as String: true,
+        kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+    ] as CFDictionary
+
     private let renderQueue = DispatchQueue(label: "app.serenada.callui.system-pip-video")
     private let renderLock = NSLock()
     private let ciContext = CIContext()
@@ -803,17 +809,12 @@ private final class SystemPictureInPictureVideoView: UIView, RTCVideoRenderer {
 
     private func render(image: CIImage, width: Int, height: Int) -> CVPixelBuffer? {
         var output: CVPixelBuffer?
-        let attrs: [String: Any] = [
-            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
-            kCVPixelBufferCGImageCompatibilityKey as String: true,
-            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
-        ]
         let status = CVPixelBufferCreate(
             kCFAllocatorDefault,
             width,
             height,
             kCVPixelFormatType_32BGRA,
-            attrs as CFDictionary,
+            Self.pixelBufferAttributes,
             &output
         )
         guard status == kCVReturnSuccess, let output else { return nil }

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -264,10 +264,12 @@ private final class SystemPictureInPictureSourceView: UIView {
             timerLabel.text = nil
             return
         }
-        let startedAtMs = participant.callStartedAtMs ?? fallbackStartedAtMs
         let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
-        let elapsedSeconds = max(0, (nowMs - startedAtMs) / 1000)
-        timerLabel.text = String(format: "%02lld:%02lld", elapsedSeconds / 60, elapsedSeconds % 60)
+        timerLabel.text = formatCallElapsed(
+            startedAtMs: participant.callStartedAtMs,
+            fallbackStartedAtMs: fallbackStartedAtMs,
+            nowMs: nowMs
+        )
     }
 }
 
@@ -366,11 +368,12 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         )
     }
 
-    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
-        coordinator.detachRenderer()
+    static func dismantleUIView(_ uiView: SystemPictureInPictureSourceView, coordinator: Coordinator) {
+        coordinator.cleanup()
     }
 
-    final class Coordinator: NSObject, AVPictureInPictureControllerDelegate {
+    @MainActor
+    final class Coordinator: NSObject, @preconcurrency AVPictureInPictureControllerDelegate {
         weak var rendererProvider: CallRendererProvider?
 
         private weak var sourceView: SystemPictureInPictureSourceView?
@@ -411,7 +414,11 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
 
             ensureController()
             contentController?.update(participant: participant, avatarImage: avatarImage)
-            attachRenderer(participant: participant)
+            if controller?.isPictureInPictureActive == true {
+                attachRenderer(participant: participant)
+            } else {
+                detachRenderer()
+            }
         }
 
         func detachRenderer() {
@@ -422,22 +429,33 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             }
             guard let source = attachedSource else { return }
             let provider = rendererProvider
-            Task { @MainActor in
-                switch source {
-                case .local:
-                    provider?.detachLocalRenderer(videoView)
-                case .remote(let cid):
-                    if let cid {
-                        provider?.detachRemoteRenderer(videoView, forCid: cid)
-                    } else {
-                        provider?.detachRemoteRenderer(videoView)
-                    }
+            switch source {
+            case .local:
+                provider?.detachLocalRenderer(videoView)
+            case .remote(let cid):
+                if let cid {
+                    provider?.detachRemoteRenderer(videoView, forCid: cid)
+                } else {
+                    provider?.detachRemoteRenderer(videoView)
                 }
             }
             attachedSource = nil
 #else
             attachedSource = nil
 #endif
+        }
+
+        func cleanup() {
+            if controller?.isPictureInPictureActive == true {
+                controller?.stopPictureInPicture()
+            }
+            sourceView?.setPlaceholderVisible(false, animated: false)
+            detachRenderer()
+            controller?.delegate = nil
+            controller = nil
+            contentController = nil
+            currentParticipant = nil
+            currentAvatarImage = nil
         }
 
         private func ensureController() {
@@ -470,16 +488,14 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             detachRenderer()
             let provider = rendererProvider
             let source = participant.source
-            Task { @MainActor in
-                switch source {
-                case .local:
-                    provider?.attachLocalRenderer(videoView)
-                case .remote(let cid):
-                    if let cid {
-                        provider?.attachRemoteRenderer(videoView, forCid: cid)
-                    } else {
-                        provider?.attachRemoteRenderer(videoView)
-                    }
+            switch source {
+            case .local:
+                provider?.attachLocalRenderer(videoView)
+            case .remote(let cid):
+                if let cid {
+                    provider?.attachRemoteRenderer(videoView, forCid: cid)
+                } else {
+                    provider?.attachRemoteRenderer(videoView)
                 }
             }
             attachedSource = source
@@ -495,10 +511,12 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
 
         func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
             updateSourcePlaceholder(visible: true, animated: false)
+            attachCurrentRenderer()
         }
 
         func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
             updateSourcePlaceholder(visible: true, animated: false)
+            attachCurrentRenderer()
         }
 
         func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
@@ -507,6 +525,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
 
         func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
             updateSourcePlaceholder(visible: false, animated: true)
+            detachRenderer()
         }
 
         private func updateSourcePlaceholder(visible: Bool, animated: Bool) {
@@ -523,6 +542,11 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
                 avatarImage: currentAvatarImage,
                 placeholderVisible: true
             )
+        }
+
+        private func attachCurrentRenderer() {
+            guard let currentParticipant else { return }
+            attachRenderer(participant: currentParticipant)
         }
     }
 }

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -13,6 +13,43 @@ enum SystemPictureInPictureSource: Equatable {
     case remote(cid: String?)
 }
 
+func selectSystemPictureInPictureSource(
+    localSourceId: String?,
+    localIsPrimary: Bool,
+    localVideoEnabled: Bool,
+    remoteParticipants: [RemoteParticipant],
+    preferredSourceIds: [String?] = [],
+    sourceIdForPreferredSourceId: (String) -> String? = { $0 }
+) -> SystemPictureInPictureSource {
+    let remoteCids = Set(remoteParticipants.map(\.cid))
+
+    for preferredSourceId in preferredSourceIds {
+        guard let preferredSourceId else { continue }
+        guard let sourceId = sourceIdForPreferredSourceId(preferredSourceId) else { continue }
+        if let localSourceId, sourceId == localSourceId {
+            if localVideoEnabled {
+                return .local
+            }
+            continue
+        }
+        guard remoteCids.contains(sourceId) else {
+            continue
+        }
+        return .remote(cid: sourceId)
+    }
+
+    if localIsPrimary && localVideoEnabled {
+        return .local
+    }
+    if let remote = remoteParticipants.first {
+        return .remote(cid: remote.cid)
+    }
+    if localVideoEnabled {
+        return .local
+    }
+    return .remote(cid: nil)
+}
+
 enum SystemPictureInPictureCoordinateSpace {
     static let name = "app.serenada.callui.system-pip"
 }

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -1,0 +1,888 @@
+import AVFoundation
+import AVKit
+import CoreImage
+import SerenadaCore
+import SwiftUI
+import UIKit
+#if canImport(WebRTC)
+@preconcurrency import WebRTC
+#endif
+
+enum SystemPictureInPictureSource: Equatable {
+    case local
+    case remote(cid: String?)
+}
+
+enum SystemPictureInPictureCoordinateSpace {
+    static let name = "app.serenada.callui.system-pip"
+}
+
+struct SystemPictureInPictureSourceFrameReporter: View {
+    let onFrameChanged: ((CGRect?) -> Void)?
+
+    var body: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(
+                key: SystemPictureInPictureSourceFramePreferenceKey.self,
+                value: proxy.frame(in: .named(SystemPictureInPictureCoordinateSpace.name))
+            )
+        }
+        .onPreferenceChange(SystemPictureInPictureSourceFramePreferenceKey.self) { frame in
+            guard let onFrameChanged else { return }
+            if let frame, !frame.isEmpty {
+                onFrameChanged(frame)
+            } else {
+                onFrameChanged(nil)
+            }
+        }
+    }
+}
+
+private struct SystemPictureInPictureSourceFramePreferenceKey: PreferenceKey {
+    static let defaultValue: CGRect? = nil
+
+    static func reduce(value: inout CGRect?, nextValue: () -> CGRect?) {
+        value = nextValue() ?? value
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func systemPictureInPictureSourceFrame(
+        onChange: ((CGRect?) -> Void)?
+    ) -> some View {
+        if onChange == nil {
+            self
+        } else {
+            background(SystemPictureInPictureSourceFrameReporter(onFrameChanged: onChange))
+        }
+    }
+}
+
+private struct SystemPictureInPictureParticipant {
+    let source: SystemPictureInPictureSource
+    let videoEnabled: Bool
+    let displayName: String?
+    let peerId: String?
+    let callStartedAtMs: Int64?
+}
+
+private final class SystemPictureInPictureSourceView: UIView {
+    private let contentView = UIView(frame: .zero)
+    private let avatarImageView = UIImageView(frame: .zero)
+    private let initialsLabel = UILabel(frame: .zero)
+    private let nameLabel = UILabel(frame: .zero)
+    private let timerLabel = UILabel(frame: .zero)
+
+    private var avatarSizeConstraint: NSLayoutConstraint?
+    private var contentWidthConstraint: NSLayoutConstraint?
+    private var nameTopConstraint: NSLayoutConstraint?
+    private var timerTopConstraint: NSLayoutConstraint?
+    private var initialsFontSize: CGFloat = 24
+    private var nameFontSize: CGFloat = 12
+    private var timerFontSize: CGFloat = 12
+    private var participant: SystemPictureInPictureParticipant?
+    private var avatarImage: UIImage?
+    private var timer: Timer?
+    private var fallbackStartedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateLayoutMetrics()
+    }
+
+    func update(
+        participant: SystemPictureInPictureParticipant,
+        avatarImage: UIImage?,
+        placeholderVisible: Bool
+    ) {
+        self.participant = participant
+        self.avatarImage = avatarImage
+        applyContent()
+        setPlaceholderVisible(placeholderVisible && !participant.videoEnabled, animated: false)
+        updateTimer()
+    }
+
+    func setPlaceholderVisible(_ visible: Bool, animated: Bool) {
+        let changes = {
+            self.contentView.alpha = visible ? 1 : 0
+        }
+
+        contentView.isHidden = false
+        if animated {
+            UIView.animate(withDuration: 0.08, animations: changes) { _ in
+                self.contentView.isHidden = !visible
+                self.updateTimerState()
+            }
+        } else {
+            changes()
+            contentView.isHidden = !visible
+            updateTimerState()
+        }
+    }
+
+    private func configure() {
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.backgroundColor = .clear
+        contentView.alpha = 0
+        contentView.isHidden = true
+        addSubview(contentView)
+
+        avatarImageView.translatesAutoresizingMaskIntoConstraints = false
+        avatarImageView.contentMode = .scaleAspectFill
+        avatarImageView.clipsToBounds = true
+        avatarImageView.backgroundColor = UIColor(white: 0.16, alpha: 1)
+
+        initialsLabel.translatesAutoresizingMaskIntoConstraints = false
+        initialsLabel.textAlignment = .center
+        initialsLabel.textColor = UIColor.white.withAlphaComponent(0.9)
+        initialsLabel.font = UIFont.systemFont(ofSize: initialsFontSize, weight: .heavy)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.textAlignment = .center
+        nameLabel.textColor = UIColor.white
+        nameLabel.font = UIFont.systemFont(ofSize: nameFontSize, weight: .bold)
+        nameLabel.numberOfLines = 1
+        nameLabel.adjustsFontSizeToFitWidth = true
+        nameLabel.minimumScaleFactor = 0.7
+
+        timerLabel.translatesAutoresizingMaskIntoConstraints = false
+        timerLabel.textAlignment = .center
+        timerLabel.textColor = UIColor.white.withAlphaComponent(0.5)
+        timerLabel.font = UIFont.monospacedDigitSystemFont(ofSize: timerFontSize, weight: .medium)
+        timerLabel.numberOfLines = 1
+
+        contentView.addSubview(avatarImageView)
+        contentView.addSubview(initialsLabel)
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(timerLabel)
+
+        let avatarSizeConstraint = avatarImageView.widthAnchor.constraint(equalToConstant: 56)
+        let contentWidthConstraint = contentView.widthAnchor.constraint(greaterThanOrEqualTo: avatarImageView.widthAnchor)
+        let nameTopConstraint = nameLabel.topAnchor.constraint(equalTo: avatarImageView.bottomAnchor, constant: 18)
+        let timerTopConstraint = timerLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 10)
+        self.avatarSizeConstraint = avatarSizeConstraint
+        self.contentWidthConstraint = contentWidthConstraint
+        self.nameTopConstraint = nameTopConstraint
+        self.timerTopConstraint = timerTopConstraint
+
+        NSLayoutConstraint.activate([
+            contentView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            contentView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            contentView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            contentView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            contentView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+            contentWidthConstraint,
+
+            avatarImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            avatarImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            avatarSizeConstraint,
+            avatarImageView.heightAnchor.constraint(equalTo: avatarImageView.widthAnchor),
+
+            initialsLabel.centerXAnchor.constraint(equalTo: avatarImageView.centerXAnchor),
+            initialsLabel.centerYAnchor.constraint(equalTo: avatarImageView.centerYAnchor),
+
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            nameTopConstraint,
+            nameLabel.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, constant: -24),
+
+            timerLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            timerLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            timerTopConstraint,
+            timerLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    private func updateLayoutMetrics() {
+        let width = max(bounds.width, 1)
+        let height = max(bounds.height, 1)
+        let scale = min(1, width / 140, height / 244)
+        let avatarSize = 140 * scale
+        let nameSize = 34 * scale
+        let timerSize = 28 * scale
+
+        avatarSizeConstraint?.constant = avatarSize
+        nameTopConstraint?.constant = 18 * scale
+        timerTopConstraint?.constant = 10 * scale
+        avatarImageView.layer.cornerRadius = avatarSize / 2
+        initialsFontSize = avatarSize * 0.41
+        nameFontSize = nameSize
+        timerFontSize = timerSize
+        initialsLabel.font = UIFont.systemFont(ofSize: initialsFontSize, weight: .heavy)
+        nameLabel.font = UIFont.systemFont(ofSize: nameFontSize, weight: .bold)
+        timerLabel.font = UIFont.monospacedDigitSystemFont(ofSize: timerFontSize, weight: .medium)
+    }
+
+    private func applyContent() {
+        guard let participant else { return }
+        let displayName = participant.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        nameLabel.text = displayName?.isEmpty == false ? displayName : nil
+
+        if let avatarImage {
+            avatarImageView.image = avatarImage
+            initialsLabel.text = nil
+        } else {
+            avatarImageView.image = nil
+            let initials = initialsFor(displayName: displayName)
+            initialsLabel.text = initials.isEmpty ? nil : initials
+        }
+    }
+
+    private func updateTimerState() {
+        if contentView.isHidden {
+            timer?.invalidate()
+            timer = nil
+        } else if timer == nil {
+            timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+                self?.updateTimer()
+            }
+        }
+        updateTimer()
+    }
+
+    private func updateTimer() {
+        guard let participant else {
+            timerLabel.text = nil
+            return
+        }
+        let startedAtMs = participant.callStartedAtMs ?? fallbackStartedAtMs
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let elapsedSeconds = max(0, (nowMs - startedAtMs) / 1000)
+        timerLabel.text = String(format: "%02lld:%02lld", elapsedSeconds / 60, elapsedSeconds % 60)
+    }
+}
+
+struct SystemPictureInPictureLayer: View {
+    let enabled: Bool
+    let uiState: CallUiState
+    let source: SystemPictureInPictureSource
+    let sourceFrame: CGRect?
+    let rendererProvider: CallRendererProvider
+
+    @Environment(\.avatarCache) private var avatarCache
+
+    var body: some View {
+        let participant = selectedParticipant
+        let avatarImage = participant.peerId.flatMap { avatarCache?.image(for: $0) }
+
+        GeometryReader { geometry in
+            let frame = normalizedSourceFrame(in: geometry.size)
+            SystemPictureInPictureHost(
+                enabled: enabled && uiState.phase.isSystemPictureInPicturePhase,
+                participant: participant,
+                avatarImage: avatarImage,
+                rendererProvider: rendererProvider
+            )
+            .frame(width: frame.width, height: frame.height)
+            .position(x: frame.midX, y: frame.midY)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+            .task(id: participant.peerId) {
+                guard let peerId = participant.peerId else { return }
+                await MainActor.run {
+                    avatarCache?.load(peerId: peerId)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func normalizedSourceFrame(in fallbackSize: CGSize) -> CGRect {
+        guard let sourceFrame,
+              !sourceFrame.isEmpty,
+              sourceFrame.width.isFinite,
+              sourceFrame.height.isFinite else {
+            return CGRect(origin: .zero, size: fallbackSize)
+        }
+        return sourceFrame
+    }
+
+    private var selectedParticipant: SystemPictureInPictureParticipant {
+        switch source {
+        case .local:
+            return SystemPictureInPictureParticipant(
+                source: .local,
+                videoEnabled: uiState.localVideoEnabled,
+                displayName: uiState.localDisplayName,
+                peerId: uiState.localCid,
+                callStartedAtMs: uiState.callStartedAtMs
+            )
+        case .remote(let cid):
+            let remote = cid.flatMap { selectedCid in
+                uiState.remoteParticipants.first { $0.cid == selectedCid }
+            } ?? uiState.remoteParticipants.first
+            return SystemPictureInPictureParticipant(
+                source: .remote(cid: remote?.cid ?? cid),
+                videoEnabled: remote?.videoEnabled == true,
+                displayName: remote?.displayName,
+                peerId: remote?.peerId,
+                callStartedAtMs: uiState.callStartedAtMs
+            )
+        }
+    }
+}
+
+private struct SystemPictureInPictureHost: UIViewRepresentable {
+    let enabled: Bool
+    let participant: SystemPictureInPictureParticipant
+    let avatarImage: UIImage?
+    let rendererProvider: CallRendererProvider
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(rendererProvider: rendererProvider)
+    }
+
+    func makeUIView(context: Context) -> SystemPictureInPictureSourceView {
+        let view = SystemPictureInPictureSourceView(frame: .zero)
+        context.coordinator.configure(sourceView: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: SystemPictureInPictureSourceView, context: Context) {
+        context.coordinator.rendererProvider = rendererProvider
+        context.coordinator.update(
+            enabled: enabled,
+            participant: participant,
+            avatarImage: avatarImage
+        )
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.detachRenderer()
+    }
+
+    final class Coordinator: NSObject, AVPictureInPictureControllerDelegate {
+        weak var rendererProvider: CallRendererProvider?
+
+        private weak var sourceView: SystemPictureInPictureSourceView?
+        private var controller: AVPictureInPictureController?
+        private var contentController: SystemPictureInPictureContentController?
+        private var attachedSource: SystemPictureInPictureSource?
+        private var currentParticipant: SystemPictureInPictureParticipant?
+        private var currentAvatarImage: UIImage?
+
+        init(rendererProvider: CallRendererProvider) {
+            self.rendererProvider = rendererProvider
+            super.init()
+        }
+
+        func configure(sourceView: SystemPictureInPictureSourceView) {
+            self.sourceView = sourceView
+            ensureController()
+        }
+
+        func update(enabled: Bool, participant: SystemPictureInPictureParticipant, avatarImage: UIImage?) {
+            currentParticipant = participant
+            currentAvatarImage = avatarImage
+            sourceView?.update(
+                participant: participant,
+                avatarImage: avatarImage,
+                placeholderVisible: controller?.isPictureInPictureActive == true
+            )
+
+            guard enabled else {
+                if controller?.isPictureInPictureActive == true {
+                    controller?.stopPictureInPicture()
+                }
+                sourceView?.setPlaceholderVisible(false, animated: false)
+                detachRenderer()
+                contentController?.update(participant: participant, avatarImage: avatarImage)
+                return
+            }
+
+            ensureController()
+            contentController?.update(participant: participant, avatarImage: avatarImage)
+            attachRenderer(participant: participant)
+        }
+
+        func detachRenderer() {
+#if canImport(WebRTC)
+            guard let videoView = contentController?.videoView else {
+                attachedSource = nil
+                return
+            }
+            guard let source = attachedSource else { return }
+            let provider = rendererProvider
+            Task { @MainActor in
+                switch source {
+                case .local:
+                    provider?.detachLocalRenderer(videoView)
+                case .remote(let cid):
+                    if let cid {
+                        provider?.detachRemoteRenderer(videoView, forCid: cid)
+                    } else {
+                        provider?.detachRemoteRenderer(videoView)
+                    }
+                }
+            }
+            attachedSource = nil
+#else
+            attachedSource = nil
+#endif
+        }
+
+        private func ensureController() {
+            guard controller == nil,
+                  AVPictureInPictureController.isPictureInPictureSupported(),
+                  let sourceView else {
+                return
+            }
+
+            let contentController = SystemPictureInPictureContentController()
+            let contentSource = AVPictureInPictureController.ContentSource(
+                activeVideoCallSourceView: sourceView,
+                contentViewController: contentController
+            )
+            let controller = AVPictureInPictureController(contentSource: contentSource)
+            controller.canStartPictureInPictureAutomaticallyFromInline = true
+            controller.delegate = self
+            self.contentController = contentController
+            self.controller = controller
+        }
+
+        private func attachRenderer(participant: SystemPictureInPictureParticipant) {
+#if canImport(WebRTC)
+            guard participant.videoEnabled else {
+                detachRenderer()
+                return
+            }
+            guard let videoView = contentController?.videoView else { return }
+            guard participant.source != attachedSource else { return }
+            detachRenderer()
+            let provider = rendererProvider
+            let source = participant.source
+            Task { @MainActor in
+                switch source {
+                case .local:
+                    provider?.attachLocalRenderer(videoView)
+                case .remote(let cid):
+                    if let cid {
+                        provider?.attachRemoteRenderer(videoView, forCid: cid)
+                    } else {
+                        provider?.attachRemoteRenderer(videoView)
+                    }
+                }
+            }
+            attachedSource = source
+#endif
+        }
+
+        func pictureInPictureController(
+            _ pictureInPictureController: AVPictureInPictureController,
+            restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+        ) {
+            completionHandler(true)
+        }
+
+        func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            updateSourcePlaceholder(visible: true, animated: false)
+        }
+
+        func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            updateSourcePlaceholder(visible: true, animated: false)
+        }
+
+        func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            updateSourcePlaceholder(visible: true, animated: false)
+        }
+
+        func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            updateSourcePlaceholder(visible: false, animated: true)
+        }
+
+        private func updateSourcePlaceholder(visible: Bool, animated: Bool) {
+            guard let currentParticipant else {
+                sourceView?.setPlaceholderVisible(false, animated: animated)
+                return
+            }
+            guard visible else {
+                sourceView?.setPlaceholderVisible(false, animated: animated)
+                return
+            }
+            sourceView?.update(
+                participant: currentParticipant,
+                avatarImage: currentAvatarImage,
+                placeholderVisible: true
+            )
+        }
+    }
+}
+
+private final class SystemPictureInPictureContentController: AVPictureInPictureVideoCallViewController {
+    private static let callAspectContentSize = CGSize(width: 360, height: 640)
+
+#if canImport(WebRTC)
+    let videoView = SystemPictureInPictureVideoView(frame: .zero)
+#else
+    let videoView = UIView(frame: .zero)
+#endif
+
+    private let placeholderView = UIView(frame: .zero)
+    private let avatarImageView = UIImageView(frame: .zero)
+    private let initialsLabel = UILabel(frame: .zero)
+    private let nameLabel = UILabel(frame: .zero)
+    private var avatarSizeConstraint: NSLayoutConstraint?
+    private var avatarCenterYConstraint: NSLayoutConstraint?
+    private var nameTopConstraint: NSLayoutConstraint?
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        preferredContentSize = Self.callAspectContentSize
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        preferredContentSize = Self.callAspectContentSize
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        configureVideoView()
+        configurePlaceholderView()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updatePlaceholderLayoutMetrics()
+    }
+
+    func update(participant: SystemPictureInPictureParticipant, avatarImage: UIImage?) {
+        let showsVideo = participant.videoEnabled
+        videoView.isHidden = !showsVideo
+        placeholderView.isHidden = showsVideo
+
+        let displayName = participant.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        nameLabel.text = displayName?.isEmpty == false ? displayName : nil
+
+        if let avatarImage {
+            avatarImageView.image = avatarImage
+            initialsLabel.text = nil
+        } else {
+            avatarImageView.image = nil
+            let initials = initialsFor(displayName: displayName)
+            initialsLabel.text = initials.isEmpty ? "•" : initials
+        }
+    }
+
+    private func configureVideoView() {
+        videoView.translatesAutoresizingMaskIntoConstraints = false
+        videoView.backgroundColor = .black
+        view.addSubview(videoView)
+        NSLayoutConstraint.activate([
+            videoView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoView.topAnchor.constraint(equalTo: view.topAnchor),
+            videoView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func configurePlaceholderView() {
+        placeholderView.translatesAutoresizingMaskIntoConstraints = false
+        placeholderView.backgroundColor = UIColor(white: 0.08, alpha: 1)
+        view.addSubview(placeholderView)
+
+        avatarImageView.translatesAutoresizingMaskIntoConstraints = false
+        avatarImageView.contentMode = .scaleAspectFill
+        avatarImageView.clipsToBounds = true
+        avatarImageView.layer.cornerRadius = 28
+        avatarImageView.backgroundColor = UIColor(white: 0.16, alpha: 1)
+
+        initialsLabel.translatesAutoresizingMaskIntoConstraints = false
+        initialsLabel.textAlignment = .center
+        initialsLabel.textColor = UIColor.white.withAlphaComponent(0.88)
+        initialsLabel.font = UIFont.systemFont(ofSize: 24, weight: .semibold)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.textAlignment = .center
+        nameLabel.textColor = UIColor.white.withAlphaComponent(0.86)
+        nameLabel.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        nameLabel.numberOfLines = 1
+        nameLabel.adjustsFontSizeToFitWidth = true
+        nameLabel.minimumScaleFactor = 0.7
+
+        placeholderView.addSubview(avatarImageView)
+        placeholderView.addSubview(initialsLabel)
+        placeholderView.addSubview(nameLabel)
+
+        let avatarSizeConstraint = avatarImageView.widthAnchor.constraint(equalToConstant: 56)
+        let avatarCenterYConstraint = avatarImageView.centerYAnchor.constraint(equalTo: placeholderView.centerYAnchor, constant: -10)
+        let nameTopConstraint = nameLabel.topAnchor.constraint(equalTo: avatarImageView.bottomAnchor, constant: 10)
+        self.avatarSizeConstraint = avatarSizeConstraint
+        self.avatarCenterYConstraint = avatarCenterYConstraint
+        self.nameTopConstraint = nameTopConstraint
+
+        NSLayoutConstraint.activate([
+            placeholderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            placeholderView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            placeholderView.topAnchor.constraint(equalTo: view.topAnchor),
+            placeholderView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            avatarImageView.centerXAnchor.constraint(equalTo: placeholderView.centerXAnchor),
+            avatarCenterYConstraint,
+            avatarSizeConstraint,
+            avatarImageView.heightAnchor.constraint(equalTo: avatarImageView.widthAnchor),
+
+            initialsLabel.centerXAnchor.constraint(equalTo: avatarImageView.centerXAnchor),
+            initialsLabel.centerYAnchor.constraint(equalTo: avatarImageView.centerYAnchor),
+
+            nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: placeholderView.leadingAnchor, constant: 18),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: placeholderView.trailingAnchor, constant: -18),
+            nameLabel.centerXAnchor.constraint(equalTo: placeholderView.centerXAnchor),
+            nameTopConstraint
+        ])
+    }
+
+    private func updatePlaceholderLayoutMetrics() {
+        let width = max(view.bounds.width, 1)
+        let avatarSize = min(max(width * 0.36, 48), 140)
+        let initialsSize = avatarSize * 0.41
+        let nameSize = min(max(width * 0.087, 12), 34)
+        let topSpacing = min(max(width * 0.046, 8), 18)
+
+        avatarSizeConstraint?.constant = avatarSize
+        avatarCenterYConstraint?.constant = -topSpacing
+        nameTopConstraint?.constant = topSpacing
+        avatarImageView.layer.cornerRadius = avatarSize / 2
+        initialsLabel.font = UIFont.systemFont(ofSize: initialsSize, weight: .semibold)
+        nameLabel.font = UIFont.systemFont(ofSize: nameSize, weight: .medium)
+    }
+}
+
+private extension CallPhase {
+    var isSystemPictureInPicturePhase: Bool {
+        self == .waiting || self == .inCall
+    }
+}
+
+#if canImport(WebRTC)
+private final class SystemPictureInPictureVideoView: UIView, RTCVideoRenderer {
+    override class var layerClass: AnyClass {
+        AVSampleBufferDisplayLayer.self
+    }
+
+    private var sampleBufferDisplayLayer: AVSampleBufferDisplayLayer {
+        layer as! AVSampleBufferDisplayLayer
+    }
+
+    private let renderQueue = DispatchQueue(label: "app.serenada.callui.system-pip-video")
+    private let renderLock = NSLock()
+    private let ciContext = CIContext()
+    private var isRendering = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureLayer()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureLayer()
+    }
+
+    func setSize(_ size: CGSize) {}
+
+    func renderFrame(_ frame: RTCVideoFrame?) {
+        guard let frame else { return }
+        renderLock.lock()
+        if isRendering {
+            renderLock.unlock()
+            return
+        }
+        isRendering = true
+        renderLock.unlock()
+
+        renderQueue.async { [weak self] in
+            guard let self else { return }
+            let sampleBuffer = self.makeSampleBuffer(from: frame)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                defer { self.finishRenderingFrame() }
+                guard let sampleBuffer else { return }
+                let layer = self.sampleBufferDisplayLayer
+                if layer.status == .failed {
+                    layer.flush()
+                }
+                if layer.isReadyForMoreMediaData {
+                    layer.enqueue(sampleBuffer)
+                }
+            }
+        }
+    }
+
+    private func configureLayer() {
+        sampleBufferDisplayLayer.videoGravity = .resizeAspectFill
+        sampleBufferDisplayLayer.backgroundColor = UIColor.black.cgColor
+    }
+
+    private func finishRenderingFrame() {
+        renderLock.lock()
+        isRendering = false
+        renderLock.unlock()
+    }
+
+    private func makeSampleBuffer(from frame: RTCVideoFrame) -> CMSampleBuffer? {
+        guard let pixelBuffer = normalizedPixelBuffer(from: frame) else { return nil }
+        var formatDescription: CMVideoFormatDescription?
+        guard CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &formatDescription
+        ) == noErr, let formatDescription else {
+            return nil
+        }
+
+        var timing = CMSampleTimingInfo(
+            duration: .invalid,
+            presentationTimeStamp: CMTime(value: frame.timeStampNs, timescale: 1_000_000_000),
+            decodeTimeStamp: .invalid
+        )
+        var sampleBuffer: CMSampleBuffer?
+        guard CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescription: formatDescription,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        ) == noErr, let sampleBuffer else {
+            return nil
+        }
+
+        if let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: true) {
+            let dictionary = unsafeBitCast(
+                CFArrayGetValueAtIndex(attachments, 0),
+                to: CFMutableDictionary.self
+            )
+            CFDictionarySetValue(
+                dictionary,
+                Unmanaged.passUnretained(kCMSampleAttachmentKey_DisplayImmediately).toOpaque(),
+                Unmanaged.passUnretained(kCFBooleanTrue).toOpaque()
+            )
+        }
+        return sampleBuffer
+    }
+
+    private func normalizedPixelBuffer(from frame: RTCVideoFrame) -> CVPixelBuffer? {
+        let sourcePixelBuffer: CVPixelBuffer?
+        if let cv = frame.buffer as? RTCCVPixelBuffer {
+            sourcePixelBuffer = cv.pixelBuffer
+        } else {
+            sourcePixelBuffer = i420ToCVPixelBuffer(frame.buffer.toI420())
+        }
+        guard let sourcePixelBuffer else { return nil }
+
+        guard let orientation = cgOrientation(for: frame.rotation), orientation != .up else {
+            return sourcePixelBuffer
+        }
+
+        var image = CIImage(cvPixelBuffer: sourcePixelBuffer).oriented(orientation)
+        let extent = image.extent.integral
+        guard extent.width > 0, extent.height > 0 else { return sourcePixelBuffer }
+        image = image.transformed(by: CGAffineTransform(translationX: -extent.origin.x, y: -extent.origin.y))
+        return render(image: image, width: Int(extent.width), height: Int(extent.height))
+    }
+
+    private func render(image: CIImage, width: Int, height: Int) -> CVPixelBuffer? {
+        var output: CVPixelBuffer?
+        let attrs: [String: Any] = [
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+        ]
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_32BGRA,
+            attrs as CFDictionary,
+            &output
+        )
+        guard status == kCVReturnSuccess, let output else { return nil }
+        ciContext.render(image, to: output)
+        return output
+    }
+}
+
+private func i420ToCVPixelBuffer(_ i420: RTCI420BufferProtocol) -> CVPixelBuffer? {
+    let width = Int(i420.width)
+    let height = Int(i420.height)
+    guard width > 0, height > 0 else { return nil }
+    var buffer: CVPixelBuffer?
+    let attrs: [String: Any] = [kCVPixelBufferIOSurfacePropertiesKey as String: [:]]
+    let status = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        width,
+        height,
+        kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        attrs as CFDictionary,
+        &buffer
+    )
+    guard status == kCVReturnSuccess, let pb = buffer else { return nil }
+
+    CVPixelBufferLockBaseAddress(pb, [])
+    defer { CVPixelBufferUnlockBaseAddress(pb, []) }
+
+    guard let yDst = CVPixelBufferGetBaseAddressOfPlane(pb, 0),
+          let uvDst = CVPixelBufferGetBaseAddressOfPlane(pb, 1) else {
+        return nil
+    }
+    let yStride = CVPixelBufferGetBytesPerRowOfPlane(pb, 0)
+    let uvStride = CVPixelBufferGetBytesPerRowOfPlane(pb, 1)
+    let yBytes = yDst.assumingMemoryBound(to: UInt8.self)
+    let uvBytes = uvDst.assumingMemoryBound(to: UInt8.self)
+
+    let srcYStride = Int(i420.strideY)
+    for row in 0..<height {
+        memcpy(
+            yBytes.advanced(by: row * yStride),
+            i420.dataY.advanced(by: row * srcYStride),
+            width
+        )
+    }
+
+    let chromaWidth = width / 2
+    let chromaHeight = height / 2
+    let strideU = Int(i420.strideU)
+    let strideV = Int(i420.strideV)
+    for row in 0..<chromaHeight {
+        let srcURow = i420.dataU.advanced(by: row * strideU)
+        let srcVRow = i420.dataV.advanced(by: row * strideV)
+        let dstRow = uvBytes.advanced(by: row * uvStride)
+        for x in 0..<chromaWidth {
+            dstRow[x * 2] = srcURow[x]
+            dstRow[x * 2 + 1] = srcVRow[x]
+        }
+    }
+
+    return pb
+}
+
+private func cgOrientation(for rotation: RTCVideoRotation) -> CGImagePropertyOrientation? {
+    switch Int(rotation.rawValue) {
+    case 0: return .up
+    case 90: return .right
+    case 180: return .down
+    case 270: return .left
+    default: return nil
+    }
+}
+#endif

--- a/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
+++ b/client-ios/SerenadaCallUI/Tests/SerenadaCallUITests/CallScreenStateTests.swift
@@ -132,6 +132,112 @@ final class CallScreenStateTests: XCTestCase {
         XCTAssertFalse(shouldPreferLargeLocalPreview(localCameraMode: .screenShare))
     }
 
+    func testSystemPictureInPictureSourceSelectorUsesSharedPriority() {
+        let remotes = [remoteParticipant("remote-a"), remoteParticipant("remote-b")]
+
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: true,
+                localVideoEnabled: true,
+                remoteParticipants: remotes
+            ),
+            .local
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: true,
+                localVideoEnabled: false,
+                remoteParticipants: remotes
+            ),
+            .remote(cid: "remote-a")
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: true,
+                remoteParticipants: []
+            ),
+            .local
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: false,
+                remoteParticipants: []
+            ),
+            .remote(cid: nil)
+        )
+    }
+
+    func testSystemPictureInPictureSourceSelectorUsesPreferredSourceIds() {
+        let remotes = [remoteParticipant("remote-a"), remoteParticipant("remote-b")]
+
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: true,
+                remoteParticipants: remotes,
+                preferredSourceIds: ["remote-b"]
+            ),
+            .remote(cid: "remote-b")
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: true,
+                remoteParticipants: remotes,
+                preferredSourceIds: ["local", "remote-b"]
+            ),
+            .local
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: false,
+                remoteParticipants: remotes,
+                preferredSourceIds: ["local", "remote-b"]
+            ),
+            .remote(cid: "remote-b")
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: true,
+                remoteParticipants: remotes,
+                preferredSourceIds: ["content:remote-b"],
+                sourceIdForPreferredSourceId: { sourceId in
+                    sourceId.hasPrefix("content:")
+                        ? String(sourceId.dropFirst("content:".count))
+                        : sourceId
+                }
+            ),
+            .remote(cid: "remote-b")
+        )
+        XCTAssertEqual(
+            selectSystemPictureInPictureSource(
+                localSourceId: "local",
+                localIsPrimary: false,
+                localVideoEnabled: true,
+                remoteParticipants: remotes,
+                preferredSourceIds: ["content:local"],
+                sourceIdForPreferredSourceId: { sourceId in
+                    sourceId.hasPrefix("content:")
+                        ? String(sourceId.dropFirst("content:".count))
+                        : sourceId
+                }
+            ),
+            .local
+        )
+    }
+
     func testPinchZoomAllowedForLargeWorldAndCompositePreview() {
         XCTAssertTrue(
             shouldEnablePinchZoom(
@@ -381,5 +487,14 @@ private func speakerDevice() -> AudioDevice {
         kind: .speakerphone,
         direction: .output,
         status: .available
+    )
+}
+
+private func remoteParticipant(_ cid: String) -> RemoteParticipant {
+    RemoteParticipant(
+        cid: cid,
+        displayName: cid,
+        videoEnabled: true,
+        connectionState: .connected
     )
 }

--- a/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
@@ -359,6 +359,7 @@ final class CameraCaptureController {
 
         let fps = selectCaptureFPS(for: format)
 
+        enableMultitaskingCameraAccessIfSupported(on: capturer.captureSession)
         capturer.startCapture(with: camera, format: format, fps: fps)
         localVideoCapturer = capturer
         localCameraSource = source
@@ -375,6 +376,11 @@ final class CameraCaptureController {
         enableContinuousAutoFocus(for: camera)
 
         return true
+    }
+
+    private func enableMultitaskingCameraAccessIfSupported(on session: AVCaptureSession) {
+        guard session.isMultitaskingCameraAccessSupported else { return }
+        session.isMultitaskingCameraAccessEnabled = true
     }
 
     private func enableContinuousAutoFocus(for device: AVCaptureDevice) {

--- a/client-ios/SerenadaCore/Sources/Call/CompositeCameraVideoCapturer.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CompositeCameraVideoCapturer.swift
@@ -74,6 +74,7 @@ final class CompositeCameraVideoCapturer: RTCVideoCapturer, AVCaptureVideoDataOu
                 started = false
                 return
             }
+            enableMultitaskingCameraAccessIfSupported()
             if !session.isRunning {
                 session.startRunning()
             }
@@ -86,6 +87,11 @@ final class CompositeCameraVideoCapturer: RTCVideoCapturer, AVCaptureVideoDataOu
             started = isRunning
         }
         return started
+    }
+
+    private func enableMultitaskingCameraAccessIfSupported() {
+        guard session.isMultitaskingCameraAccessSupported else { return }
+        session.isMultitaskingCameraAccessEnabled = true
     }
 
     func stopCapture() {

--- a/client-ios/Sources/App/RootView.swift
+++ b/client-ios/Sources/App/RootView.swift
@@ -108,7 +108,8 @@ struct RootView: View {
                             inviteControlsEnabled: true,
                             debugOverlayEnabled: true,
                             snapshotEnabled: true,
-                            uiVariant: callManager.callUiVariant
+                            uiVariant: callManager.callUiVariant,
+                            systemPictureInPictureEnabled: true
                         ),
                         strings: L10n.serenadaCallStrings,
                         onInviteToRoom: { await callManager.inviteToCurrentRoom() },

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -71,6 +71,7 @@ Provider mode does not expose Serenada server helpers. These APIs require `serve
 | `inviteControlsEnabled` | Bool | `true` | Show/hide the built-in QR code and share-link UI in the waiting screen |
 | `debugOverlayEnabled` | Bool | `false` | Show/hide the in-call debug toggle and diagnostics panel |
 | `autoHideControls` | Bool | `true` | When `true`, the call controls bar fades out after a few seconds of idle time and a tap on the stage brings it back. When `false`, the controls stay visible for the entire call and the idle timer never runs. |
+| `systemPictureInPictureEnabled` | Bool | `false` | Android and iOS. Enables system Picture-in-Picture for waiting and active calls on supported mobile platforms. Android host apps must also set activity PiP manifest flags; iOS host apps must include background audio/VoIP modes. The SDK opts iOS capture sessions into multitasking camera access when supported and closes Android PiP by finishing the activity if the call ends while still in PiP. Custom PiP actions are not used, so call controls remain available after returning to the app. |
 
 ### iOS
 
@@ -83,7 +84,8 @@ SerenadaCallFlow(
         debugOverlayEnabled: true,
         autoHideControls: false,
         videoEnabled: false,
-        uiVariant: .frontline
+        uiVariant: .frontline,
+        systemPictureInPictureEnabled: true
     ),
     onDismiss: { dismiss() }
 )
@@ -101,6 +103,7 @@ SerenadaCallFlow(
         debugOverlayEnabled = true,
         autoHideControls = false,
         videoEnabled = false,
+        systemPictureInPictureEnabled = true,
     ),
     onDismiss = { navController.popBackStack() }
 )

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -92,6 +92,31 @@ fun FrontlineCallScreen(url: String) {
 
 URL-first frontline calls start audio-first and use the camera order `world -> selfie -> composite`. For session-first usage, set `defaultVideoEnabled = false` and `cameraModes = listOf(LocalCameraMode.WORLD, LocalCameraMode.SELFIE, LocalCameraMode.COMPOSITE)` on the `SerenadaConfig` used to create the session. When `Frontline` is selected, Android keeps Frontline styling for lifecycle states, 1:1 calls, and multi-party calls. The More sheet shows the current audio route first and opens a checkmarked route list for routes published by the session audio coordinator. Invite/share actions remain in the Frontline More sheet; the standard waiting-screen QR code is not shown.
 
+### Optional System Picture-in-Picture
+
+The prebuilt call UI can configure Android system Picture-in-Picture for waiting and active calls. Host apps must also opt their call activity into PiP in the manifest:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:supportsPictureInPicture="true"
+    android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation">
+    ...
+</activity>
+```
+
+Then enable the call UI flag:
+
+```kotlin
+SerenadaCallFlow(
+    url = url,
+    config = SerenadaCallFlowConfig(systemPictureInPictureEnabled = true),
+    onDismiss = { navController.popBackStack() }
+)
+```
+
+When enabled on a supported device, the SDK keeps the active video or avatar visible in system PiP and auto-enters PiP on Home/gesture leave where Android supports it. Android custom PiP actions are intentionally not used, so call controls remain available after returning to the app. If the call ends while the activity is still in PiP, the SDK finishes that activity so the system closes the PiP window instead of showing non-call UI inside it.
+
 ## Session-First (Pre-Observation)
 
 Create a session before presenting UI to observe state early:

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -68,6 +68,30 @@ SerenadaCallFlow(
 
 URL-first frontline calls start audio-first and use the camera order `world -> selfie -> composite`. For session-first usage, set `defaultVideoEnabled = false` and `cameraModes = [.world, .selfie, .composite]` on the `SerenadaConfig` used to create the session. When `frontline` is selected, iOS keeps Frontline styling for lifecycle states, 1:1 calls, and multi-party calls. The More sheet shows the current audio route first and opens the SDK route picker backed by `availableAudioDevices`, `currentAudioDevice`, and `selectAudioDevice(...)`; Phone is hidden while Bluetooth audio is present. Invite/share actions remain in the Frontline More sheet; the standard waiting-screen QR code is not shown.
 
+### Optional System Picture in Picture
+
+The prebuilt call UI can configure iOS video-call Picture in Picture for waiting and active calls. Host apps must include background audio/VoIP modes in their app `Info.plist`:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+    <string>voip</string>
+</array>
+```
+
+Then enable the call UI flag:
+
+```swift
+SerenadaCallFlow(
+    url: url,
+    config: SerenadaCallFlowConfig(systemPictureInPictureEnabled: true),
+    onDismiss: { dismiss() }
+)
+```
+
+When enabled on a supported iOS device, the SDK keeps the active large video feed or avatar visible in system PiP and lets the system return control bring the user back to the app. The SDK enables multitasking camera access on its capture sessions when iOS reports support, so local camera video can continue in PiP on supported devices. iOS does not support custom in-window PiP actions for video calls, so End Call remains available only after returning to the app.
+
 ## Session-First (Pre-Observation)
 
 Create a session before presenting UI to observe state early:


### PR DESCRIPTION
## Summary
- Add mobile system Picture in Picture support for Android and iOS call UI integrations.
- Keep PiP content simple: selected video feed when available, otherwise a scaled avatar/initials placeholder.
- Add host-app hooks, background camera handling on iOS, Android PiP activity behavior, and SDK integration docs.

## Notes
- Android PiP intentionally omits call controls and exits PiP when the call ends.
- iOS uses the system video-call PiP path and maps restore animation geometry to the active large call surface or no-video avatar cluster.

## Validation
- `git diff --check`
- `xcodegen generate`
- `xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' build`
- `./scripts/deploy_to_device.sh --udid 9C3F87BA-CA63-58AC-8A17-076E7CFFDBFE`
- `./gradlew assembleDebug`