### PR TITLE
[codex] Add custom call end handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.2] — 2026-06-02
+
+### Added
+- Web, Android, iOS: `SerenadaCallFlow` now accepts an optional
+  `onEndCall` callback so host apps can route the end-call button
+  through app-owned cleanup, analytics, service teardown, or navigation.
+
+### Changed
+- Web, Android, iOS: reconnect/status badges are gated by an 800 ms
+  delay before appearing, including the Frontline call UI.
+
 ## [0.8.1] — 2026-06-01
 
 ### Changed

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.0`
-- `app.serenada:core:0.8.0`
-- `app.serenada:call-ui:0.8.0`
+- `app.serenada:libwebrtc-7827-universal:0.8.2`
+- `app.serenada:core:0.8.2`
+- `app.serenada:call-ui:0.8.2`
 
 Release APK (signed):
 ```bash

--- a/client-android/app/src/main/java/app/serenada/android/ui/SerenadaAppRoot.kt
+++ b/client-android/app/src/main/java/app/serenada/android/ui/SerenadaAppRoot.kt
@@ -417,6 +417,9 @@ fun SerenadaAppRoot(
                             onRemoteVideoFitChanged = { isCover ->
                                 callManager.updateRemoteVideoFitCover(isCover)
                             },
+                            onEndCall = {
+                                callManager.endCall()
+                            },
                             onStartScreenShare = { intent -> callManager.startScreenShare(intent) },
                             onStopScreenShare = { callManager.stopScreenShare() },
                         )

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.1"
+                version = "0.8.2"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/FrontlineCallScreen.kt
@@ -138,6 +138,7 @@ private val FrontlineStageLocalAccentWidth = 2.5.dp
 private const val FRONTLINE_ZOOM_CHANGE_THRESHOLD = 0.01f
 private const val FRONTLINE_CONTENT_SPOTLIGHT_PREFIX = "content:"
 private const val FRONTLINE_MORE_BUTTON_HEIGHT_TO_WIDTH_RATIO = 1.62f
+private const val FRONTLINE_RECONNECTING_BADGE_DELAY_MS = 800L
 
 private enum class FrontlineFeed {
     Local,
@@ -203,6 +204,7 @@ internal fun FrontlineCallScreen(
     var isAudioRouteSheetVisible by rememberSaveable { mutableStateOf(false) }
     var showSnapshotFlash by remember { mutableStateOf(false) }
     var showDebug by rememberSaveable { mutableStateOf(false) }
+    var showConnectionStatusBadge by remember { mutableStateOf(false) }
     var debugTapTimestampMs by remember { mutableStateOf(0L) }
     var remoteVideoFitCover by rememberSaveable { mutableStateOf(initialRemoteVideoFitCover) }
     var localAspectRatio by remember { mutableStateOf<Float?>(null) }
@@ -322,9 +324,19 @@ internal fun FrontlineCallScreen(
         } else {
             null
         }
+    LaunchedEffect(uiState.phase, uiState.connectionStatus) {
+        if (uiState.phase != CallPhase.InCall || uiState.connectionStatus == ConnectionStatus.Connected) {
+            showConnectionStatusBadge = false
+            return@LaunchedEffect
+        }
+        delay(FRONTLINE_RECONNECTING_BADGE_DELAY_MS)
+        if (uiState.phase == CallPhase.InCall && uiState.connectionStatus != ConnectionStatus.Connected) {
+            showConnectionStatusBadge = true
+        }
+    }
     val showReconnectingBadge =
         uiState.phase == CallPhase.InCall &&
-            uiState.connectionStatus != ConnectionStatus.Connected
+            showConnectionStatusBadge
     LaunchedEffect(isSystemPictureInPicture) {
         if (isSystemPictureInPicture) {
             isMoreSheetVisible = false

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -58,13 +58,15 @@ private val FRONTLINE_CAMERA_MODES =
  * @param onInviteToRoom Called when the user taps the invite control. Pass `null` to hide it.
  * @param onRemoteVideoFitChanged Called when the user toggles remote video fit/fill mode.
  * @param onEndCall Called when the user taps the end-call button. When `null`, the session leaves directly.
+ *   When provided, the host owns any cleanup and dismissal for that button path.
  * @param onStartScreenShare Called with the [MediaProjection][android.media.projection.MediaProjection]
  *   consent intent when the user starts screen sharing. Use this to start a foreground service with
  *   [FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION][android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION]
  *   before the projection begins. When `null`, the session handles screen sharing directly.
  * @param onStopScreenShare Called when the user stops screen sharing. Use this to downgrade the
  *   foreground service type. When `null`, the session handles it directly.
- * @param onDismiss Called when the call ends and the UI should be dismissed.
+ * @param onDismiss Called when the call ends and the UI should be dismissed, excluding a custom
+ *   [onEndCall] button path.
  */
 @Composable
 fun SerenadaCallFlow(
@@ -124,6 +126,7 @@ fun SerenadaCallFlow(
     var pendingPermissions by remember(activeSession) { mutableStateOf<List<app.serenada.core.MediaCapability>?>(null) }
     var pendingPermissionPurpose by remember(activeSession) { mutableStateOf<PermissionRequestPurpose?>(null) }
     var hasStarted by remember(activeSession) { mutableStateOf(false) }
+    var skipNextIdleDismiss by remember(activeSession) { mutableStateOf(false) }
 
     val permissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -169,7 +172,11 @@ fun SerenadaCallFlow(
         if (state.phase != CallPhase.Idle) {
             hasStarted = true
         } else if (hasStarted) {
-            onDismiss()
+            if (skipNextIdleDismiss) {
+                skipNextIdleDismiss = false
+            } else {
+                onDismiss()
+            }
         }
     }
 
@@ -221,7 +228,12 @@ fun SerenadaCallFlow(
         onFlipCamera = { activeSession.flipCamera() },
         onToggleFlashlight = { activeSession.toggleFlashlight() },
         onLocalPinchZoom = { scaleFactor -> activeSession.adjustLocalCameraZoom(scaleFactor) },
-        onEndCall = onEndCall ?: { activeSession.leave() },
+        onEndCall = onEndCall?.let { customEndCall ->
+            {
+                skipNextIdleDismiss = true
+                customEndCall()
+            }
+        } ?: { activeSession.leave() },
         onSelectAudioDevice = { device -> activeSession.selectAudioDevice(device) },
         onShareLink = onShareLink,
         onInviteToRoom = { onInviteToRoom?.invoke() },

--- a/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
+++ b/client-android/serenada-call-ui/src/main/java/app/serenada/callui/SerenadaCallFlow.kt
@@ -57,6 +57,7 @@ private val FRONTLINE_CAMERA_MODES =
  * @param onShareLink Called when the user taps the share-link control. Pass `null` to hide it.
  * @param onInviteToRoom Called when the user taps the invite control. Pass `null` to hide it.
  * @param onRemoteVideoFitChanged Called when the user toggles remote video fit/fill mode.
+ * @param onEndCall Called when the user taps the end-call button. When `null`, the session leaves directly.
  * @param onStartScreenShare Called with the [MediaProjection][android.media.projection.MediaProjection]
  *   consent intent when the user starts screen sharing. Use this to start a foreground service with
  *   [FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION][android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION]
@@ -77,6 +78,7 @@ fun SerenadaCallFlow(
     onShareLink: (() -> Unit)? = null,
     onInviteToRoom: (() -> Unit)? = null,
     onRemoteVideoFitChanged: ((Boolean) -> Unit)? = null,
+    onEndCall: (() -> Unit)? = null,
     onStartScreenShare: ((Intent) -> Unit)? = null,
     onStopScreenShare: (() -> Unit)? = null,
     onSnapshotCaptured: ((SnapshotResult) -> Unit)? = null,
@@ -219,7 +221,7 @@ fun SerenadaCallFlow(
         onFlipCamera = { activeSession.flipCamera() },
         onToggleFlashlight = { activeSession.toggleFlashlight() },
         onLocalPinchZoom = { scaleFactor -> activeSession.adjustLocalCameraZoom(scaleFactor) },
-        onEndCall = { activeSession.leave() },
+        onEndCall = onEndCall ?: { activeSession.leave() },
         onSelectAudioDevice = { device -> activeSession.selectAudioDevice(device) },
         onShareLink = onShareLink,
         onInviteToRoom = { onInviteToRoom?.invoke() },

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.1"
+val sdkVersion = "0.8.2"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.1"
+val sdkVersion = "0.8.2"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
+++ b/client-ios/SerenadaCallUI/Sources/FrontlineCallScreen.swift
@@ -18,6 +18,7 @@ private let frontlineMoreButtonHeightToWidthRatio: CGFloat = 1.62
 private let frontlineLargeVideoAccentLineWidth: CGFloat = 3
 private let frontlinePipVideoAccentLineWidth: CGFloat = 2.5
 private let frontlinePipBorderLineWidth: CGFloat = 1.5
+private let frontlineReconnectingBadgeDelayNanoseconds: UInt64 = 800_000_000
 
 private enum FrontlineFeed {
     case local
@@ -135,6 +136,7 @@ struct FrontlineCallScreenView: View {
     @State private var lastVideoStartedParticipantId: String?
     @State private var previousRemoteVideoEnabled: [String: Bool] = [:]
     @State private var broadcastTriggerCount = 0
+    @State private var showConnectionStatusBadge = false
 
     init(
         roomId: String,
@@ -318,6 +320,17 @@ struct FrontlineCallScreenView: View {
         .onChange(of: uiState.localCameraMode) { _ in pipSwapped = false }
         .task(id: currentSystemPictureInPictureSource) {
             onSystemPictureInPictureSourceChanged?(currentSystemPictureInPictureSource)
+        }
+        .task(id: "\(uiState.phase.rawValue):\(uiState.connectionStatus.rawValue)") {
+            guard uiState.phase == .inCall, uiState.connectionStatus != .connected else {
+                showConnectionStatusBadge = false
+                return
+            }
+            showConnectionStatusBadge = false
+            try? await Task.sleep(nanoseconds: frontlineReconnectingBadgeDelayNanoseconds)
+            guard !Task.isCancelled else { return }
+            guard uiState.phase == .inCall, uiState.connectionStatus != .connected else { return }
+            showConnectionStatusBadge = true
         }
         .onChange(of: uiState.remoteParticipants.map { $0.cid }) { activeCids in
             let active = Set(activeCids)
@@ -676,7 +689,7 @@ struct FrontlineCallScreenView: View {
 
     private var reconnectingBadge: some View {
         Group {
-            if uiState.phase == .inCall && uiState.connectionStatus != .connected {
+            if uiState.phase == .inCall && showConnectionStatusBadge {
                 VStack(spacing: 4) {
                     Text(str(.callReconnecting))
                         .font(.system(size: 14, weight: .medium))

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -19,6 +19,7 @@ public struct SerenadaCallFlow: View {
     private let config: SerenadaCallFlowConfig
     private let strings: [SerenadaString: String]?
     private let onDismiss: (() -> Void)?
+    private var onEndCall: (() -> Void)?
     private var onCallEnded: ((EndReason) -> Void)?
     private var onSnapshotCaptured: ((SnapshotResult) -> Void)?
     private var onSnapshotError: ((SnapshotError) -> Void)?
@@ -45,12 +46,14 @@ public struct SerenadaCallFlow: View {
         serenadaConfig: SerenadaConfig = SerenadaConfig(serverHost: "serenada.app"),
         config: SerenadaCallFlowConfig = SerenadaCallFlowConfig(),
         strings: [SerenadaString: String]? = nil,
+        onEndCall: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.mode = .urlFirst(url: url, serenadaConfig: serenadaConfig)
         self.config = config
         self.strings = strings
         self.onDismiss = onDismiss
+        self.onEndCall = onEndCall
         self.onCallEnded = nil
         self._avatarCache = StateObject(wrappedValue: AvatarCache(provider: config.avatarProvider))
     }
@@ -65,6 +68,7 @@ public struct SerenadaCallFlow: View {
         strings: [SerenadaString: String]? = nil,
         onInviteToRoom: (() async -> Result<Void, Error>)? = nil,
         onRemoteVideoFitChanged: ((Bool) -> Void)? = nil,
+        onEndCall: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.mode = .sessionFirst(SessionParams(
@@ -77,6 +81,7 @@ public struct SerenadaCallFlow: View {
         self.config = config
         self.strings = strings
         self.onDismiss = onDismiss
+        self.onEndCall = onEndCall
         self.onCallEnded = nil
         self._avatarCache = StateObject(wrappedValue: AvatarCache(provider: config.avatarProvider))
     }
@@ -93,6 +98,7 @@ public struct SerenadaCallFlow: View {
                     config: config,
                     strings: strings,
                     onDismiss: onDismiss,
+                    onEndCall: onEndCall,
                     onCallEnded: onCallEnded,
                     onSnapshotCaptured: onSnapshotCaptured,
                     onSnapshotError: onSnapshotError
@@ -104,6 +110,7 @@ public struct SerenadaCallFlow: View {
                     config: config,
                     strings: strings,
                     onDismiss: onDismiss,
+                    onEndCall: onEndCall,
                     onCallEnded: onCallEnded,
                     onSnapshotCaptured: onSnapshotCaptured,
                     onSnapshotError: onSnapshotError
@@ -145,6 +152,7 @@ private struct URLFirstCallFlow: View {
     let config: SerenadaCallFlowConfig
     let strings: [SerenadaString: String]?
     let onDismiss: (() -> Void)?
+    let onEndCall: (() -> Void)?
     let onCallEnded: ((EndReason) -> Void)?
     let onSnapshotCaptured: ((SnapshotResult) -> Void)?
     let onSnapshotError: ((SnapshotError) -> Void)?
@@ -166,6 +174,7 @@ private struct URLFirstCallFlow: View {
                     config: config,
                     strings: strings,
                     onDismiss: onDismiss,
+                    onEndCall: onEndCall,
                     onCallEnded: onCallEnded,
                     onSnapshotCaptured: onSnapshotCaptured,
                     onSnapshotError: onSnapshotError
@@ -210,6 +219,7 @@ private struct SessionFirstCallFlow: View {
     let config: SerenadaCallFlowConfig
     let strings: [SerenadaString: String]?
     let onDismiss: (() -> Void)?
+    let onEndCall: (() -> Void)?
     let onCallEnded: ((EndReason) -> Void)?
     let onSnapshotCaptured: ((SnapshotResult) -> Void)?
     let onSnapshotError: ((SnapshotError) -> Void)?
@@ -223,6 +233,7 @@ private struct SessionFirstCallFlow: View {
         config: SerenadaCallFlowConfig,
         strings: [SerenadaString: String]?,
         onDismiss: (() -> Void)?,
+        onEndCall: (() -> Void)?,
         onCallEnded: ((EndReason) -> Void)?,
         onSnapshotCaptured: ((SnapshotResult) -> Void)? = nil,
         onSnapshotError: ((SnapshotError) -> Void)? = nil
@@ -231,6 +242,7 @@ private struct SessionFirstCallFlow: View {
         self.config = config
         self.strings = strings
         self.onDismiss = onDismiss
+        self.onEndCall = onEndCall
         self.onCallEnded = onCallEnded
         self.onSnapshotCaptured = onSnapshotCaptured
         self.onSnapshotError = onSnapshotError
@@ -400,6 +412,10 @@ private struct SessionFirstCallFlow: View {
     }
 
     private func endCall() {
+        if let onEndCall {
+            onEndCall()
+            return
+        }
         session.leave()
         onCallEnded?(.localLeft)
         onDismiss?()

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -19,7 +19,7 @@ public struct SerenadaCallFlow: View {
     private let config: SerenadaCallFlowConfig
     private let strings: [SerenadaString: String]?
     private let onDismiss: (() -> Void)?
-    private var onEndCall: (() -> Void)?
+    private let onEndCall: (() -> Void)?
     private var onCallEnded: ((EndReason) -> Void)?
     private var onSnapshotCaptured: ((SnapshotResult) -> Void)?
     private var onSnapshotError: ((SnapshotError) -> Void)?

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.1"
+    public static let version = "0.8.2"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/Sources/App/RootView.swift
+++ b/client-ios/Sources/App/RootView.swift
@@ -116,6 +116,9 @@ struct RootView: View {
                         onRemoteVideoFitChanged: { value in
                             SettingsStore().isRemoteVideoFitCover = value
                         },
+                        onEndCall: {
+                            callManager.dismissActiveCall()
+                        },
                         onDismiss: { callManager.dismissActiveCall() }
                     )
                     .onSnapshotCaptured { result in

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.1",
-        "@agatx/serenada-react-ui": "0.8.1",
+        "@agatx/serenada-core": "0.8.2",
+        "@agatx/serenada-react-ui": "0.8.2",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.1"
+        "@agatx/serenada-core": "0.8.2"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.1",
+        "@agatx/serenada-core": "^0.8.2",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.1",
-    "@agatx/serenada-react-ui": "0.8.1",
+    "@agatx/serenada-core": "0.8.2",
+    "@agatx/serenada-react-ui": "0.8.2",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.1';
+export const SERENADA_CORE_VERSION = '0.8.2';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.1",
+    "@agatx/serenada-core": "^0.8.2",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.1"
+    "@agatx/serenada-core": "0.8.2"
   },
   "repository": {
     "type": "git",

--- a/client/packages/react-ui/src/SerenadaCallFlow.tsx
+++ b/client/packages/react-ui/src/SerenadaCallFlow.tsx
@@ -307,6 +307,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     strings,
     waitingActions,
     onDismiss,
+    onEndCall,
     onStatsUpdate,
     onSnapshotCaptured,
     onSnapshotError,
@@ -398,7 +399,7 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     // automatically when video comes back on.
     const effectiveLocalLarge = isLocalLarge && !isCameraOff;
     const [areControlsVisible, setAreControlsVisible] = useState(true);
-    const [showRecoveringBadge, setShowRecoveringBadge] = useState(false);
+    const [showConnectionStatusBadge, setShowConnectionStatusBadge] = useState(false);
     const [showWaiting, setShowWaiting] = useState(true);
     const [showDebug, setShowDebug] = useState(false);
     const [debugStats, setDebugStats] = useState<CallStats | null>(null);
@@ -487,30 +488,25 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     }, [localParticipant?.cameraMode]);
 
     const showReconnecting = useMemo(() => (
-        effectiveState.phase !== 'idle' &&
-        effectiveState.phase !== 'ending' &&
-        effectiveState.connectionStatus === 'retrying'
-    ) || (
-        effectiveState.phase !== 'idle' &&
-        effectiveState.phase !== 'ending' &&
-        effectiveState.connectionStatus === 'recovering' &&
-        showRecoveringBadge
-    ), [effectiveState.connectionStatus, effectiveState.phase, showRecoveringBadge]);
+        (effectiveState.phase === 'waiting' || effectiveState.phase === 'inCall') &&
+        effectiveState.connectionStatus !== 'connected' &&
+        showConnectionStatusBadge
+    ), [effectiveState.connectionStatus, effectiveState.phase, showConnectionStatusBadge]);
 
     useEffect(() => {
         if (effectiveState.phase !== 'waiting' && effectiveState.phase !== 'inCall') {
             // eslint-disable-next-line react-hooks/set-state-in-effect -- reconnect badge resets immediately when the call is no longer active
-            setShowRecoveringBadge(false);
+            setShowConnectionStatusBadge(false);
             return;
         }
 
-        if (effectiveState.connectionStatus !== 'recovering') {
-            setShowRecoveringBadge(false);
+        if (effectiveState.connectionStatus === 'connected') {
+            setShowConnectionStatusBadge(false);
             return;
         }
 
         const timer = window.setTimeout(() => {
-            setShowRecoveringBadge(true);
+            setShowConnectionStatusBadge(true);
         }, 800);
         return () => window.clearTimeout(timer);
     }, [effectiveState.connectionStatus, effectiveState.phase]);
@@ -712,11 +708,13 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
     }, [onDismiss, session]);
 
     const handleLeave = useCallback(() => {
-        if (session) {
-            session.leave();
+        if (onEndCall) {
+            onEndCall();
+            return;
         }
+        session?.leave();
         onDismiss?.();
-    }, [onDismiss, session]);
+    }, [onDismiss, onEndCall, session]);
 
     const handleToggleAudio = useCallback(() => {
         session?.toggleAudio();
@@ -999,7 +997,10 @@ export const SerenadaCallFlow: React.FC<CallFlowProps> = ({
 
     const overlayContent = (
         <>
-            <StatusOverlay connectionStatus={effectiveState.connectionStatus} strings={strings} />
+            <StatusOverlay
+                connectionStatus={showReconnecting ? effectiveState.connectionStatus : 'connected'}
+                strings={strings}
+            />
             {permissionDenied && effectiveState.phase === 'inCall' && (
                 <div className="permission-denied-banner">
                     {resolveString('permissionDeniedSettings', strings)}

--- a/client/packages/react-ui/src/types.ts
+++ b/client/packages/react-ui/src/types.ts
@@ -172,9 +172,9 @@ export interface CallFlowProps {
     strings?: Partial<Record<SerenadaString, string>>;
     /** Optional host-app controls rendered in the waiting screen below default invite controls. */
     waitingActions?: ReactNode;
-    /** Called when the user dismisses the call UI (end/leave/cancel). */
+    /** Called when the call UI dismisses itself, such as cancel or the default end-call behavior. */
     onDismiss?: () => void;
-    /** Called when the user taps the end-call button. When unset, the session leaves directly. */
+    /** Called when the user taps the end-call button. When set, the host owns leaving and dismissal. */
     onEndCall?: () => void;
     /** Callback fired when call stats are updated for host-owned diagnostics or bridge code. */
     onStatsUpdate?: (stats: CallStats | null) => void;

--- a/client/packages/react-ui/src/types.ts
+++ b/client/packages/react-ui/src/types.ts
@@ -174,6 +174,8 @@ export interface CallFlowProps {
     waitingActions?: ReactNode;
     /** Called when the user dismisses the call UI (end/leave/cancel). */
     onDismiss?: () => void;
+    /** Called when the user taps the end-call button. When unset, the session leaves directly. */
+    onEndCall?: () => void;
     /** Callback fired when call stats are updated for host-owned diagnostics or bridge code. */
     onStatsUpdate?: (stats: CallStats | null) => void;
     /**

--- a/client/src/pages/CallRoom.tsx
+++ b/client/src/pages/CallRoom.tsx
@@ -443,6 +443,11 @@ const CallRoom: React.FC = () => {
         navigate('/');
     }, [navigate, roomId]);
 
+    const handleEndCall = useCallback(() => {
+        session?.leave();
+        handleDismiss();
+    }, [handleDismiss, session]);
+
     const handleInvite = useCallback(async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         if (!roomId || isInviting) return;
@@ -671,6 +676,7 @@ const CallRoom: React.FC = () => {
             strings={strings}
             waitingActions={waitingActions}
             onDismiss={handleDismiss}
+            onEndCall={handleEndCall}
             onSnapshotCaptured={handleSnapshotCaptured}
             onSnapshotError={handleSnapshotError}
         />

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -391,6 +391,16 @@ Only the exported `SerenadaString` keys are overridable. Other small utility lab
 
 ---
 
+## End-call handling
+
+`SerenadaCallFlow` leaves the active session directly when the user taps End Call
+unless you provide `onEndCall`. Use `onEndCall` when the host app needs to route
+the button through app-owned cleanup, foreground-service teardown, analytics, or
+navigation. When provided, the callback owns calling `session.leave()` and
+releasing any host-owned session resources.
+
+---
+
 ## Theming
 
 Each platform provides a theme object to customize the call UI's visual appearance.

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -138,10 +138,22 @@ fun handleDeepLink(uri: Uri) {
     // In your Composable:
     SerenadaCallFlow(
         session = session,
-        onDismiss = { navController.popBackStack() }
+        onEndCall = {
+            session.leave()
+            session.close()
+            navController.popBackStack()
+        },
+        onDismiss = {
+            session.close()
+            navController.popBackStack()
+        }
     )
 }
 ```
+
+If `onEndCall` is omitted, the prebuilt UI calls `session.leave()` before
+dismissing. When you provide `onEndCall`, your host owns the end button behavior,
+including leaving or closing the session and updating navigation state.
 
 ## Create a Room
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.0")
-    implementation("app.serenada:call-ui:0.8.0")
+    implementation("app.serenada:core:0.8.2")
+    implementation("app.serenada:call-ui:0.8.2")
 }
 ```
 

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -107,11 +107,22 @@ func handleDeepLink(_ url: URL) {
     // Observe session.state before showing UI if needed
 
     presentFullScreen {
-        SerenadaCallFlow(session: session, onDismiss: { dismiss() })
+        SerenadaCallFlow(
+            session: session,
+            onEndCall: {
+                session.leave()
+                dismiss()
+            },
+            onDismiss: { dismiss() }
+        )
             .serenadaTheme(.init(accentColor: .blue))
     }
 }
 ```
+
+If `onEndCall` is omitted, the prebuilt UI calls `session.leave()` before
+dismissing. When you provide `onEndCall`, your host owns the end button behavior,
+including leaving the session and updating navigation state.
 
 ## Create a Room
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.0 @agatx/serenada-react-ui@0.8.0 lucide-react
+npm install @agatx/serenada-core@0.8.2 @agatx/serenada-react-ui@0.8.2 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -57,11 +57,22 @@ function CallPage() {
     return (
         <SerenadaCallFlow
             session={session}
-            onDismiss={() => navigate('/')}
+            onEndCall={() => {
+                session.leave()
+                navigate('/')
+            }}
+            onDismiss={() => {
+                session.destroy()
+                navigate('/')
+            }}
         />
     )
 }
 ```
+
+If `onEndCall` is omitted, the prebuilt UI calls `session.leave()` before
+dismissing. When you provide `onEndCall`, your host owns the end button behavior,
+including leaving or destroying the session and updating navigation state.
 
 ## Create a Room
 

--- a/samples/android/README.md
+++ b/samples/android/README.md
@@ -4,7 +4,7 @@ Minimal Android host app demonstrating Serenada SDK integration using `serenada-
 
 ## What it does
 
-- Accepts a call URL and presents `SerenadaCallFlow` (URL-first path)
+- Accepts a call URL, creates a session, and presents `SerenadaCallFlow` (session-first path)
 - Creates a new room via `SerenadaCore.createRoom()` and joins explicitly with `join()` (session-first path)
 - Starts a provider-mode demo backed by a local in-memory `SignalingProvider`
 - Shows incremental `peerJoined` events and peer-message delivery without Serenada server transport
@@ -51,11 +51,20 @@ val serenada = SerenadaCore(
     context = this,
 )
 
-// 2. Join via URL (URL-first — SDK creates the session internally)
+// 2. Join via URL and present the host-owned session.
+val session = serenada.join(url = callUrl)
 SerenadaCallFlow(
-    url = callUrl,
+    session = session,
     config = SerenadaCallFlowConfig(screenSharingEnabled = false, inviteControlsEnabled = false),
-    onDismiss = { /* navigate back */ },
+    onEndCall = {
+        session.leave()
+        session.close()
+        // navigate back
+    },
+    onDismiss = {
+        session.close()
+        // navigate back
+    },
 )
 
 // 3. Or create a room, then join explicitly
@@ -66,7 +75,10 @@ scope.launch {
     SerenadaCallFlow(
         session = session,
         config = SerenadaCallFlowConfig(screenSharingEnabled = false, inviteControlsEnabled = false),
-        onDismiss = { /* navigate back */ },
+        onDismiss = {
+            session.close()
+            // navigate back
+        },
     )
 }
 ```

--- a/samples/android/app/src/main/java/app/serenada/sample/MainActivity.kt
+++ b/samples/android/app/src/main/java/app/serenada/sample/MainActivity.kt
@@ -78,15 +78,24 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun SampleApp(serenada: SerenadaCore) {
-    var callUrl by remember { mutableStateOf<String?>(null) }
+    var callSession by remember { mutableStateOf<SerenadaSession?>(null) }
     var providerDemo by remember { mutableStateOf<ProviderDemoSession?>(null) }
     val context = LocalContext.current
+    fun dismissCall(leave: Boolean) {
+        val session = callSession
+        if (leave) {
+            session?.leave()
+        }
+        session?.close()
+        callSession = null
+    }
 
     when {
-        callUrl != null -> SerenadaCallFlow(
-            url = callUrl!!,
+        callSession != null -> SerenadaCallFlow(
+            session = callSession!!,
             config = sampleCallFlowConfig,
-            onDismiss = { callUrl = null },
+            onEndCall = { dismissCall(leave = true) },
+            onDismiss = { dismissCall(leave = false) },
         )
 
         providerDemo != null -> ProviderDemoScreen(
@@ -98,7 +107,7 @@ private fun SampleApp(serenada: SerenadaCore) {
         )
 
         else -> HomeScreen(
-            onJoinUrl = { callUrl = it },
+            onJoinUrl = { callSession = serenada.join(it) },
             onStartProviderDemo = {
                 val provider = SampleMockSignalingProvider()
                 val coordinator = SampleAudioCoordinator()

--- a/samples/ios/README.md
+++ b/samples/ios/README.md
@@ -4,7 +4,7 @@ Minimal iOS host app demonstrating Serenada SDK integration with SwiftUI.
 
 ## What it does
 
-- Accepts a call URL and presents `SerenadaCallFlow` using built-in Serenada signaling
+- Accepts a call URL, creates a session, and presents `SerenadaCallFlow` using built-in Serenada signaling
 - Creates a new room via `SerenadaCore.createRoom()` and joins explicitly with `join()`
 - Starts a provider-mode demo backed by a local in-memory `SignalingProvider`
 - Shows incremental `peerJoined` events and peer-message delivery without Serenada transport
@@ -64,13 +64,22 @@ import SerenadaCore
 let serenada = SerenadaCore(config: .init(serverHost: "serenada.app"))
 
 // 1. Join an existing invite link.
-SerenadaCallFlow(url: callURL, config: .init(screenSharingEnabled: false, inviteControlsEnabled: false))
+let session = serenada.join(url: callURL)
+SerenadaCallFlow(
+    session: session,
+    config: .init(screenSharingEnabled: false, inviteControlsEnabled: false),
+    onEndCall: {
+        session.leave()
+        dismiss()
+    },
+    onDismiss: { dismiss() }
+)
 
 // 2. Create a room, then join explicitly.
 Task {
     let room = try await serenada.createRoom()
-    let session = serenada.join(url: room.url)
-    SerenadaCallFlow(session: session, config: .init(screenSharingEnabled: false, inviteControlsEnabled: false))
+    let roomSession = serenada.join(url: room.url)
+    SerenadaCallFlow(session: roomSession, config: .init(screenSharingEnabled: false, inviteControlsEnabled: false))
 }
 ```
 

--- a/samples/ios/SampleApp/SampleApp.swift
+++ b/samples/ios/SampleApp/SampleApp.swift
@@ -10,7 +10,7 @@ private let sampleCallFlowConfig = SerenadaCallFlowConfig(
 )
 
 private enum ActiveCall {
-    case url(URL)
+    case session(SerenadaSession)
 }
 
 private struct ProviderDemoSession {
@@ -66,10 +66,14 @@ struct SerenadaiOSSampleApp: App {
     @ViewBuilder
     private func callFlow(for activeCall: ActiveCall) -> some View {
         switch activeCall {
-        case .url(let url):
+        case .session(let session):
             SerenadaCallFlow(
-                url: url,
+                session: session,
                 config: sampleCallFlowConfig,
+                onEndCall: {
+                    session.leave()
+                    self.activeCall = nil
+                },
                 onDismiss: { self.activeCall = nil }
             )
         }
@@ -182,7 +186,7 @@ private struct HomeView: View {
         }
 
         errorMessage = nil
-        onStartCall(.url(url))
+        onStartCall(.session(serenada.join(url: url)))
     }
 
     private func createRoom() {
@@ -194,7 +198,7 @@ private struct HomeView: View {
                 let room = try await serenada.createRoom()
                 isCreatingRoom = false
                 lastCreatedRoomURL = room.url
-                onStartCall(.url(room.url))
+                onStartCall(.session(serenada.join(url: room.url)))
             } catch {
                 isCreatingRoom = false
                 errorMessage = error.localizedDescription

--- a/samples/web/README.md
+++ b/samples/web/README.md
@@ -4,7 +4,7 @@ Minimal web host app demonstrating Serenada SDK integration with React.
 
 ## What it does
 
-- Accepts a call URL and renders `<SerenadaCallFlow>` using built-in Serenada signaling
+- Accepts a call URL, creates a session, and renders `<SerenadaCallFlow>` using built-in Serenada signaling
 - Creates a new room via `createSerenadaCore({ serverHost }).createRoom()` and joins explicitly with `join()`
 - Starts a custom-provider demo backed by an in-memory `SignalingProvider`
 - Shows provider-mode incremental `peerJoined` events plus `onPeerMessage()` delivery without Serenada transport
@@ -48,12 +48,29 @@ const serenada = createSerenadaCore({ serverHost: 'serenada.app' })
 // Prefer SerenadaSessionHandle in app-facing code and component props.
 
 // 2a. Join an existing invite link by URL
-<SerenadaCallFlow url={callUrl} onDismiss={() => navigate('/')} />
+const callSession = serenada.join(callUrl)
+<SerenadaCallFlow
+  session={callSession}
+  onEndCall={() => {
+    callSession.leave()
+    navigate('/')
+  }}
+  onDismiss={() => {
+    callSession.destroy()
+    navigate('/')
+  }}
+/>
 
 // 2b. Create a room, then join explicitly.
 const room = await serenada.createRoom()
 const session = serenada.join(room.url)
-<SerenadaCallFlow session={session} onDismiss={() => navigate('/')} />
+<SerenadaCallFlow
+  session={session}
+  onDismiss={() => {
+    session.destroy()
+    navigate('/')
+  }}
+/>
 ```
 
 Provider mode uses the same SDK package with an injected provider instead of `serverHost`:

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.7.1",
+      "version": "0.8.2",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.7.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.7.1"
+        "@agatx/serenada-core": "0.8.2"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.7.1",
+        "@agatx/serenada-core": "^0.8.2",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/samples/web/src/App.tsx
+++ b/samples/web/src/App.tsx
@@ -13,8 +13,7 @@ const builtInSerenada = createSerenadaCore({ serverHost: 'serenada.app' })
 
 interface ActiveCall {
     kind: 'built-in'
-    url: string
-    session?: SerenadaSessionHandle
+    session: SerenadaSessionHandle
 }
 
 interface ProviderDemoState {
@@ -128,6 +127,13 @@ class SampleMockProvider extends SignalingProviderEmitter {
 export default function App() {
     const [activeScreen, setActiveScreen] = useState<ActiveScreen>(null)
 
+    const startBuiltInCall = useCallback((url: string) => {
+        setActiveScreen({
+            kind: 'built-in',
+            session: builtInSerenada.join(url),
+        })
+    }, [])
+
     const dismissProviderDemo = useCallback(() => {
         setActiveScreen((current) => {
             if (!current || current.kind !== 'provider-demo') {
@@ -190,9 +196,15 @@ export default function App() {
     if (activeScreen?.kind === 'built-in') {
         return (
             <SerenadaCallFlow
-                url={activeScreen.url}
                 session={activeScreen.session}
-                onDismiss={() => setActiveScreen(null)}
+                onEndCall={() => {
+                    activeScreen.session.leave()
+                    setActiveScreen(null)
+                }}
+                onDismiss={() => {
+                    activeScreen.session.destroy()
+                    setActiveScreen(null)
+                }}
             />
         )
     }
@@ -208,7 +220,7 @@ export default function App() {
 
     return (
         <HomeScreen
-            onJoin={(call) => setActiveScreen(call)}
+            onJoin={startBuiltInCall}
             onStartProviderDemo={startProviderDemo}
         />
     )
@@ -218,7 +230,7 @@ function HomeScreen({
     onJoin,
     onStartProviderDemo,
 }: {
-    onJoin: (call: ActiveCall) => void
+    onJoin: (url: string) => void
     onStartProviderDemo: () => void
 }) {
     const [urlText, setUrlText] = useState('')
@@ -226,7 +238,7 @@ function HomeScreen({
     const handleCreateRoom = useCallback(async () => {
         const room = await builtInSerenada.createRoom()
         console.log('Share this URL:', room.url)
-        onJoin({ kind: 'built-in', url: room.url })
+        onJoin(room.url)
     }, [onJoin])
 
     return (
@@ -249,7 +261,7 @@ function HomeScreen({
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                     <button
-                        onClick={() => onJoin({ kind: 'built-in', url: urlText })}
+                        onClick={() => onJoin(urlText)}
                         disabled={!urlText}
                     >
                         Join Call


### PR DESCRIPTION
## Summary
- Adds an optional `onEndCall` hook to the prebuilt call flow on Android, iOS, and web so host apps can route the end button through app-owned cleanup.
- Reduces the Frontline reconnect/status badge delay to 800ms and applies the same gated status overlay behavior across platforms.
- Bumps SDK package/artifact versions, code constants, docs, changelog, and sample lock metadata to `0.8.2`.
- Updates host apps, samples, and SDK docs to use/document host-owned session cleanup.

## Validation
- `node scripts/check-version-parity.mjs`
- `git diff --check`
- `cd client && npm run build`
- `cd client-android && ./gradlew :serenada-core:compileDebugKotlin :serenada-call-ui:compileDebugKotlin --console=plain`
- `cd client-android && ./gradlew :serenada-call-ui:compileDebugKotlin :app:compileDebugKotlin --console=plain`
- `cd client-ios && xcodegen generate`
- `cd client-ios && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' build CODE_SIGNING_ALLOWED=NO`
- `cd samples/android && ./gradlew :app:compileDebugKotlin --console=plain`
- `cd samples/web && npm run build`
- `cd samples/ios && xcodegen generate && xcodebuild -project SerenadaiOSSample.xcodeproj -scheme SerenadaiOSSample -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' build CODE_SIGNING_ALLOWED=NO`

Note: the generic `platform=iOS Simulator,name=iPhone 16` destination did not resolve in this local Xcode setup, so iOS builds were rerun successfully against the concrete simulator ID above.