### PR TITLE
[codex] Fix SDK media negotiation and bump 0.8.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,10 @@ SDK packages must not depend on UI frameworks (no SwiftUI in SerenadaCore, no Re
 
 ## Cross-Platform Parity
 - Resilience constants are shared across all clients. Run `node scripts/check-resilience-constants.mjs` to verify.
+- Signaling protocol wire constants are shared across all clients. Run `node scripts/check-signaling-protocol-constants.mjs` to verify.
 - Signaling protocol v1 is identical across all platforms (see `docs/serenada_protocol_v1.md`).
 - When changing resilience timing, update all three constant files and run the verification script.
+- When changing signaling protocol wire constants, update all three protocol constant files and run the verification script.
 
 ## Documentation
 - Update all relevant documentation when making changes. Only update documentation that is directly relevant to the change:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.3] — 2026-06-04
+
+### Fixed
+- Web: answerers attach or start local media before creating an answer,
+  so initial audio/video is negotiated instead of waiting for media
+  recovery when the answerer is the deterministic non-offerer.
+- Web, Android, iOS: late local track negotiation uses a normal
+  deterministic-offerer renegotiation request, while true stalled
+  outbound media recovery keeps the peer-recreate path.
+- Web, Android, iOS: local sender replacement now prefers negotiated
+  transceivers and clears stale same-kind senders before attaching the
+  active track.
+
 ## [0.8.2] — 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ bash tools/integration-test/run.sh    # Run signaling integration tests (require
 
 ### Version Parity
 
-Verify SDK versions match across all platforms:
+Verify SDK versions and shared protocol constants match across all platforms:
 ```bash
 node scripts/check-version-parity.mjs
+node scripts/check-signaling-protocol-constants.mjs
 ```
 
 ## Architecture

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.2`
-- `app.serenada:core:0.8.2`
-- `app.serenada:call-ui:0.8.2`
+- `app.serenada:libwebrtc-7827-universal:0.8.3`
+- `app.serenada:core:0.8.3`
+- `app.serenada:call-ui:0.8.3`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.2"
+                version = "0.8.3"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.2"
+val sdkVersion = "0.8.3"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.3.0"
+        const val VERSION = "0.8.3"
     }
 }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -159,7 +159,8 @@ internal class PeerNegotiationEngine(
                 handleRemoteIce(slot, fromCid, candidate, offerIdFromPayload(msg.payload))
             }
             "media_restart_request" -> {
-                handleMediaRestartRequest(slot, fromCid)
+                val reason = msg.payload?.optString("reason").orEmpty().trim()
+                handleMediaRestartRequest(slot, fromCid, reason)
             }
         }
     }
@@ -282,7 +283,7 @@ internal class PeerNegotiationEngine(
             },
             { cid ->
                 handler.post {
-                    getSlot(cid)?.let { maybeSendOffer(it, force = true) }
+                    handleRenegotiationNeeded(cid)
                 }
             }
         )
@@ -608,7 +609,20 @@ internal class PeerNegotiationEngine(
         if (!force) slot.markOfferSent()
     }
 
-    private fun handleMediaRestartRequest(slot: PeerConnectionSlotProtocol, remoteCid: String) {
+    private fun handleRenegotiationNeeded(remoteCid: String) {
+        val slot = getSlot(remoteCid) ?: return
+        if (shouldIOffer(remoteCid, getCurrentRoomState())) {
+            maybeSendOffer(slot, force = true)
+        } else {
+            requestPeerLocalTrackNegotiation(remoteCid, slot)
+        }
+    }
+
+    private fun handleMediaRestartRequest(slot: PeerConnectionSlotProtocol, remoteCid: String, reason: String) {
+        if (reason == SignalingProtocolConstants.MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION) {
+            handleLocalTrackNegotiationRequest(slot, remoteCid)
+            return
+        }
         if (!canOffer(slot)) return
         val now = clock.nowMs()
         val lastHandledAt = lastMediaRestartHandledAtByCid[remoteCid]
@@ -617,6 +631,12 @@ internal class PeerNegotiationEngine(
         logger?.log(SerenadaLogLevel.WARNING, TAG, "Recreating peer after media restart request from $remoteCid")
         val replacement = replacePeerSlotForMediaRecovery(remoteCid) ?: return
         maybeSendOffer(replacement)
+    }
+
+    private fun handleLocalTrackNegotiationRequest(slot: PeerConnectionSlotProtocol, remoteCid: String) {
+        if (!canOffer(slot) || slot.getSignalingState() != PeerConnection.SignalingState.STABLE) return
+        logger?.log(SerenadaLogLevel.DEBUG, TAG, "Creating offer after peer local track negotiation request from $remoteCid")
+        maybeSendOffer(slot, force = true)
     }
 
     // --- Outbound Media Watchdog ---
@@ -707,6 +727,16 @@ internal class PeerNegotiationEngine(
         if (!isSignalingConnected() || !isParticipantActive(remoteCid)) return
         logger?.log(SerenadaLogLevel.WARNING, TAG, "Requesting media restart from $remoteCid after $reason")
         val payload = JSONObject().apply { put("reason", reason) }
+        sendMessage("media_restart_request", payload, remoteCid)
+    }
+
+    private fun requestPeerLocalTrackNegotiation(remoteCid: String, slot: PeerConnectionSlotProtocol) {
+        if (!isSignalingConnected() || !isLocalMediaReady() || !isParticipantActive(remoteCid)) return
+        if (slot.getSignalingState() != PeerConnection.SignalingState.STABLE) return
+        logger?.log(SerenadaLogLevel.DEBUG, TAG, "Requesting local track negotiation offer from $remoteCid")
+        val payload = JSONObject().apply {
+            put("reason", SignalingProtocolConstants.MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION)
+        }
         sendMessage("media_restart_request", payload, remoteCid)
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingProtocolConstants.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingProtocolConstants.kt
@@ -1,0 +1,9 @@
+package app.serenada.core.call
+
+/**
+ * Canonical signaling protocol wire constants shared across Serenada clients.
+ * Run `node scripts/check-signaling-protocol-constants.mjs` to verify cross-platform parity.
+ */
+internal object SignalingProtocolConstants {
+    const val MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION = "local track negotiation"
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -361,6 +361,53 @@ class SessionNegotiationTest {
     }
 
     @Test
+    fun `designated offerer sends normal offer for local track negotiation request`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "zeta", localJoinedAt = 1, remoteJoinedAt = 2)
+        val slot = factory.fakeMedia.fakeSlots["zeta"]
+        assertNotNull(slot)
+        factory.simulateAnswerFromRemote("zeta", offerId = latestOfferId())
+        val offersBefore = factory.fakeProvider.sentMessages("offer").size
+        val slotOffersBefore = slot!!.createOfferCalls
+
+        factory.fakeProvider.simulateMessage(
+            from = "zeta",
+            type = "media_restart_request",
+            payload = JSONObject().apply {
+                put("from", "zeta")
+                put("reason", "local track negotiation")
+            },
+        )
+        ShadowLooper.idleMainLooper()
+
+        assertSame("Local track negotiation should keep the existing peer slot", slot, factory.fakeMedia.fakeSlots["zeta"])
+        assertFalse("Existing peer slot must not be closed", slot.closePeerConnectionCalled)
+        assertEquals("Exactly one normal offer should be sent", offersBefore + 1, factory.fakeProvider.sentMessages("offer").size)
+        assertEquals("Existing slot should create the offer", slotOffersBefore + 1, slot.createOfferCalls)
+        assertEquals("Local track negotiation must not request ICE restart", false, slot.createOfferIceRestartFlags.last())
+    }
+
+    @Test
+    fun `non offerer requests local track negotiation offer when renegotiation is needed`() {
+        factory.advanceToInCallWithTurn(localCid = "zeta", remoteCid = "alpha", localJoinedAt = 2, remoteJoinedAt = 1)
+        factory.simulateOfferFromRemote("alpha", offerId = "remote-offer")
+        ShadowLooper.idleMainLooper()
+        val slot = factory.fakeMedia.fakeSlots["alpha"]
+        assertNotNull(slot)
+        val offersBefore = factory.fakeProvider.sentMessages("offer").size
+
+        slot!!.simulateRenegotiationNeeded()
+        ShadowLooper.idleMainLooper()
+
+        assertSame("Local track negotiation should keep the existing peer slot", slot, factory.fakeMedia.fakeSlots["alpha"])
+        assertFalse("Existing peer slot must not be closed", slot.closePeerConnectionCalled)
+        assertEquals("Non-offerer must not send an offer directly", offersBefore, factory.fakeProvider.sentMessages("offer").size)
+        val restartRequests = factory.fakeProvider.sentMessages("media_restart_request")
+        assertEquals("Non-offerer should ask the deterministic offer owner to renegotiate", 1, restartRequests.size)
+        assertEquals("alpha", restartRequests.single().peerId)
+        assertEquals("local track negotiation", restartRequests.single().payload?.optString("reason"))
+    }
+
+    @Test
     fun `media restart request is rate limited per peer`() {
         factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "zeta", localJoinedAt = 1, remoteJoinedAt = 2)
         val oldSlot = factory.fakeMedia.fakeSlots["zeta"]

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -66,6 +66,7 @@ internal class FakeMediaEngine : SessionMediaEngine {
             onConnectionStateChange = onConnectionStateChange,
             onIceConnectionStateChange = onIceConnectionStateChange,
             onSignalingStateChange = onSignalingStateChange,
+            onRenegotiationNeeded = onRenegotiationNeeded,
         )
         if (failNextCreatedSlotRemoteOffer) {
             slot.failNextRemoteOffer = true

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -17,6 +17,7 @@ internal class FakePeerConnectionSlot(
     private val onConnectionStateChange: ((String, PeerConnection.PeerConnectionState) -> Unit)? = null,
     private val onIceConnectionStateChange: ((String, PeerConnection.IceConnectionState) -> Unit)? = null,
     private val onSignalingStateChange: ((String, PeerConnection.SignalingState) -> Unit)? = null,
+    private val onRenegotiationNeeded: ((String) -> Unit)? = null,
 ) : PeerConnectionSlotProtocol {
 
     // State
@@ -203,5 +204,9 @@ internal class FakePeerConnectionSlot(
     fun simulateIceConnectionStateChange(state: PeerConnection.IceConnectionState) {
         iceConnectionState = state
         onIceConnectionStateChange?.invoke(remoteCid, state)
+    }
+
+    fun simulateRenegotiationNeeded() {
+        onRenegotiationNeeded?.invoke(remoteCid)
     }
 }

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.2"
+val sdkVersion = "0.8.3"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -203,7 +203,8 @@ final class PeerNegotiationEngine {
             )
 
         case "media_restart_request":
-            handleMediaRestartRequest(slot: slot, remoteCid: fromCid)
+            let reason = message.payload?.objectValue?["reason"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            handleMediaRestartRequest(slot: slot, remoteCid: fromCid, reason: reason)
 
         default:
             break
@@ -352,8 +353,7 @@ final class PeerNegotiationEngine {
             },
             { [weak self] cid in
                 Task { @MainActor in
-                    guard let self, let slot = self.getSlot(cid) else { return }
-                    self.maybeSendOffer(slot: slot, force: true, iceRestart: false)
+                    self?.handleRenegotiationNeeded(remoteCid: cid)
                 }
             }
         ) else {
@@ -732,7 +732,20 @@ final class PeerNegotiationEngine {
         }
     }
 
-    private func handleMediaRestartRequest(slot: any PeerConnectionSlotProtocol, remoteCid: String) {
+    private func handleRenegotiationNeeded(remoteCid: String) {
+        guard let slot = getSlot(remoteCid) else { return }
+        if shouldIOffer(remoteCid: remoteCid, roomState: getCurrentRoomState()) {
+            maybeSendOffer(slot: slot, force: true, iceRestart: false)
+        } else {
+            requestPeerLocalTrackNegotiation(remoteCid: remoteCid, slot: slot)
+        }
+    }
+
+    private func handleMediaRestartRequest(slot: any PeerConnectionSlotProtocol, remoteCid: String, reason: String) {
+        if reason == SignalingProtocolConstants.mediaRestartReasonLocalTrackNegotiation {
+            handleLocalTrackNegotiationRequest(slot: slot, remoteCid: remoteCid)
+            return
+        }
         guard canOffer(slot: slot) else { return }
         let now = clock.nowMs()
         if let lastHandledAt = lastMediaRestartHandledAtByCid[remoteCid],
@@ -743,6 +756,12 @@ final class PeerNegotiationEngine {
         logger?.log(.warning, tag: "PeerNegotiationEngine", "Recreating peer after media restart request from \(remoteCid)")
         guard let replacement = replacePeerSlotForMediaRecovery(remoteCid: remoteCid) else { return }
         maybeSendOffer(slot: replacement)
+    }
+
+    private func handleLocalTrackNegotiationRequest(slot: any PeerConnectionSlotProtocol, remoteCid: String) {
+        guard canOffer(slot: slot), slot.getSignalingState() == "STABLE" else { return }
+        logger?.log(.debug, tag: "PeerNegotiationEngine", "Creating offer after peer local track negotiation request from \(remoteCid)")
+        maybeSendOffer(slot: slot, force: true)
     }
 
     // MARK: - Outbound Media Watchdog
@@ -837,6 +856,17 @@ final class PeerNegotiationEngine {
         guard isSignalingConnected(), isParticipantActive(remoteCid: remoteCid) else { return }
         logger?.log(.warning, tag: "PeerNegotiationEngine", "Requesting media restart from \(remoteCid) after \(reason)")
         sendMessage("media_restart_request", .object(["reason": .string(reason)]), remoteCid)
+    }
+
+    private func requestPeerLocalTrackNegotiation(remoteCid: String, slot: any PeerConnectionSlotProtocol) {
+        guard isSignalingConnected(), isLocalMediaReady(), isParticipantActive(remoteCid: remoteCid) else { return }
+        guard slot.getSignalingState() == "STABLE" else { return }
+        logger?.log(.debug, tag: "PeerNegotiationEngine", "Requesting local track negotiation offer from \(remoteCid)")
+        sendMessage(
+            "media_restart_request",
+            .object(["reason": .string(SignalingProtocolConstants.mediaRestartReasonLocalTrackNegotiation)]),
+            remoteCid
+        )
     }
 
     private func recreatePeerForMediaRecovery(remoteCid: String, reason: String) {

--- a/client-ios/SerenadaCore/Sources/Call/SignalingProtocolConstants.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SignalingProtocolConstants.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Canonical signaling protocol wire constants shared across Serenada clients.
+/// Run `node scripts/check-signaling-protocol-constants.mjs` to verify cross-platform parity.
+enum SignalingProtocolConstants {
+    static let mediaRestartReasonLocalTrackNegotiation = "local track negotiation"
+}

--- a/client-ios/SerenadaCore/Sources/Models/Participant.swift
+++ b/client-ios/SerenadaCore/Sources/Models/Participant.swift
@@ -6,7 +6,7 @@ import Foundation
 /// room slot open for reconnect — peers MUST keep existing peer connections
 /// alive during the suspend window so established media survives arbitrary-
 /// length signaling outages.
-public enum ParticipantSignalingStatus: String, Codable, Equatable {
+public enum ParticipantSignalingStatus: String, Codable, Equatable, Sendable {
     case active
     case suspended
 }

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.2"
+    public static let version = "0.8.3"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -76,7 +76,8 @@ final class FakeMediaEngine: SessionMediaEngine {
             remoteCid: remoteCid,
             onConnectionStateChange: onConnectionStateChange,
             onIceConnectionStateChange: onIceConnectionStateChange,
-            onSignalingStateChange: onSignalingStateChange
+            onSignalingStateChange: onSignalingStateChange,
+            onRenegotiationNeeded: onRenegotiationNeeded
         )
         if failNextCreatedSlotRemoteOffer {
             slot.failNextRemoteOffer = true

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakePeerConnectionSlot.swift
@@ -36,17 +36,20 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
     private let onConnectionStateChange: ((String, String) -> Void)?
     private let onIceConnectionStateChange: ((String, String) -> Void)?
     private let onSignalingStateChange: ((String, String) -> Void)?
+    private let onRenegotiationNeeded: ((String) -> Void)?
 
     init(
         remoteCid: String,
         onConnectionStateChange: ((String, String) -> Void)? = nil,
         onIceConnectionStateChange: ((String, String) -> Void)? = nil,
-        onSignalingStateChange: ((String, String) -> Void)? = nil
+        onSignalingStateChange: ((String, String) -> Void)? = nil,
+        onRenegotiationNeeded: ((String) -> Void)? = nil
     ) {
         self.remoteCid = remoteCid
         self.onConnectionStateChange = onConnectionStateChange
         self.onIceConnectionStateChange = onIceConnectionStateChange
         self.onSignalingStateChange = onSignalingStateChange
+        self.onRenegotiationNeeded = onRenegotiationNeeded
     }
 
     // MARK: - Offer Lifecycle
@@ -247,5 +250,9 @@ final class FakePeerConnectionSlot: PeerConnectionSlotProtocol {
     func simulateSignalingStateChange(_ state: String) {
         signalingState = state
         onSignalingStateChange?(remoteCid, state)
+    }
+
+    func simulateRenegotiationNeeded() {
+        onRenegotiationNeeded?(remoteCid)
     }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Helpers/SessionTestHarness.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Helpers/SessionTestHarness.swift
@@ -111,6 +111,34 @@ final class SessionTestHarness {
         }
     }
 
+    func waitForLocalMedia(attempts: Int = 32) async {
+        for _ in 0..<attempts {
+            if !fakeMedia.startLocalMediaCalls.isEmpty {
+                return
+            }
+            await yieldToMainActor()
+        }
+    }
+
+    func waitForIceServers(attempts: Int = 32) async {
+        for _ in 0..<attempts {
+            if fakeMedia.hasIceServers() {
+                return
+            }
+            await yieldToMainActor()
+        }
+    }
+
+    func waitForInitialOfferIfNeeded(localCid: String, remoteCid: String, attempts: Int = 32) async {
+        guard localCid < remoteCid else { return }
+        for _ in 0..<attempts {
+            if !fakeProvider.sentPeerMessages(ofType: "offer").isEmpty {
+                return
+            }
+            await yieldToMainActor()
+        }
+    }
+
     // MARK: - Negotiation Test Helpers
 
     /// Advance to inCall state with TURN credentials ready and ICE servers set.
@@ -123,6 +151,7 @@ final class SessionTestHarness {
     ) async {
         fakeProvider.iceServerResults = [.success(iceServers)]
         await advancePastPermissions()
+        await waitForLocalMedia()
         openSignaling()
         simulateJoinedResponse(
             cid: localCid,
@@ -135,6 +164,9 @@ final class SessionTestHarness {
         await yieldToMainActor()
         await fakeClock.advance(byMs: 100)
         await yieldToMainActor()
+        await waitForLocalMedia()
+        await waitForIceServers()
+        await waitForInitialOfferIfNeeded(localCid: localCid, remoteCid: remoteCid)
     }
 
     func simulateOfferFromRemote(fromCid: String, sdp: String = "remote-offer-sdp", offerId: String? = nil) {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/LoopbackSignalingProviderTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/LoopbackSignalingProviderTests.swift
@@ -338,8 +338,6 @@ final class LoopbackSignalingProviderTests: XCTestCase {
         // Alice's media engine should know about the initial room state.
         XCTAssertFalse(mediaA.createdSlotCids.isEmpty == false && mediaA.createdSlotCids.contains("alice"),
                        "Should not create a slot for self")
-        let initialSlotCount = mediaA.createdSlotCids.count
-
         let (sessionB, _) = makeSession(provider: providerB)
         await advancePastPermissions(sessionB)
         await settle()

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
@@ -143,11 +143,16 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertNotNil(fakeSlot)
 
         // Verify offer was sent
+        await waitUntil {
+            (fakeSlot?.createOfferCalls ?? 0) > 0
+        }
         XCTAssertGreaterThan(fakeSlot?.createOfferCalls ?? 0, 0)
 
         // Simulate answer from remote
         harness.simulateAnswerFromRemote(fromCid: "remote")
-        await harness.yieldToMainActor()
+        await waitUntil {
+            fakeSlot?.setRemoteDescriptionCalls.last?.type == .answer
+        }
 
         XCTAssertEqual(fakeSlot?.setRemoteDescriptionCalls.last?.type, .answer, "Should set answer as remote desc")
         XCTAssertEqual(fakeSlot?.pendingIceRestart, false, "pendingIceRestart should be cleared after answer")
@@ -493,6 +498,66 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertTrue(oldSlot.closePeerConnectionCalled, "Old slot should be closed")
         XCTAssertGreaterThan(replacement.createOfferCalls, 0, "Replacement should send a fresh offer")
         XCTAssertEqual(harness.fakeProvider.sentPeerMessages(ofType: "offer").count, offersBefore + 1)
+    }
+
+    func testDesignatedOffererSendsNormalOfferForLocalTrackNegotiationRequest() async throws {
+        await harness.advanceToInCallWithTurn(
+            localCid: "alpha",
+            remoteCid: "zeta",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+        let slot = try XCTUnwrap(harness.fakeMedia.fakeSlots["zeta"])
+        let offerId = try XCTUnwrap(harness.fakeProvider.sentPeerMessages(ofType: "offer").last?.payload?["offerId"]?.stringValue)
+        harness.simulateAnswerFromRemote(fromCid: "zeta", offerId: offerId)
+        await harness.yieldToMainActor()
+        let offersBefore = harness.fakeProvider.sentPeerMessages(ofType: "offer").count
+        let slotOffersBefore = slot.createOfferCalls
+
+        harness.fakeProvider.simulateMessage(
+            from: "zeta",
+            type: "media_restart_request",
+            payload: [
+                "from": .string("zeta"),
+                "reason": .string("local track negotiation")
+            ]
+        )
+        await waitUntil {
+            harness.fakeProvider.sentPeerMessages(ofType: "offer").count == offersBefore + 1
+        }
+
+        let current = try XCTUnwrap(harness.fakeMedia.fakeSlots["zeta"])
+        XCTAssertTrue(current === slot, "Local track negotiation should keep the existing peer slot")
+        XCTAssertFalse(slot.closePeerConnectionCalled, "Existing peer slot must not be closed")
+        XCTAssertEqual(harness.fakeProvider.sentPeerMessages(ofType: "offer").count, offersBefore + 1)
+        XCTAssertEqual(slot.createOfferCalls, slotOffersBefore + 1, "Existing slot should create the offer")
+        XCTAssertEqual(slot.createOfferIceRestartFlags.last, false, "Local track negotiation must not request ICE restart")
+    }
+
+    func testNonOffererRequestsLocalTrackNegotiationOfferWhenRenegotiationIsNeeded() async throws {
+        await harness.advanceToInCallWithTurn(
+            localCid: "zeta",
+            remoteCid: "alpha",
+            localJoinedAt: 2,
+            remoteJoinedAt: 1
+        )
+        harness.simulateOfferFromRemote(fromCid: "alpha", offerId: "remote-offer")
+        await harness.yieldToMainActor()
+        let slot = try XCTUnwrap(harness.fakeMedia.fakeSlots["alpha"])
+        let offersBefore = harness.fakeProvider.sentPeerMessages(ofType: "offer").count
+
+        slot.simulateRenegotiationNeeded()
+        await waitUntil {
+            harness.fakeProvider.sentPeerMessages(ofType: "media_restart_request").count == 1
+        }
+
+        let current = try XCTUnwrap(harness.fakeMedia.fakeSlots["alpha"])
+        XCTAssertTrue(current === slot, "Local track negotiation should keep the existing peer slot")
+        XCTAssertFalse(slot.closePeerConnectionCalled, "Existing peer slot must not be closed")
+        XCTAssertEqual(harness.fakeProvider.sentPeerMessages(ofType: "offer").count, offersBefore, "Non-offerer must not send an offer directly")
+        let restartRequest = try XCTUnwrap(harness.fakeProvider.sentPeerMessages(ofType: "media_restart_request").first)
+        XCTAssertEqual(restartRequest.peerId, "alpha")
+        XCTAssertEqual(restartRequest.payload?["reason"]?.stringValue, "local track negotiation")
     }
 
     func testMediaRestartRequestIsRateLimitedPerPeer() async throws {

--- a/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
+++ b/client-ios/SerenadaiOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		020878B7FEDCAC4D331E914F /* SnapshotSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403AD1CCCE81251BF5DDDA2 /* SnapshotSaver.swift */; };
 		03021554EADCBAE157B71297 /* PushSubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5849DCA4B2F1D0DD0411242 /* PushSubscriptionManager.swift */; };
 		0361CD790E1AFC86D02CF4F6 /* FakeAudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2247BFD0D693E4041DAF16 /* FakeAudioController.swift */; };
+		04D7E7ED7668772D030F664A /* MosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302CBF35EC718795357FDD32 /* MosTests.swift */; };
 		0587ECB1D9436E518EF012E9 /* FakeAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F42A2D07ED2383049D7227F /* FakeAPIClient.swift */; };
 		0A2C0A7E3C1A621804CC59C9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = EA93F28D0C87ABED6B756036 /* Localizable.strings */; };
 		144C4C15F4B31D2E8AE8057A /* FakeSessionClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B88E3237E25D45BB2BD9B4 /* FakeSessionClock.swift */; };
@@ -57,7 +58,9 @@
 		85B89222838ED1AA3AF9F938 /* CallScreenStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03DA37A007DFCE3DA069244 /* CallScreenStateTests.swift */; };
 		887A6F874A06A47C37E73A85 /* SignalingPayloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD06F6B1E706207C4ED2D7DD /* SignalingPayloadsTests.swift */; };
 		89865919658F9327ADF61AED /* RecentCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA4F257ABA1CF5875CA4B83 /* RecentCall.swift */; };
+		8E139ED2ACA346DCB12AB5C9 /* ReconnectReasonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44BB9DBC9B2DEAEC2D0618F5 /* ReconnectReasonTests.swift */; };
 		90E4D65F01CB4CBE8E6CA6EF /* SessionTestHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E34F50FDC1E2F064028B68 /* SessionTestHarness.swift */; };
+		9273398E6847F67671F7A5B4 /* SerenadaSessionTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4BD6CCDC47CDAFB5AC1854 /* SerenadaSessionTelemetryTests.swift */; };
 		932FE0F4C5B2A808073B537A /* BackoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC9E71EE9415390DBBFC4A7 /* BackoffTests.swift */; };
 		9342C14683CA7530772F5F93 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE887624CBDA34B0B333C6A /* SettingsStore.swift */; };
 		9ADDE9F64E5B64AB5128AF50 /* CameraModeFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F052EA0D1D083D292B3CF0E /* CameraModeFlowTests.swift */; };
@@ -83,8 +86,10 @@
 		CEEA0CFAF57BC2B4A48F8441 /* DeepLinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BC48440A4DD113050C3E29 /* DeepLinkParserTests.swift */; };
 		D05E6EDD64E9A169FF7DAD21 /* SerenadaCoreProviderModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF59DDD3EB32D08B6F0B913 /* SerenadaCoreProviderModeTests.swift */; };
 		D137590CDB7A1FC9C94D3F74 /* SignalingClientFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62ED85E9C29EE8FB7BC0806 /* SignalingClientFallbackTests.swift */; };
+		D950928F5053A8E8369858B9 /* CallQualityTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C653D2F58E227F02843983 /* CallQualityTrackerTests.swift */; };
 		DABDC3CE432EA96C10798200 /* CallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48285CB0CBEE51504B0674B /* CallManager.swift */; };
 		E023D6932A1411B953694012 /* PushKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0666A6C1733C1FA1856919 /* PushKeyStore.swift */; };
+		E63D8928F846DF0065D3BD02 /* StatsCounterMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA079DE639FF5E6D908BEE8A /* StatsCounterMergeTests.swift */; };
 		EE8328B7F79EEA681164E7ED /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018403014C9AEDF89B039618 /* SettingsScreen.swift */; };
 		F237C6E7ED0C17810C58C49F /* SavedRoomStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD8A5FB8E492716B9681E3 /* SavedRoomStoreTests.swift */; };
 		F550B054F40D9A81D9A612F8 /* FakeAudioCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CA13885164CF265442E406 /* FakeAudioCoordinator.swift */; };
@@ -158,6 +163,7 @@
 		0824DD6CEC2DF4431D724B4D /* JoinSnapshotFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSnapshotFeature.swift; sourceTree = "<group>"; };
 		08BED6C2775E7E4CB2896F08 /* DeepLinkRejoinFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRejoinFlowUITests.swift; sourceTree = "<group>"; };
 		09DDC60F805A4A4624F90F9B /* SessionOrchestrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOrchestrationTests.swift; sourceTree = "<group>"; };
+		0B4BD6CCDC47CDAFB5AC1854 /* SerenadaSessionTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerenadaSessionTelemetryTests.swift; sourceTree = "<group>"; };
 		0FC78E56ECCCC36978DAE4FE /* AppLaunchOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchOverrides.swift; sourceTree = "<group>"; };
 		18568C3FC4A75A087A876FB4 /* SerenadaiOSUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SerenadaiOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A7CC3F22BEA1500363B20A6 /* EndpointHostParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointHostParserTests.swift; sourceTree = "<group>"; };
@@ -171,8 +177,10 @@
 		2D7AA70D76623801E762E2DB /* ErrorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreen.swift; sourceTree = "<group>"; };
 		2E86658C3658DD731910A0A6 /* SerenadaNotificationService.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SerenadaNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F42A2D07ED2383049D7227F /* FakeAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeAPIClient.swift; sourceTree = "<group>"; };
+		302CBF35EC718795357FDD32 /* MosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MosTests.swift; sourceTree = "<group>"; };
 		34F0B8DB451442FAB82D1D94 /* JoinScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinScreen.swift; sourceTree = "<group>"; };
 		3529A15EA2C43DB2F91F46FC /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		35C653D2F58E227F02843983 /* CallQualityTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityTrackerTests.swift; sourceTree = "<group>"; };
 		367DCC8F4EDC812C9FBA3F02 /* LiveRoomOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveRoomOverride.swift; sourceTree = "<group>"; };
 		3F0D033C8F77DC9925D9668A /* RoomStatusesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStatusesTests.swift; sourceTree = "<group>"; };
 		3FB457A612C7F7FCB2736B1F /* SessionMediaLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMediaLivenessTests.swift; sourceTree = "<group>"; };
@@ -180,6 +188,7 @@
 		41E34F50FDC1E2F064028B68 /* SessionTestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTestHarness.swift; sourceTree = "<group>"; };
 		43E2F0452DE65337073894BF /* RecentCallStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCallStore.swift; sourceTree = "<group>"; };
 		4403AD1CCCE81251BF5DDDA2 /* SnapshotSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotSaver.swift; sourceTree = "<group>"; };
+		44BB9DBC9B2DEAEC2D0618F5 /* ReconnectReasonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectReasonTests.swift; sourceTree = "<group>"; };
 		461DCF4D9C695C2B6051BF91 /* FakeMediaEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMediaEngine.swift; sourceTree = "<group>"; };
 		47CAF324C3A37900C769BB9F /* FeedbackScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackScreen.swift; sourceTree = "<group>"; };
 		4D4E0E538F82CE87BE4FDB24 /* SerenadaCallUI */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SerenadaCallUI; path = SerenadaCallUI; sourceTree = SOURCE_ROOT; };
@@ -215,6 +224,7 @@
 		B56B39E2A60D65FD1477B020 /* SampleHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleHandler.swift; sourceTree = "<group>"; };
 		B8648687C9C97AD05ABC9AEB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B8DC46B13DBF27F02DA8B2D2 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		BA079DE639FF5E6D908BEE8A /* StatsCounterMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCounterMergeTests.swift; sourceTree = "<group>"; };
 		BAC97F9BB82CE31EBF9C084B /* FakeSessionSignaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeSessionSignaling.swift; sourceTree = "<group>"; };
 		BB6EC0967F80C7CB8EB7E9E0 /* FakeSignalingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeSignalingProvider.swift; sourceTree = "<group>"; };
 		BF6DFD71F64E86AEEFE9DFDC /* SnapshotCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotCaptureTests.swift; sourceTree = "<group>"; };
@@ -426,6 +436,7 @@
 				6CE28EAA8E90B562F29DF6DB /* AudioLevelMonitorTests.swift */,
 				F5E92820F7589FD19AFAEB65 /* AudioLevelPollerFallbackTests.swift */,
 				9FC9E71EE9415390DBBFC4A7 /* BackoffTests.swift */,
+				35C653D2F58E227F02843983 /* CallQualityTrackerTests.swift */,
 				9F052EA0D1D083D292B3CF0E /* CameraModeFlowTests.swift */,
 				D5DEACDD78A7F800281C0FC6 /* CaptureResolutionSelectionTests.swift */,
 				F5BC48440A4DD113050C3E29 /* DeepLinkParserTests.swift */,
@@ -435,11 +446,14 @@
 				F54D58A452D7949DF145435E /* JoinRecoveryTests.swift */,
 				E194DC9F376B307952F4AD8E /* LayoutConformanceTests.swift */,
 				801D5040B2102E7DFFFDC2B2 /* LoopbackSignalingProviderTests.swift */,
+				302CBF35EC718795357FDD32 /* MosTests.swift */,
+				44BB9DBC9B2DEAEC2D0618F5 /* ReconnectReasonTests.swift */,
 				E77004950192C89C56E76A8F /* RecoveryStorageTests.swift */,
 				79D3BC3109B79353E8157F76 /* RoomWatcherTests.swift */,
 				ECF59DDD3EB32D08B6F0B913 /* SerenadaCoreProviderModeTests.swift */,
 				4138C434295A490147BCF1F9 /* SerenadaDiagnosticsTests.swift */,
 				2A15CC6B14E97F4E2C37C573 /* SerenadaServerProviderTests.swift */,
+				0B4BD6CCDC47CDAFB5AC1854 /* SerenadaSessionTelemetryTests.swift */,
 				7830FA5A71601737755C721D /* SerenadaSessionTests.swift */,
 				8815B032D4EFBB62BB976B66 /* SessionDirtyPairTests.swift */,
 				3FB457A612C7F7FCB2736B1F /* SessionMediaLivenessTests.swift */,
@@ -452,6 +466,7 @@
 				1E1404CBCB96AB880E893C3F /* SignalingMessageTests.swift */,
 				FD06F6B1E706207C4ED2D7DD /* SignalingPayloadsTests.swift */,
 				BF6DFD71F64E86AEEFE9DFDC /* SnapshotCaptureTests.swift */,
+				BA079DE639FF5E6D908BEE8A /* StatsCounterMergeTests.swift */,
 				DA4E5581F6502FD66EEAB5CD /* Fakes */,
 				9E464FDC4DB6B63C2181B47E /* Helpers */,
 			);
@@ -829,6 +844,7 @@
 				64A7BCD5402B626283D5F7A7 /* AudioLevelMonitorTests.swift in Sources */,
 				7249AE4FA6B6BD9FA933F350 /* AudioLevelPollerFallbackTests.swift in Sources */,
 				932FE0F4C5B2A808073B537A /* BackoffTests.swift in Sources */,
+				D950928F5053A8E8369858B9 /* CallQualityTrackerTests.swift in Sources */,
 				85B89222838ED1AA3AF9F938 /* CallScreenStateTests.swift in Sources */,
 				9ADDE9F64E5B64AB5128AF50 /* CameraModeFlowTests.swift in Sources */,
 				80AC65E9FEE68E60586E6055 /* CaptureResolutionSelectionTests.swift in Sources */,
@@ -849,7 +865,9 @@
 				6EE2ED9D63185C2AA8581CFE /* L10nTests.swift in Sources */,
 				366BA266D1F08550723BA77D /* LayoutConformanceTests.swift in Sources */,
 				C0500F3658A11A038780B5FD /* LoopbackSignalingProviderTests.swift in Sources */,
+				04D7E7ED7668772D030F664A /* MosTests.swift in Sources */,
 				C5EB06A2D9075772AE396FDD /* RecentCallStoreTests.swift in Sources */,
+				8E139ED2ACA346DCB12AB5C9 /* ReconnectReasonTests.swift in Sources */,
 				2A96BF63C126AFE8CE2976D4 /* RecoveryStorageTests.swift in Sources */,
 				71320D322F59D2244B5A2027 /* RoomStatusesTests.swift in Sources */,
 				9C333A1799F89B5A4A9080BB /* RoomWatcherTests.swift in Sources */,
@@ -858,6 +876,7 @@
 				D05E6EDD64E9A169FF7DAD21 /* SerenadaCoreProviderModeTests.swift in Sources */,
 				6D7CC8795CCE4899285777B4 /* SerenadaDiagnosticsTests.swift in Sources */,
 				838D89A84D60CC6245CB2EFC /* SerenadaServerProviderTests.swift in Sources */,
+				9273398E6847F67671F7A5B4 /* SerenadaSessionTelemetryTests.swift in Sources */,
 				A281E4C5D7AE35EEF75A87A8 /* SerenadaSessionTests.swift in Sources */,
 				2BF323F5A22C2952822DE96D /* SessionDirtyPairTests.swift in Sources */,
 				4137872C50BFF4B70C29DDED /* SessionMediaLivenessTests.swift in Sources */,
@@ -871,6 +890,7 @@
 				60DD419576BB73E40DC4D993 /* SignalingMessageTests.swift in Sources */,
 				887A6F874A06A47C37E73A85 /* SignalingPayloadsTests.swift in Sources */,
 				65AD76EF24108797F74DA6CF /* SnapshotCaptureTests.swift in Sources */,
+				E63D8928F846DF0065D3BD02 /* StatsCounterMergeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.2",
-        "@agatx/serenada-react-ui": "0.8.2",
+        "@agatx/serenada-core": "0.8.3",
+        "@agatx/serenada-react-ui": "0.8.3",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.2"
+        "@agatx/serenada-core": "0.8.3"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.2",
+        "@agatx/serenada-core": "^0.8.3",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.2",
-    "@agatx/serenada-react-ui": "0.8.2",
+    "@agatx/serenada-core": "0.8.3",
+    "@agatx/serenada-react-ui": "0.8.3",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.2';
+export const SERENADA_CORE_VERSION = '0.8.3';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -1,6 +1,7 @@
 import type { RoomState, SignalingMessage } from '../signaling/types.js';
 import type { ConnectionStatus, SerenadaLogger } from '../types.js';
 import { parseOfferPayload, parseAnswerPayload, parseIceCandidatePayload } from '../signaling/payloads.js';
+import { MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION } from '../signaling/protocolConstants.js';
 import { formatError } from '../formatError.js';
 import { normalizeIceServers } from '../iceServers.js';
 import {
@@ -236,8 +237,9 @@ export class MediaEngine {
                 }
                 case 'media_restart_request': {
                     const fromCid = typeof payload.from === 'string' ? payload.from.trim() : '';
+                    const reason = typeof payload.reason === 'string' ? payload.reason.trim() : '';
                     if (fromCid && this.isCurrentParticipant(fromCid)) {
-                        void this.handleMediaRestartRequest(fromCid);
+                        void this.handleMediaRestartRequest(fromCid, reason);
                     }
                     break;
                 }
@@ -299,11 +301,7 @@ export class MediaEngine {
                         peer.pendingLocalTrackNegotiation = true;
                     }
                 } else if (!this.shouldIOffer(remoteCid) && peer.pc.remoteDescription) {
-                    if (peer.pc.signalingState === 'stable') {
-                        void this.createOfferTo(remoteCid);
-                    } else {
-                        peer.pendingLocalTrackNegotiation = true;
-                    }
+                    this.scheduleLocalTrackNegotiation(remoteCid, peer);
                 }
             }
             this.notifyChange();
@@ -985,6 +983,12 @@ export class MediaEngine {
             const c = peer.iceBuffer.shift();
             if (c) await peer.pc.addIceCandidate(c);
         }
+        if (this.localStream) {
+            await this.attachLocalTracksToPeer(fromCid, peer, this.localStream);
+        } else {
+            await this.startLocalMedia();
+        }
+        await this.applyAudioSenderParameters(peer.pc);
         const answer = await peer.pc.createAnswer();
         await peer.pc.setLocalDescription(answer);
         this.sendSignalingMessage('answer', { sdp: answer.sdp, offerId }, fromCid);
@@ -1167,6 +1171,8 @@ export class MediaEngine {
                         await videoTransceiver.sender.replaceTrack(newTrack);
                         if (videoTransceiver.direction !== 'sendrecv' && videoTransceiver.direction !== 'stopped' && this.videoCaptureSupported) {
                             videoTransceiver.direction = 'sendrecv';
+                        }
+                        if (newTrack && this.needsLocalTrackNegotiation(videoTransceiver)) {
                             this.scheduleLocalTrackNegotiation(remoteCid, peer);
                         }
                     } catch (err) {
@@ -1222,9 +1228,10 @@ export class MediaEngine {
     }
 
     private findTransceiver(pc: RTCPeerConnection, kind: 'audio' | 'video'): RTCRtpTransceiver | undefined {
-        return pc.getTransceivers().find(transceiver => (
+        const transceivers = pc.getTransceivers().filter(transceiver => (
             transceiver.receiver.track?.kind === kind || transceiver.sender.track?.kind === kind
         ));
+        return transceivers.find(transceiver => transceiver.mid !== null) ?? transceivers[0];
     }
 
     private async attachLocalTracksToPeer(remoteCid: string, peer: PeerState, stream: MediaStream): Promise<void> {
@@ -1238,26 +1245,40 @@ export class MediaEngine {
     }
 
     private async attachLocalTrackToPeer(peer: PeerState, track: MediaStreamTrack, stream: MediaStream): Promise<boolean> {
-        if (peer.pc.getSenders().some(sender => sender.track?.kind === track.kind)) {
-            return false;
-        }
-
         const transceiver = track.kind === 'audio' || track.kind === 'video'
             ? this.findTransceiver(peer.pc, track.kind)
             : undefined;
         if (transceiver) {
+            if (transceiver.sender.track?.kind === track.kind) {
+                return this.needsLocalTrackNegotiation(transceiver);
+            }
+            for (const sender of peer.pc.getSenders()) {
+                if (sender === transceiver.sender || sender.track?.kind !== track.kind) {
+                    continue;
+                }
+                try {
+                    await sender.replaceTrack(null);
+                } catch (err) {
+                    this.logger?.log('warning', 'WebRTC', `Failed to detach stale ${track.kind} track from peer: ${formatError(err)}`);
+                }
+            }
             try {
                 await transceiver.sender.replaceTrack(track);
+                let negotiationNeeded = this.needsLocalTrackNegotiation(transceiver);
                 if (transceiver.direction !== 'sendrecv' && transceiver.direction !== 'stopped') {
                     transceiver.direction = 'sendrecv';
-                    return true;
+                    negotiationNeeded = true;
                 }
+                return negotiationNeeded;
             } catch (err) {
                 this.logger?.log('warning', 'WebRTC', `Failed to attach ${track.kind} track to peer: ${formatError(err)}`);
             }
             return false;
         }
 
+        if (peer.pc.getSenders().some(sender => sender.track?.kind === track.kind)) {
+            return false;
+        }
         peer.pc.addTrack(track, stream);
         return true;
     }
@@ -1276,7 +1297,39 @@ export class MediaEngine {
             return;
         }
         peer.pendingLocalTrackNegotiation = false;
+        if (!this.hasUnnegotiatedLocalTracks(peer.pc)) {
+            return;
+        }
+        if (!this.shouldIOffer(remoteCid)) {
+            this.requestPeerMediaRecovery(remoteCid, MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION);
+            return;
+        }
         void this.createOfferTo(remoteCid);
+    }
+
+    private hasUnnegotiatedLocalTracks(pc: RTCPeerConnection): boolean {
+        for (const sender of pc.getSenders()) {
+            const track = sender.track;
+            if (!track || track.readyState !== 'live' || !track.enabled) {
+                continue;
+            }
+            const transceiver = pc.getTransceivers().find(candidate => candidate.sender === sender);
+            if (!transceiver) {
+                return true;
+            }
+            if (this.needsLocalTrackNegotiation(transceiver)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private needsLocalTrackNegotiation(transceiver: RTCRtpTransceiver): boolean {
+        const track = transceiver.sender.track;
+        if (!track || track.readyState !== 'live' || !track.enabled) {
+            return false;
+        }
+        return transceiver.currentDirection !== 'sendrecv' && transceiver.currentDirection !== 'sendonly';
     }
 
     private async refreshLocalVideoTrack(reason: string, forceRefresh = false): Promise<boolean> {
@@ -1498,16 +1551,32 @@ export class MediaEngine {
 
     private requestPeerMediaRecovery(remoteCid: string, reason: string): void {
         if (!this.isSignalingConnected || !this.isParticipantActive(remoteCid)) return;
-        this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Requesting media restart after ${reason}`);
+        if (reason === MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION) {
+            this.logger?.log('debug', 'WebRTC', `[${remoteCid}] Requesting offer after ${reason}`);
+        } else {
+            this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Requesting media restart after ${reason}`);
+        }
         this.sendSignalingMessage('media_restart_request', { reason }, remoteCid);
     }
 
-    private async handleMediaRestartRequest(fromCid: string): Promise<void> {
+    private async handleMediaRestartRequest(fromCid: string, reason = ''): Promise<void> {
+        if (reason === MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION) {
+            await this.handlePeerLocalTrackNegotiationRequest(fromCid);
+            return;
+        }
         const now = Date.now();
         const lastHandledAt = this.mediaRestartHandledAtByCid.get(fromCid) ?? 0;
         if (now - lastHandledAt < OUTBOUND_MEDIA_RECOVERY_COOLDOWN_MS) return;
         this.mediaRestartHandledAtByCid.set(fromCid, now);
         await this.recreatePeerForMediaRecovery(fromCid, 'peer media restart request');
+    }
+
+    private async handlePeerLocalTrackNegotiationRequest(fromCid: string): Promise<void> {
+        if (!this.shouldIOffer(fromCid) || !this.isSignalingConnected || !this.isParticipantActive(fromCid)) return;
+        const peer = this.peers.get(fromCid);
+        if (!peer || peer.pc.signalingState !== 'stable') return;
+        this.logger?.log('debug', 'WebRTC', `[${fromCid}] Creating offer after peer local track negotiation request`);
+        await this.createOfferTo(fromCid);
     }
 
     private async recreatePeerForMediaRecovery(remoteCid: string, reason: string): Promise<void> {

--- a/client/packages/core/src/signaling/protocolConstants.ts
+++ b/client/packages/core/src/signaling/protocolConstants.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonical signaling protocol wire constants shared across Serenada clients.
+ * @internal
+ * @module
+ */
+
+export const MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION = 'local track negotiation';

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -88,8 +88,15 @@ class FakeRtcPeerConnection {
             return;
         }
 
+        if (description.type === 'offer') {
+            this.ensureLocalOfferTransceiver('audio', '0');
+            this.ensureLocalOfferTransceiver('video', '1');
+        }
         this.localDescription = description;
         this.signalingState = description.type === 'offer' ? 'have-local-offer' : 'stable';
+        if (description.type === 'answer') {
+            this.finalizeNegotiatedDirections();
+        }
         this.onsignalingstatechange?.();
     }
     async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
@@ -98,8 +105,15 @@ class FakeRtcPeerConnection {
             this.failNextRemoteOffer = false;
             throw new Error('set remote offer failed');
         }
+        if (description.type === 'offer') {
+            this.ensureRemoteOfferTransceiver('audio', '0');
+            this.ensureRemoteOfferTransceiver('video', '1');
+        }
         this.remoteDescription = description;
         this.signalingState = description.type === 'offer' ? 'have-remote-offer' : 'stable';
+        if (description.type === 'answer') {
+            this.finalizeNegotiatedDirections();
+        }
         this.onsignalingstatechange?.();
     }
     async addIceCandidate(candidate: RTCIceCandidateInit): Promise<void> {
@@ -107,6 +121,40 @@ class FakeRtcPeerConnection {
     }
     setConfiguration(configuration: RTCConfiguration): void {
         this.configurationUpdates.push(configuration);
+    }
+
+    private ensureRemoteOfferTransceiver(kind: 'audio' | 'video', mid: string): void {
+        if (this.transceivers.some(transceiver => transceiver.mid === mid)) {
+            return;
+        }
+        const sender = new FakeRtcRtpSender(null);
+        this.senders.push(sender);
+        this.transceivers.push(new FakeRtcRtpTransceiver(kind, sender, 'recvonly', mid));
+    }
+
+    private ensureLocalOfferTransceiver(kind: 'audio' | 'video', mid: string): void {
+        if (this.transceivers.some(transceiver => transceiver.mid === mid)) {
+            return;
+        }
+        const transceiver = this.transceivers.find(candidate => (
+            candidate.mid === null &&
+            (candidate.receiver.track?.kind === kind || candidate.sender.track?.kind === kind)
+        ));
+        if (transceiver) {
+            transceiver.mid = mid;
+            return;
+        }
+        const sender = new FakeRtcRtpSender(null);
+        this.senders.push(sender);
+        this.transceivers.push(new FakeRtcRtpTransceiver(kind, sender, 'recvonly', mid));
+    }
+
+    private finalizeNegotiatedDirections(): void {
+        for (const transceiver of this.transceivers) {
+            if (transceiver.mid !== null) {
+                transceiver.currentDirection = transceiver.direction;
+            }
+        }
     }
 }
 
@@ -133,11 +181,13 @@ class FakeRtcRtpSender {
 
 class FakeRtcRtpTransceiver {
     readonly receiver: RTCRtpReceiver;
+    currentDirection: RTCRtpTransceiverDirection | null = null;
 
     constructor(
         kind: 'audio' | 'video',
         public sender: FakeRtcRtpSender,
         public direction: RTCRtpTransceiverDirection,
+        public mid: string | null = null,
     ) {
         this.receiver = {
             track: createMediaTrack(kind),
@@ -389,6 +439,9 @@ describe('MediaEngine', () => {
         if (peer) {
             peer.remoteDescription = { type: 'answer', sdp: 'fake-answer-sdp' };
             peer.signalingState = 'stable';
+            peer.transceivers.forEach(transceiver => {
+                transceiver.currentDirection = transceiver.direction;
+            });
         }
 
         await engine.reacquireVideoTrack();
@@ -399,6 +452,108 @@ describe('MediaEngine', () => {
         });
         expect(peer?.senders.map(sender => sender.track?.kind)).toEqual(['audio', 'video']);
         expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
+    });
+
+    it('moves answerer local tracks to negotiated transceivers before answering remote offers', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream({ audio: true, video: true }));
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({}, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'zeta');
+        await engine.startLocalMedia();
+
+        const peer = engine.getPeerConnectionsMap().get('alpha') as FakeRtcPeerConnection | undefined;
+        expect(peer).toBeDefined();
+        expect(peer?.transceivers.filter(transceiver => transceiver.mid === null).map(transceiver => transceiver.sender.track?.kind)).toEqual(['audio', 'video']);
+
+        engine.processSignalingMessage({
+            v: 1,
+            type: 'offer',
+            payload: { from: 'alpha', sdp: 'remote-offer', offerId: 'offer-1' },
+        });
+        await flushPromises();
+
+        await vi.waitFor(() => {
+            expect(sentMessages.filter(message => message.type === 'answer')).toHaveLength(1);
+        });
+        expect(peer?.transceivers.find(transceiver => transceiver.mid === '0')?.sender.track?.kind).toBe('audio');
+        expect(peer?.transceivers.find(transceiver => transceiver.mid === '1')?.sender.track?.kind).toBe('video');
+        expect(peer?.transceivers.filter(transceiver => transceiver.mid === null).map(transceiver => transceiver.sender.track)).toEqual([null, null]);
+    });
+
+    it('asks the offerer to renegotiate when non-offer late video needs a new m-line direction', async () => {
+        const getUserMedia = vi.fn().mockImplementation(async (constraints: MediaStreamConstraints) => {
+            if (constraints.video) {
+                return createMediaStream({ audio: false, video: true });
+            }
+            return createMediaStream();
+        });
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'zeta');
+        await engine.startLocalMedia();
+        engine.processSignalingMessage({
+            v: 1,
+            type: 'offer',
+            payload: { from: 'alpha', sdp: 'remote-offer', offerId: 'offer-1' },
+        });
+        await flushPromises();
+
+        const peer = engine.getPeerConnectionsMap().get('alpha') as FakeRtcPeerConnection | undefined;
+        expect(peer).toBeDefined();
+        let videoTransceiver: FakeRtcRtpTransceiver | undefined;
+        await vi.waitFor(() => {
+            videoTransceiver = peer?.transceivers.find(transceiver => transceiver.mid === '1');
+            expect(videoTransceiver?.currentDirection).toBe('recvonly');
+        });
+        if (videoTransceiver) {
+            videoTransceiver.direction = 'sendrecv';
+        }
+        sentMessages.length = 0;
+
+        await engine.reacquireVideoTrack();
+        await flushPromises();
+
+        expect(peer?.closed).toBe(false);
+        expect(sentMessages.filter(message => message.type === 'offer')).toHaveLength(0);
+        expect(sentMessages.filter(message => message.type === 'media_restart_request')).toEqual([
+            { type: 'media_restart_request', payload: { reason: 'local track negotiation' }, to: 'alpha' },
+        ]);
     });
 
     it('does not restore camera after stopping screen share that started from audio-only media', async () => {
@@ -708,7 +863,9 @@ describe('MediaEngine', () => {
             type: 'offer',
             payload: { from: 'alpha', sdp: 'remote-offer', offerId: 'offer-1' },
         });
-        await flushPromises();
+        await vi.waitFor(() => {
+            expect(sentMessages.filter((message) => message.type === 'answer')).toHaveLength(1);
+        });
 
         const peer = engine.getPeerConnectionsMap().get('alpha') as FakeRtcPeerConnection | undefined;
         expect(peer).toBeDefined();
@@ -964,6 +1121,56 @@ describe('MediaEngine', () => {
         expect(replacement).toBeDefined();
         expect(replacement).not.toBe(peer);
         expect(peer?.closed).toBe(true);
+        expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(2);
+    });
+
+    it('renegotiates without recreating the offerer peer for local track negotiation requests', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream({ audio: true, video: true }));
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({}, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        await engine.startLocalMedia();
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+        await vi.waitFor(() => {
+            expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
+        });
+
+        const firstOfferId = sentMessages.find((message) => message.type === 'offer')?.payload?.offerId;
+        engine.processSignalingMessage({
+            v: 1,
+            type: 'answer',
+            payload: { from: 'zeta', sdp: 'remote-answer', offerId: firstOfferId },
+        });
+        await flushPromises();
+
+        const peer = engine.getPeerConnectionsMap().get('zeta') as FakeRtcPeerConnection | undefined;
+        expect(peer).toBeDefined();
+        engine.processSignalingMessage({
+            v: 1,
+            type: 'media_restart_request',
+            payload: { from: 'zeta', reason: 'local track negotiation' },
+        });
+        await flushPromises();
+
+        expect(engine.getPeerConnectionsMap().get('zeta')).toBe(peer);
+        expect(peer?.closed).toBe(false);
         expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(2);
     });
 

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.2",
+    "@agatx/serenada-core": "^0.8.3",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.2"
+    "@agatx/serenada-core": "0.8.3"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.2")
-    implementation("app.serenada:call-ui:0.8.2")
+    implementation("app.serenada:core:0.8.3")
+    implementation("app.serenada:call-ui:0.8.3")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.2 @agatx/serenada-react-ui@0.8.2 lucide-react
+npm install @agatx/serenada-core@0.8.3 @agatx/serenada-react-ui@0.8.3 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -585,9 +585,13 @@ schedule fresh negotiation against confirmed state.
 
 ### 4.16 `media_restart_request` (client → server → client)
 
-Asks the deterministic offer owner for a peer pair to recreate that pair and
-send a fresh offer because media stopped flowing even though SDP, ICE, and
-peer-connection states still look healthy.
+Asks the deterministic offer owner for a peer pair to send a fresh offer. Most
+requests are media-recovery requests, where media stopped flowing even though
+SDP, ICE, and peer-connection states still look healthy. A request with
+`reason: "local track negotiation"` is a lighter negotiation-only request: the
+receiver should keep the existing peer connection and create a new offer.
+This reason is a shared client wire constant verified by
+`node scripts/check-signaling-protocol-constants.mjs`.
 
 ```json
 {
@@ -605,8 +609,12 @@ peer-connection states still look healthy.
 - Relay like `offer`/`answer`/`ice` and add `from` to the payload.
 
 **Client behavior**
-- If the receiver is the deterministic offer owner for `from`, close and
-  recreate that peer connection, then send a fresh offer.
+- If the receiver is the deterministic offer owner for `from` and
+  `reason === "local track negotiation"`, keep the existing peer connection
+  and send a fresh offer.
+- If the receiver is the deterministic offer owner for `from` and the reason is
+  media recovery, close and recreate that peer connection, then send a fresh
+  offer.
 - If the receiver is not the offer owner, ignore the request.
 - Do not let this bypass perfect negotiation ownership; non-offerers request
   recovery instead of sending their own offer.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.2"
+        "@agatx/serenada-core": "0.8.3"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.2",
+        "@agatx/serenada-core": "^0.8.3",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/scripts/check-signaling-protocol-constants.mjs
+++ b/scripts/check-signaling-protocol-constants.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies signaling protocol wire constants that must stay identical across
+ * all three Serenada clients (web, Android, iOS).
+ *
+ * Usage:  node scripts/check-signaling-protocol-constants.mjs
+ * Exit 0 on match, 1 on mismatch.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const TS_PATH = resolve(root, 'client/packages/core/src/signaling/protocolConstants.ts');
+const KT_PATH = resolve(root, 'client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingProtocolConstants.kt');
+const SWIFT_PATH = resolve(root, 'client-ios/SerenadaCore/Sources/Call/SignalingProtocolConstants.swift');
+
+const EXPECTED = new Map([
+    ['MEDIA_RESTART_REASON_LOCAL_TRACK_NEGOTIATION', 'local track negotiation'],
+]);
+
+function parseTypeScript(src) {
+    const constants = new Map();
+    for (const m of src.matchAll(/export\s+const\s+([A-Z_]+)\s*=\s*['"]([^'"]*)['"]/g)) {
+        constants.set(m[1], m[2]);
+    }
+    return constants;
+}
+
+function parseKotlin(src) {
+    const constants = new Map();
+    for (const m of src.matchAll(/const\s+val\s+([A-Z_]+)\s*=\s*"([^"]*)"/g)) {
+        constants.set(m[1], m[2]);
+    }
+    return constants;
+}
+
+function swiftCamelToUpperSnake(name) {
+    return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase();
+}
+
+function parseSwift(src) {
+    const constants = new Map();
+    for (const m of src.matchAll(/static\s+let\s+(\w+)\s*=\s*"([^"]*)"/g)) {
+        constants.set(swiftCamelToUpperSnake(m[1]), m[2]);
+    }
+    return constants;
+}
+
+const platformMaps = [
+    ['TypeScript', parseTypeScript(readFileSync(TS_PATH, 'utf-8'))],
+    ['Kotlin', parseKotlin(readFileSync(KT_PATH, 'utf-8'))],
+    ['Swift', parseSwift(readFileSync(SWIFT_PATH, 'utf-8'))],
+];
+
+let exitCode = 0;
+
+function fail(msg) {
+    console.error(`  FAIL: ${msg}`);
+    exitCode = 1;
+}
+
+for (const [name, expectedValue] of EXPECTED) {
+    for (const [platform, constants] of platformMaps) {
+        const actualValue = constants.get(name);
+        if (actualValue === undefined) {
+            fail(`${name}: missing in ${platform}`);
+        } else if (actualValue !== expectedValue) {
+            fail(`${name}: ${platform}=${JSON.stringify(actualValue)} expected=${JSON.stringify(expectedValue)}`);
+        }
+    }
+}
+
+if (exitCode === 0) {
+    console.log(`OK: ${EXPECTED.size} signaling protocol constants match across platforms.`);
+}
+
+process.exit(exitCode);

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -38,6 +38,11 @@ const sources = [
         regex: /sdkVersion\s*=\s*"([^"]+)"/,
     },
     {
+        name: 'serenada-core (Kotlin constant)',
+        file: 'client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt',
+        regex: /VERSION\s*=\s*"([^"]+)"/,
+    },
+    {
         name: 'serenada-webrtc (build.gradle.kts)',
         file: 'client-android/serenada-webrtc/build.gradle.kts',
         regex: /sdkVersion\s*=\s*"([^"]+)"/,


### PR DESCRIPTION
## Summary

- Fix Web SDK answerer media negotiation so local tracks are attached or started before answering, avoiding receive-only answers on the deterministic non-offerer.
- Add local-track negotiation recovery across Web, Android, and iOS so late video/audio enable asks the deterministic offerer for a normal renegotiation while preserving peer recreation for true stalled outbound media recovery.
- Prefer negotiated transceivers and detach stale same-kind senders before replacing local tracks.
- Bump Serenada SDK packages and docs/samples from `0.8.2` to `0.8.3`, including the Android runtime `SerenadaCore.VERSION`, and extend version parity checks to cover that Kotlin constant.

## Validation

- `node scripts/check-version-parity.mjs`
- `node scripts/check-resilience-constants.mjs`
- `node scripts/check-telemetry-parity.mjs`
- `npm test`
- `npm run build`
- `./gradlew :serenada-core:testDebugUnitTest --console=plain`
- `./gradlew :serenada-core:assembleRelease :serenada-call-ui:assembleRelease :serenada-webrtc:verifyLocalWebRtcAar --console=plain`
- `xcodegen generate && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' test`
- Earlier device smoke deploy: web build, Android install/launch on `SM_G950U1` and `A065`, iOS install/launch on `iPhone (2)` and `Alexey’s iPad`.

## Notes

Non-blocking warnings observed: Vite large chunk warning, Xcode AppIntents metadata skipped because no AppIntents dependency, and the expected WebRTC checksum script dependency-analysis note.