### PR TITLE
Fix web audio routing and bump SDK to 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.4] — 2026-06-05
+
+### Fixed
+- Web: local audio capture now follows the browser's current default
+  audio route before first capture and after device changes, so a
+  Bluetooth headset selected as the default input/output does not leave
+  calls on the built-in microphone.
+- Web: concurrent local media starts now share one in-flight capture,
+  avoiding duplicate `getUserMedia` calls during multi-party attach and
+  renegotiation flows.
+
 ## [0.8.3] — 2026-06-04
 
 ### Fixed

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.3`
-- `app.serenada:core:0.8.3`
-- `app.serenada:call-ui:0.8.3`
+- `app.serenada:libwebrtc-7827-universal:0.8.4`
+- `app.serenada:core:0.8.4`
+- `app.serenada:call-ui:0.8.4`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.3"
+                version = "0.8.4"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.3"
+val sdkVersion = "0.8.4"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.8.3"
+        const val VERSION = "0.8.4"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.3"
+val sdkVersion = "0.8.4"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.3"
+    public static let version = "0.8.4"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.3",
-        "@agatx/serenada-react-ui": "0.8.3",
+        "@agatx/serenada-core": "0.8.4",
+        "@agatx/serenada-react-ui": "0.8.4",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.3"
+        "@agatx/serenada-core": "0.8.4"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.3",
+        "@agatx/serenada-core": "^0.8.4",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.3",
-    "@agatx/serenada-react-ui": "0.8.3",
+    "@agatx/serenada-core": "0.8.4",
+    "@agatx/serenada-react-ui": "0.8.4",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.3';
+export const SERENADA_CORE_VERSION = '0.8.4';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -24,6 +24,7 @@ const ICE_STATE_PRIORITY: RTCIceConnectionState[] = ['failed', 'disconnected', '
 const CONN_STATE_PRIORITY: RTCPeerConnectionState[] = ['failed', 'disconnected', 'connecting', 'new', 'connected', 'closed'];
 const SIG_STATE_PRIORITY: RTCSignalingState[] = ['closed', 'have-local-offer', 'have-remote-offer', 'have-local-pranswer', 'have-remote-pranswer', 'stable'];
 const LEGACY_OFFER_ID = '__legacy__';
+const DEVICE_CHANGE_SETTLE_DELAY_MS = 2000;
 
 function getSignalingState(pc: RTCPeerConnection): RTCSignalingState {
     return pc.signalingState;
@@ -67,6 +68,12 @@ interface PeerState {
     lastOutboundMediaRecoveryAt: number;
 }
 
+interface PreferredAudioInputSelection {
+    device: MediaDeviceInfo | null;
+    currentMatchesPreferredRoute: boolean;
+    basis: 'default-input' | 'default-output' | 'already-matched' | 'none' | 'no-devices';
+}
+
 export interface MediaEngineConfig {
     turnsOnly?: boolean;
     logger?: SerenadaLogger;
@@ -104,6 +111,8 @@ export class MediaEngine {
     private requestingMedia = false;
     private destroyed = false;
     private cameraRecoveryInFlight = false;
+    private audioRecoveryInFlight = false;
+    private localMediaStartPromise: Promise<MediaStream | null> | null = null;
     private mediaRequestId = 0;
     private retryingTimer: number | null = null;
     private localVideoHeartbeatAt = Date.now();
@@ -117,6 +126,7 @@ export class MediaEngine {
     private onlineHandler: (() => void) | null = null;
     private networkChangeHandler: (() => void) | null = null;
     private deviceChangeHandler: (() => void) | null = null;
+    private deviceChangeSettleTimer: number | null = null;
     private turnsOnly: boolean;
     private logger?: SerenadaLogger;
     private offerSequence = 0;
@@ -250,34 +260,40 @@ export class MediaEngine {
     }
 
     async startLocalMedia(): Promise<MediaStream | null> {
+        if (this.localStream) return this.localStream;
+        if (this.localMediaStartPromise) return this.localMediaStartPromise;
+        const startPromise = this.startLocalMediaInternal();
+        this.localMediaStartPromise = startPromise;
+        try {
+            return await startPromise;
+        } finally {
+            if (this.localMediaStartPromise === startPromise) {
+                this.localMediaStartPromise = null;
+            }
+        }
+    }
+
+    private async startLocalMediaInternal(): Promise<MediaStream | null> {
         const requestId = this.mediaRequestId + 1;
         this.mediaRequestId = requestId;
 
-        if (this.localStream) return this.localStream;
         this.requestingMedia = true;
         try {
             if (!navigator.mediaDevices?.getUserMedia) {
                 this.requestingMedia = false;
                 return null;
             }
-            const audioConstraints: MediaTrackConstraints = {
-                echoCancellation: { ideal: true },
-                noiseSuppression: { ideal: true },
-                autoGainControl: { ideal: true },
-                channelCount: { ideal: 1 },
-                sampleRate: { ideal: 48000 }
-            };
+            const initialDevices = await this.enumerateMediaDevices();
+            const preferredInput = this.selectPreferredAudioInput(initialDevices, null);
+            const preferredDeviceId = preferredInput.device?.deviceId;
             let stream: MediaStream;
             if (!this.videoCaptureSupported || !this.initialVideoEnabled) {
-                stream = await navigator.mediaDevices.getUserMedia({ video: false, audio: audioConstraints });
+                stream = await this.acquireInitialMedia(false, preferredDeviceId);
             } else {
                 try {
-                    stream = await navigator.mediaDevices.getUserMedia({
-                        video: { facingMode: this.facingMode },
-                        audio: audioConstraints
-                    });
+                    stream = await this.acquireInitialMedia({ facingMode: this.facingMode }, preferredDeviceId);
                 } catch {
-                    stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+                    stream = await this.acquireInitialMedia(true, preferredDeviceId);
                 }
             }
 
@@ -288,11 +304,17 @@ export class MediaEngine {
 
             this.applySpeechTrackHints(stream);
             this.localStream = stream;
-            await this.detectCameras();
+            const postStartDevices = await this.enumerateMediaDevices();
+            await this.detectCameras(postStartDevices);
             this.requestingMedia = false;
+            if (this.roomState && this.clientId) {
+                await this.refreshLocalAudioTrack('initial-route-check', postStartDevices, false);
+            }
+            const activeStream = this.localStream;
+            if (!activeStream) return null;
 
             for (const [remoteCid, peer] of this.peers) {
-                await this.attachLocalTracksToPeer(remoteCid, peer, stream);
+                await this.attachLocalTracksToPeer(remoteCid, peer, activeStream);
                 void this.applyAudioSenderParameters(peer.pc);
                 if (this.shouldIOffer(remoteCid) && !peer.pc.remoteDescription) {
                     if (peer.pc.signalingState === 'stable') {
@@ -305,7 +327,7 @@ export class MediaEngine {
                 }
             }
             this.notifyChange();
-            return stream;
+            return activeStream;
         } catch (err) {
             this.logger?.log('error', 'WebRTC', `Error accessing media: ${formatError(err)}`);
             this.requestingMedia = false;
@@ -315,6 +337,7 @@ export class MediaEngine {
 
     stopLocalMedia(): void {
         this.mediaRequestId += 1;
+        this.localMediaStartPromise = null;
         if (this.screenShareTrack) {
             this.screenShareTrack.onended = null;
             this.screenShareTrack = null;
@@ -1218,6 +1241,139 @@ export class MediaEngine {
         this.notifyChange();
     }
 
+    private async acquireInitialMedia(
+        video: boolean | MediaTrackConstraints,
+        preferredDeviceId?: string,
+    ): Promise<MediaStream> {
+        try {
+            return await navigator.mediaDevices.getUserMedia({
+                video,
+                audio: this.createAudioConstraints(preferredDeviceId),
+            });
+        } catch (err) {
+            if (!preferredDeviceId) throw err;
+            this.logger?.log('warning', 'WebRTC', `Failed to acquire preferred initial audio input: ${formatError(err)}`);
+            return navigator.mediaDevices.getUserMedia({
+                video,
+                audio: this.createAudioConstraints(),
+            });
+        }
+    }
+
+    private async acquireAudioTrack(enabled: boolean, preferredDeviceId?: string): Promise<MediaStreamTrack> {
+        let audioStream: MediaStream;
+        try {
+            audioStream = await navigator.mediaDevices.getUserMedia({
+                video: false,
+                audio: this.createAudioConstraints(preferredDeviceId),
+            });
+        } catch (err) {
+            if (!preferredDeviceId) throw err;
+            this.logger?.log('warning', 'WebRTC', `Failed to acquire preferred audio input: ${formatError(err)}`);
+            audioStream = await navigator.mediaDevices.getUserMedia({
+                video: false,
+                audio: this.createAudioConstraints(),
+            });
+        }
+        const audioTrack = audioStream.getAudioTracks()[0];
+        if (!audioTrack) {
+            audioStream.getTracks().forEach(track => track.stop());
+            throw new Error('No audio track returned');
+        }
+        audioTrack.enabled = enabled;
+        this.applySpeechTrackHints(audioStream);
+        return audioTrack;
+    }
+
+    private async replaceAudioTrackOnAllPeers(newTrack: MediaStreamTrack, stream: MediaStream): Promise<void> {
+        await Promise.all(
+            Array.from(this.peers.entries()).map(async ([remoteCid, peer]) => {
+                const audioTransceiver = this.findTransceiver(peer.pc, 'audio');
+                if (audioTransceiver) {
+                    try {
+                        await audioTransceiver.sender.replaceTrack(newTrack);
+                        let negotiationNeeded = this.needsLocalTrackNegotiation(audioTransceiver);
+                        if (audioTransceiver.direction !== 'sendrecv' && audioTransceiver.direction !== 'stopped') {
+                            audioTransceiver.direction = 'sendrecv';
+                            negotiationNeeded = true;
+                        }
+                        if (negotiationNeeded) {
+                            this.scheduleLocalTrackNegotiation(remoteCid, peer);
+                        }
+                    } catch (err) {
+                        this.logger?.log('warning', 'WebRTC', `Failed to replace audio track on peer: ${formatError(err)}`);
+                    }
+                    return;
+                }
+                try {
+                    peer.pc.addTrack(newTrack, stream);
+                    this.scheduleLocalTrackNegotiation(remoteCid, peer);
+                } catch (err) {
+                    this.logger?.log('warning', 'WebRTC', `Failed to add audio track on peer: ${formatError(err)}`);
+                }
+            })
+        );
+    }
+
+    private async refreshLocalAudioTrack(reason: string, devices?: MediaDeviceInfo[] | null, updatePeers = true): Promise<boolean> {
+        const currentAudioTrack = this.localStream?.getAudioTracks()[0] ?? null;
+        if (!this.localStream) {
+            return false;
+        }
+        if (this.requestingMedia) {
+            return false;
+        }
+        if (this.audioRecoveryInFlight) {
+            return false;
+        }
+        const preferredInput = this.selectPreferredAudioInput(devices ?? null, currentAudioTrack);
+        if (preferredInput.basis === 'no-devices' || preferredInput.basis === 'none') {
+            return false;
+        }
+        if (preferredInput.currentMatchesPreferredRoute) {
+            return false;
+        }
+
+        const requestId = this.mediaRequestId;
+        this.audioRecoveryInFlight = true;
+        try {
+            const nextTrack = await this.acquireAudioTrack(currentAudioTrack?.enabled ?? true, preferredInput.device?.deviceId);
+            if (this.destroyed || !this.localStream || this.mediaRequestId !== requestId) {
+                nextTrack.stop();
+                return false;
+            }
+
+            const nextStream = new MediaStream();
+            let replacedAudio = false;
+            for (const track of this.localStream.getTracks()) {
+                if (track.kind !== 'audio') {
+                    nextStream.addTrack(track);
+                    continue;
+                }
+                if (!replacedAudio) {
+                    nextStream.addTrack(nextTrack);
+                    replacedAudio = true;
+                }
+            }
+            if (!replacedAudio) {
+                nextStream.addTrack(nextTrack);
+            }
+            this.localStream = nextStream;
+            if (updatePeers) {
+                await this.replaceAudioTrackOnAllPeers(nextTrack, nextStream);
+            }
+            if (currentAudioTrack && currentAudioTrack !== nextTrack) currentAudioTrack.stop();
+            this.logger?.log('info', 'WebRTC', `Refreshed local audio track (${reason})`);
+            this.notifyChange();
+            return true;
+        } catch (err) {
+            this.logger?.log('warning', 'WebRTC', `Failed to refresh local audio track (${reason}): ${formatError(err)}`);
+            return false;
+        } finally {
+            this.audioRecoveryInFlight = false;
+        }
+    }
+
     private ensureMediaTransceivers(pc: RTCPeerConnection): void {
         if (!this.findTransceiver(pc, 'audio') && !pc.getSenders().some(sender => sender.track?.kind === 'audio')) {
             pc.addTransceiver('audio', { direction: 'recvonly' });
@@ -1358,12 +1514,115 @@ export class MediaEngine {
         }
     }
 
-    private async detectCameras(): Promise<void> {
-        if (!navigator.mediaDevices?.enumerateDevices) return;
+    private async enumerateMediaDevices(): Promise<MediaDeviceInfo[] | null> {
+        if (!navigator.mediaDevices?.enumerateDevices) {
+            return null;
+        }
         try {
-            const devices = await navigator.mediaDevices.enumerateDevices();
-            this.hasMultipleCameras = devices.filter(d => d.kind === 'videoinput').length > 1;
-        } catch { /* ignore */ }
+            return await navigator.mediaDevices.enumerateDevices();
+        } catch {
+            return null;
+        }
+    }
+
+    private async detectCameras(devices?: MediaDeviceInfo[] | null): Promise<void> {
+        const resolvedDevices = devices === undefined ? await this.enumerateMediaDevices() : devices;
+        if (!resolvedDevices) return;
+        this.hasMultipleCameras = resolvedDevices.filter(d => d.kind === 'videoinput').length > 1;
+    }
+
+    private createAudioConstraints(deviceId?: string): MediaTrackConstraints {
+        const constraints: MediaTrackConstraints = {
+            echoCancellation: { ideal: true },
+            noiseSuppression: { ideal: true },
+            autoGainControl: { ideal: true },
+            channelCount: { ideal: 1 },
+            sampleRate: { ideal: 48000 },
+        };
+        if (deviceId) {
+            constraints.deviceId = { exact: deviceId };
+        }
+        return constraints;
+    }
+
+    private getTrackGroupId(track: MediaStreamTrack | null): string | null {
+        try {
+            const groupId = track?.getSettings().groupId;
+            return groupId ? groupId : null;
+        } catch {
+            return null;
+        }
+    }
+
+    private isVirtualDefaultAudioDevice(device: MediaDeviceInfo): boolean {
+        return device.deviceId === 'default' || device.deviceId === 'communications';
+    }
+
+    private selectPreferredAudioInput(devices: MediaDeviceInfo[] | null, currentAudioTrack: MediaStreamTrack | null): PreferredAudioInputSelection {
+        if (!devices) {
+            return {
+                device: null,
+                currentMatchesPreferredRoute: false,
+                basis: 'no-devices',
+            };
+        }
+        const currentGroupId = currentAudioTrack?.readyState === 'live' ? this.getTrackGroupId(currentAudioTrack) : null;
+        const audioInputs = devices.filter(device => device.kind === 'audioinput');
+        const defaultInput = audioInputs.find(device => device.deviceId === 'default');
+        const defaultOutput = devices.find(device => device.kind === 'audiooutput' && device.deviceId === 'default');
+        const inputForGroup = (groupId: string): MediaDeviceInfo | null => {
+            const matchingInputs = audioInputs.filter(device => device.groupId === groupId);
+            return matchingInputs.find(device => !this.isVirtualDefaultAudioDevice(device)) ?? matchingInputs[0] ?? null;
+        };
+
+        if (defaultInput && (!defaultInput.groupId || currentGroupId !== defaultInput.groupId)) {
+            return {
+                device: defaultInput.groupId ? inputForGroup(defaultInput.groupId) ?? defaultInput : defaultInput,
+                currentMatchesPreferredRoute: false,
+                basis: 'default-input',
+            };
+        }
+
+        if (defaultOutput?.groupId && currentGroupId !== defaultOutput.groupId) {
+            return {
+                device: inputForGroup(defaultOutput.groupId),
+                currentMatchesPreferredRoute: false,
+                basis: 'default-output',
+            };
+        }
+
+        if (currentGroupId && (currentGroupId === defaultInput?.groupId || currentGroupId === defaultOutput?.groupId)) {
+            return {
+                device: null,
+                currentMatchesPreferredRoute: true,
+                basis: 'already-matched',
+            };
+        }
+
+        return {
+            device: null,
+            currentMatchesPreferredRoute: false,
+            basis: 'none',
+        };
+    }
+
+    private async refreshDevicesAfterChange(reason: string): Promise<void> {
+        const devices = await this.enumerateMediaDevices();
+        await Promise.all([
+            this.detectCameras(devices),
+            this.refreshLocalAudioTrack(reason, devices),
+        ]);
+    }
+
+    private handleDeviceChange(): void {
+        void this.refreshDevicesAfterChange('device-change');
+        if (this.deviceChangeSettleTimer !== null) {
+            window.clearTimeout(this.deviceChangeSettleTimer);
+        }
+        this.deviceChangeSettleTimer = window.setTimeout(() => {
+            this.deviceChangeSettleTimer = null;
+            void this.refreshDevicesAfterChange('device-change-settled');
+        }, DEVICE_CHANGE_SETTLE_DELAY_MS);
     }
 
     private setupEventListeners(): void {
@@ -1379,7 +1638,7 @@ export class MediaEngine {
         const conn = (navigator as any).connection;
         conn?.addEventListener?.('change', this.networkChangeHandler);
 
-        this.deviceChangeHandler = () => { void this.detectCameras(); };
+        this.deviceChangeHandler = () => { this.handleDeviceChange(); };
         navigator.mediaDevices?.addEventListener?.('devicechange', this.deviceChangeHandler);
         void this.detectCameras();
 
@@ -1433,6 +1692,10 @@ export class MediaEngine {
         const conn = (navigator as any).connection;
         if (this.networkChangeHandler) conn?.removeEventListener?.('change', this.networkChangeHandler);
         if (this.deviceChangeHandler) navigator.mediaDevices?.removeEventListener?.('devicechange', this.deviceChangeHandler);
+        if (this.deviceChangeSettleTimer !== null) {
+            window.clearTimeout(this.deviceChangeSettleTimer);
+            this.deviceChangeSettleTimer = null;
+        }
         if (this.visibilityHandler) document.removeEventListener('visibilitychange', this.visibilityHandler);
         if (this.pageShowHandler) window.removeEventListener('pageshow', this.pageShowHandler);
         if (this.heartbeatInterval !== null) window.clearInterval(this.heartbeatInterval);

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -308,7 +308,7 @@ export class MediaEngine {
             await this.detectCameras(postStartDevices);
             this.requestingMedia = false;
             if (this.roomState && this.clientId) {
-                await this.refreshLocalAudioTrack('initial-route-check', postStartDevices, false);
+                await this.refreshLocalAudioTrack('initial-route-check', postStartDevices);
             }
             const activeStream = this.localStream;
             if (!activeStream) return null;
@@ -1333,6 +1333,9 @@ export class MediaEngine {
         if (preferredInput.currentMatchesPreferredRoute) {
             return false;
         }
+        if (!preferredInput.device) {
+            return false;
+        }
 
         const requestId = this.mediaRequestId;
         this.audioRecoveryInFlight = true;
@@ -1566,7 +1569,8 @@ export class MediaEngine {
                 basis: 'no-devices',
             };
         }
-        const currentGroupId = currentAudioTrack?.readyState === 'live' ? this.getTrackGroupId(currentAudioTrack) : null;
+        const hasCurrentAudioTrack = currentAudioTrack?.readyState === 'live';
+        const currentGroupId = hasCurrentAudioTrack ? this.getTrackGroupId(currentAudioTrack) : null;
         const audioInputs = devices.filter(device => device.kind === 'audioinput');
         const defaultInput = audioInputs.find(device => device.deviceId === 'default');
         const defaultOutput = devices.find(device => device.kind === 'audiooutput' && device.deviceId === 'default');
@@ -1575,17 +1579,33 @@ export class MediaEngine {
             return matchingInputs.find(device => !this.isVirtualDefaultAudioDevice(device)) ?? matchingInputs[0] ?? null;
         };
 
-        if (defaultInput && (!defaultInput.groupId || currentGroupId !== defaultInput.groupId)) {
+        if (defaultInput && !defaultInput.groupId) {
             return {
-                device: defaultInput.groupId ? inputForGroup(defaultInput.groupId) ?? defaultInput : defaultInput,
+                device: hasCurrentAudioTrack && !currentGroupId ? null : defaultInput,
+                currentMatchesPreferredRoute: hasCurrentAudioTrack && !currentGroupId,
+                basis: hasCurrentAudioTrack && !currentGroupId ? 'already-matched' : 'default-input',
+            };
+        }
+
+        if (defaultInput && currentGroupId !== defaultInput.groupId) {
+            return {
+                device: inputForGroup(defaultInput.groupId) ?? defaultInput,
                 currentMatchesPreferredRoute: false,
                 basis: 'default-input',
             };
         }
 
         if (defaultOutput?.groupId && currentGroupId !== defaultOutput.groupId) {
+            const outputInput = inputForGroup(defaultOutput.groupId);
+            if (!outputInput) {
+                return {
+                    device: null,
+                    currentMatchesPreferredRoute: false,
+                    basis: 'none',
+                };
+            }
             return {
-                device: inputForGroup(defaultOutput.groupId),
+                device: outputInput,
                 currentMatchesPreferredRoute: false,
                 basis: 'default-output',
             };

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -588,6 +588,90 @@ describe('MediaEngine', () => {
         engine.destroy();
     });
 
+    it('keeps the current input when the default output route has no matching microphone', async () => {
+        const initialStream = createMediaStream({ audioSettings: { deviceId: 'built-in-mic', groupId: 'built-in' } });
+        const getUserMedia = vi.fn().mockResolvedValue(initialStream);
+        let route: 'built-in' | 'speaker-output' = 'built-in';
+        const enumerateDevices = vi.fn().mockImplementation(async () => {
+            const outputGroup = route === 'speaker-output' ? 'speaker' : 'built-in';
+            return [
+                createMediaDevice('audioinput', 'default', 'built-in', 'Default - Microphone'),
+                createMediaDevice('audioinput', 'built-in-mic', 'built-in', 'MacBook Pro Microphone'),
+                createMediaDevice('audiooutput', 'default', outputGroup, 'Default - Output'),
+                createMediaDevice('audiooutput', 'built-in-speakers', 'built-in', 'MacBook Pro Speakers'),
+                createMediaDevice('audiooutput', 'speaker', 'speaker', 'External Speaker'),
+            ];
+        });
+        let deviceChangeHandler: (() => void) | undefined;
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices,
+                    addEventListener: vi.fn((event: string, handler: () => void) => {
+                        if (event === 'devicechange') {
+                            deviceChangeHandler = handler;
+                        }
+                    }),
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        await engine.startLocalMedia();
+        route = 'speaker-output';
+        deviceChangeHandler?.();
+        await flushPromises();
+
+        expect(getUserMedia).toHaveBeenCalledTimes(1);
+        expect(engine.localStream?.getAudioTracks()[0]).toBe(initialStream.getAudioTracks()[0]);
+
+        engine.destroy();
+    });
+
+    it('does not refresh audio repeatedly when current and default input group identity is unknown', async () => {
+        const initialStream = createMediaStream({ audioSettings: { deviceId: 'default' } });
+        const getUserMedia = vi.fn().mockResolvedValue(initialStream);
+        const devices = [
+            createMediaDevice('audioinput', 'default', '', 'Default - Microphone'),
+            createMediaDevice('audioinput', 'built-in-mic', '', 'MacBook Pro Microphone'),
+            createMediaDevice('audiooutput', 'default', '', 'Default - Output'),
+        ];
+        let deviceChangeHandler: (() => void) | undefined;
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue(devices),
+                    addEventListener: vi.fn((event: string, handler: () => void) => {
+                        if (event === 'devicechange') {
+                            deviceChangeHandler = handler;
+                        }
+                    }),
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        await engine.startLocalMedia();
+        deviceChangeHandler?.();
+        await flushPromises();
+
+        expect(getUserMedia).toHaveBeenCalledTimes(1);
+        expect(getUserMedia).toHaveBeenLastCalledWith({
+            video: false,
+            audio: expect.objectContaining({
+                deviceId: { exact: 'default' },
+            }),
+        });
+
+        engine.destroy();
+    });
+
     it('uses the reserved video transceiver when video is enabled after an audio-only start', async () => {
         const getUserMedia = vi.fn().mockImplementation(async (constraints: MediaStreamConstraints) => {
             if (constraints.video) {

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -221,7 +221,7 @@ class FakeMediaStream {
 
 let trackId = 0;
 
-function createMediaTrack(kind: 'audio' | 'video'): MediaStreamTrack {
+function createMediaTrack(kind: 'audio' | 'video', settings: MediaTrackSettings = {}): MediaStreamTrack {
     trackId += 1;
     return {
         id: `${kind}-${trackId}`,
@@ -229,15 +229,26 @@ function createMediaTrack(kind: 'audio' | 'video'): MediaStreamTrack {
         enabled: true,
         muted: false,
         readyState: 'live',
+        getSettings: () => settings,
         stop() {},
     } as MediaStreamTrack;
 }
 
-function createMediaStream(options: { audio?: boolean; video?: boolean } = { audio: true }): MediaStream {
+function createMediaStream(options: { audio?: boolean; video?: boolean; audioSettings?: MediaTrackSettings; videoSettings?: MediaTrackSettings } = { audio: true }): MediaStream {
     const tracks: MediaStreamTrack[] = [];
-    if (options.audio !== false) tracks.push(createMediaTrack('audio'));
-    if (options.video) tracks.push(createMediaTrack('video'));
+    if (options.audio !== false) tracks.push(createMediaTrack('audio', options.audioSettings));
+    if (options.video) tracks.push(createMediaTrack('video', options.videoSettings));
     return new FakeMediaStream(tracks) as unknown as MediaStream;
+}
+
+function createMediaDevice(kind: MediaDeviceKind, deviceId: string, groupId: string, label: string): MediaDeviceInfo {
+    return {
+        kind,
+        deviceId,
+        groupId,
+        label,
+        toJSON: () => ({ kind, deviceId, groupId, label }),
+    } as MediaDeviceInfo;
 }
 
 function createOutboundStats(audioBytesSent: number, videoBytesSent: number, videoFramesSent: number): RTCStatsReport {
@@ -398,6 +409,183 @@ describe('MediaEngine', () => {
                 echoCancellation: { ideal: true },
             }),
         });
+    });
+
+    it('starts local media with the default audio input when it is available before capture', async () => {
+        const getUserMedia = vi.fn().mockResolvedValue(createMediaStream({ audioSettings: { deviceId: 'bt-mic', groupId: 'bluetooth' } }));
+        const devices = [
+            createMediaDevice('audioinput', 'default', 'bluetooth', 'Default - Headset Microphone'),
+            createMediaDevice('audioinput', 'built-in-mic', 'built-in', 'MacBook Pro Microphone'),
+            createMediaDevice('audioinput', 'bt-mic', 'bluetooth', 'Headset Microphone'),
+            createMediaDevice('audiooutput', 'default', 'bluetooth', 'Default - Headset'),
+            createMediaDevice('audiooutput', 'bt-speakers', 'bluetooth', 'Headset'),
+        ];
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue(devices),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        await engine.startLocalMedia();
+
+        expect(getUserMedia).toHaveBeenCalledTimes(1);
+        expect(getUserMedia).toHaveBeenCalledWith({
+            video: false,
+            audio: expect.objectContaining({
+                deviceId: { exact: 'bt-mic' },
+            }),
+        });
+        expect(engine.localStream?.getAudioTracks()[0]?.getSettings().groupId).toBe('bluetooth');
+
+        engine.destroy();
+    });
+
+    it('refreshes the local audio input to match the default output route without renegotiating active peers', async () => {
+        const initialStream = createMediaStream({ audioSettings: { deviceId: 'built-in-mic', groupId: 'built-in' } });
+        const refreshedStream = createMediaStream({ audioSettings: { deviceId: 'bt-mic', groupId: 'bluetooth' } });
+        const getUserMedia = vi.fn()
+            .mockResolvedValueOnce(initialStream)
+            .mockResolvedValueOnce(refreshedStream);
+        let route: 'built-in' | 'bluetooth-output' = 'built-in';
+        const enumerateDevices = vi.fn().mockImplementation(async () => {
+            const outputGroup = route === 'bluetooth-output' ? 'bluetooth' : 'built-in';
+            return [
+                createMediaDevice('audioinput', 'default', 'built-in', 'Default - MacBook Pro Microphone'),
+                createMediaDevice('audioinput', 'built-in-mic', 'built-in', 'MacBook Pro Microphone'),
+                createMediaDevice('audioinput', 'bt-mic', 'bluetooth', 'Headset Microphone'),
+                createMediaDevice('audiooutput', 'default', outputGroup, 'Default - Output'),
+                createMediaDevice('audiooutput', 'built-in-speakers', 'built-in', 'MacBook Pro Speakers'),
+                createMediaDevice('audiooutput', 'bt-speakers', 'bluetooth', 'Headset'),
+            ];
+        });
+        let deviceChangeHandler: (() => void) | undefined;
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices,
+                    addEventListener: vi.fn((event: string, handler: () => void) => {
+                        if (event === 'devicechange') {
+                            deviceChangeHandler = handler;
+                        }
+                    }),
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const sentMessages: Array<{ type: string; payload?: Record<string, unknown>; to?: string }> = [];
+        const engine = new MediaEngine({ initialVideoEnabled: false }, (type, payload, to) => {
+            sentMessages.push({ type, payload, to });
+        });
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+        await engine.startLocalMedia();
+        await vi.waitFor(() => {
+            expect(sentMessages.filter((message) => message.type === 'offer')).toHaveLength(1);
+        });
+
+        const offerId = sentMessages.find((message) => message.type === 'offer')?.payload?.offerId;
+        engine.processSignalingMessage({
+            v: 1,
+            type: 'answer',
+            payload: { from: 'zeta', sdp: 'remote-answer', offerId },
+        });
+        await flushPromises();
+        sentMessages.length = 0;
+
+        const initialAudioTrack = initialStream.getAudioTracks()[0];
+        const refreshedAudioTrack = refreshedStream.getAudioTracks()[0];
+        if (initialAudioTrack) {
+            initialAudioTrack.enabled = false;
+        }
+
+        route = 'bluetooth-output';
+        deviceChangeHandler?.();
+        await vi.waitFor(() => {
+            expect(getUserMedia).toHaveBeenCalledTimes(2);
+            expect(engine.localStream?.getAudioTracks()[0]).toBe(refreshedAudioTrack);
+        });
+
+        expect(getUserMedia).toHaveBeenLastCalledWith({
+            video: false,
+            audio: expect.objectContaining({
+                deviceId: { exact: 'bt-mic' },
+            }),
+        });
+        const peer = engine.getPeerConnectionsMap().get('zeta') as FakeRtcPeerConnection | undefined;
+        const audioSender = peer?.senders.find(sender => sender.track?.kind === 'audio');
+        expect(refreshedAudioTrack?.enabled).toBe(false);
+        expect(audioSender?.track).toBe(refreshedAudioTrack);
+        expect(audioSender?.replaceTrackCalls.at(-1)).toBe(refreshedAudioTrack);
+        expect(sentMessages).toEqual([]);
+
+        engine.destroy();
+    });
+
+    it('prefers the default audio input route when refreshing after a device change', async () => {
+        const initialStream = createMediaStream({ audioSettings: { deviceId: 'built-in-mic', groupId: 'built-in' } });
+        const refreshedStream = createMediaStream({ audioSettings: { deviceId: 'bt-mic', groupId: 'bluetooth' } });
+        const getUserMedia = vi.fn()
+            .mockResolvedValueOnce(initialStream)
+            .mockResolvedValueOnce(refreshedStream);
+        let route: 'built-in' | 'bluetooth-input' = 'built-in';
+        const enumerateDevices = vi.fn().mockImplementation(async () => {
+            const inputGroup = route === 'bluetooth-input' ? 'bluetooth' : 'built-in';
+            return [
+                createMediaDevice('audioinput', 'default', inputGroup, 'Default - Microphone'),
+                createMediaDevice('audioinput', 'built-in-mic', 'built-in', 'MacBook Pro Microphone'),
+                createMediaDevice('audioinput', 'bt-mic', 'bluetooth', 'Headset Microphone'),
+                createMediaDevice('audiooutput', 'default', 'built-in', 'Default - MacBook Pro Speakers'),
+                createMediaDevice('audiooutput', 'built-in-speakers', 'built-in', 'MacBook Pro Speakers'),
+                createMediaDevice('audiooutput', 'bt-speakers', 'bluetooth', 'Headset'),
+            ];
+        });
+        let deviceChangeHandler: (() => void) | undefined;
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices,
+                    addEventListener: vi.fn((event: string, handler: () => void) => {
+                        if (event === 'devicechange') {
+                            deviceChangeHandler = handler;
+                        }
+                    }),
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        await engine.startLocalMedia();
+        route = 'bluetooth-input';
+        deviceChangeHandler?.();
+
+        await vi.waitFor(() => {
+            expect(getUserMedia).toHaveBeenCalledTimes(2);
+            expect(engine.localStream?.getAudioTracks()[0]).toBe(refreshedStream.getAudioTracks()[0]);
+        });
+        expect(getUserMedia).toHaveBeenLastCalledWith({
+            video: false,
+            audio: expect.objectContaining({
+                deviceId: { exact: 'bt-mic' },
+            }),
+        });
+
+        engine.destroy();
     });
 
     it('uses the reserved video transceiver when video is enabled after an audio-only start', async () => {

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.3",
+    "@agatx/serenada-core": "^0.8.4",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.3"
+    "@agatx/serenada-core": "0.8.4"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.3")
-    implementation("app.serenada:call-ui:0.8.3")
+    implementation("app.serenada:core:0.8.4")
+    implementation("app.serenada:call-ui:0.8.4")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.3 @agatx/serenada-react-ui@0.8.3 lucide-react
+npm install @agatx/serenada-core@0.8.4 @agatx/serenada-react-ui@0.8.4 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.3"
+        "@agatx/serenada-core": "0.8.4"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.3",
+        "@agatx/serenada-core": "^0.8.4",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary
- Fix web local audio capture to prefer the browser default audio input before first capture, with default-output fallback on device changes.
- Refresh the local audio track after immediate and settled `devicechange` events without renegotiating already-active peer senders when replacement is enough.
- Share concurrent `startLocalMedia()` calls and bump the SDK to `0.8.4` across package metadata, platform constants, docs, and web sample lockfiles.

## Root Cause
Chrome can keep an existing built-in microphone track alive even after the browser default audio route points at a Bluetooth headset. The web SDK only captured generic audio constraints and only watched device changes for camera availability, so loopback tabs could send built-in mic audio while output correctly moved to Bluetooth.

## Checks
- `node scripts/check-version-parity.mjs`
- `npx eslint src/media/MediaEngine.ts` from `client/packages/core`
- `npm test -- test/media/MediaEngine.test.ts` from `client/packages/core` (409 tests)
- `npm run build` from `client` (passes with existing Vite large-chunk warning)
- `npm run build` from `samples/web`
