### PR TITLE
Document provider-driven TURN credential refresh for custom providers

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -19,5 +19,14 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Honor the `_`-prefix convention for intentionally-unused bindings
+      // (interface-stub params, ignored callback args, swallowed catch errors).
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/client/packages/core/src/cameraModes.ts
+++ b/client/packages/core/src/cameraModes.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CAMERA_MODES, type ConfigurableCameraMode, type SerenadaConfig } from './types.js';
+import { DEFAULT_CAMERA_MODES, type ConfigurableCameraMode } from './types.js';
 
 /**
  * Resolve the configured {@link SerenadaConfig.cameraModes} list into the set

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -563,6 +563,19 @@ describe('SerenadaSession', () => {
             }]);
         });
 
+        it('applies a provider iceServersChanged push to live peer connections', () => {
+            // Provider-driven refresh: a custom provider rotates TURN credentials by
+            // pushing iceServersChanged at any time; the session forwards them to the
+            // media engine, which applies them to current and future peers.
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            const rotated = [{ urls: ['turns:rotated.example.com'], username: 'next-user', credential: 'next-pass' }];
+
+            harness.signaling.emitIceServersChanged(rotated);
+
+            expect(harness.media.setIceServersCalls.at(-1)).toEqual(rotated);
+        });
+
         it('transitions to error when initial ICE server retries are exhausted', async () => {
             harness = new TestSessionHarness();
             harness.signaling.getIceServersResults = [

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -34,7 +34,7 @@ const Footer: React.FC = () => {
 
         try {
             mediaQuery.addEventListener('change', handleMediaQueryChange);
-        } catch (e) {
+        } catch {
             // Fallback for older browsers
             mediaQuery.addListener(handleMediaQueryChange);
         }
@@ -43,7 +43,7 @@ const Footer: React.FC = () => {
             window.removeEventListener('beforeinstallprompt', handler);
             try {
                 mediaQuery.removeEventListener('change', handleMediaQueryChange);
-            } catch (e) {
+            } catch {
                 mediaQuery.removeListener(handleMediaQueryChange);
             }
         };

--- a/docs/sdk/sdk-api-reference.md
+++ b/docs/sdk/sdk-api-reference.md
@@ -73,7 +73,7 @@ Key contract rules:
 - Public/provider-facing identifiers use `peerId`. Built-in `cid` naming stays internal to `SerenadaServerProvider`.
 - `hostPeerId` is optional in `JoinedEvent` and `RoomStateEvent`.
 - `roomStateUpdated` is optional. Incremental `peerJoined` / `peerLeft` is enough for a valid adapter.
-- `iceServersChanged` refreshes both existing and future peer connections.
+- `iceServersChanged` refreshes both existing and future peer connections. Providers with time-limited TURN credentials must push fresh servers through it before expiry (the SDK fetches `getIceServers()` only once, at join). See "ICE-server sourcing and refresh" in the customization guide.
 - `version` must be `1`.
 
 ### Reconnection ownership

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -16,7 +16,7 @@ Provider mode is best for integrators who already have their own peer-message de
 - `hostPeerId` is optional. UI and session layers tolerate it being absent.
 - `peerId` is the provider-facing identifier. Built-in `cid` mapping stays internal.
 - `getIceServers()` supplies the initial ICE server list.
-- `iceServersChanged` rotates ICE servers for both current and future peer connections.
+- `iceServersChanged` rotates ICE servers for both current and future peer connections. Time-limited TURN credentials must be refreshed through this before they expire — see ICE-server sourcing and refresh.
 
 ### Reconnection ownership
 
@@ -29,13 +29,15 @@ This flag does not transfer initial join-timeout ownership to the provider. The 
 
 Only set `handlesReconnection = true` when your adapter already preserves identity and transport recovery semantics. The built-in `SerenadaServerProvider` does this on all platforms.
 
-### ICE-server sourcing
+### ICE-server sourcing and refresh
 
-Provider mode does not use Serenada's TURN token API. Your adapter owns ICE sourcing:
+Provider mode does not use Serenada's TURN token API. Your adapter owns the ICE credential lifecycle, including refresh:
 
-- Return STUN/TURN configs from `getIceServers()`.
-- Reject/throw on failure so the session can retry.
-- Emit `iceServersChanged` when credentials rotate.
+- Return STUN/TURN configs from `getIceServers()` — the one-time fetch at join. Reject/throw on failure so the session retries.
+- **Refresh time-limited credentials before they expire.** If your TURN credentials have a TTL, run your own timer and push fresh servers through the provider listener's `iceServersChanged` *before* the current ones lapse. A good default is to refresh at ~0.8 × TTL (the SDK uses the same ratio internally). The session applies the new servers to every current and future peer connection, so the next relay (re)allocation and any post-reconnect ICE restart use valid credentials.
+- The built-in `SerenadaServerProvider` works exactly this way (it drives a `turn-refresh` loop and pushes `iceServersChanged`). The SDK does not refresh provider credentials for you: `getIceServers()` is called only once, at join, and only your adapter knows the credentials' real lifetime.
+
+Why this matters: on relay-only networks (symmetric NAT, cross-LAN) a call that outlives its TURN credential TTL can no longer allocate a relay, so a mid-call ICE restart — for example after a network blip — fails and the call drops. Proactive `iceServersChanged` refresh keeps the relay path valid for the life of the call. See "Threading and actor guarantees" below for when and from which thread the listener may be called.
 
 `runTurnProbe()` also uses provider ICE servers in provider mode, so the same source feeds both diagnostics and live calls.
 


### PR DESCRIPTION
## Problem

App-owned signaling mode (custom `SignalingProvider`, no `serverHost`) fetches ICE servers once at join. On relay-dependent networks (symmetric NAT, cross-LAN), a call that outlives its TURN credential TTL can no longer allocate a relay, so a mid-call ICE restart (e.g. after a network blip) fails with stale credentials and the call drops.

## Approach: document the existing provider-driven path (option B)

The capability to keep credentials fresh **already exists and is provider-agnostic**: a provider pushes rotated servers via `iceServersChanged` and the session applies them to all current and future peer connections — the same path the built-in `SerenadaServerProvider` uses on its `turn-refresh` loop, and already covered by per-platform contract tests. The gap was **guidance, not capability**: nothing told integrators they must drive that refresh *before* their TTL elapses.

We initially built an SDK-side refresh scheduler (option A) that fetched a TTL from the provider and refreshed at 0.8 × TTL. It worked, but the SDK can't observe a custom provider's real credential lifecycle, so it had to *guess* (rotation vs cache-hit, reported-vs-real TTL, clock domains, sleep, push-vs-poll). That guessing produced ~1000 lines and a long tail of edge cases. **The host owns its credentials, so the host should own the refresh** — exactly like the internal provider. So this PR is the documentation + a parity test, not a scheduler.

## Changes

- **`docs/sdk/sdk-customization.md`** — strengthened "ICE-server sourcing and refresh": hosts with time-limited TURN credentials must push fresh servers through `iceServersChanged` before expiry (recommend ~0.8 × TTL), the SDK applies them to all live + future peers, this mirrors the built-in `SerenadaServerProvider`, and the SDK does not refresh provider credentials for you. Spells out the failure mode and points at the existing threading guarantees.
- **`docs/sdk/sdk-api-reference.md`** — note the same on the `iceServersChanged` contract rule.
- **Web test** — asserts a provider's `iceServersChanged` push reaches the media engine (Android/iOS already have equivalent contract tests).
- **Lint cleanup** (separate commit) — eslint now honors the repo's `_`-prefix unused-binding convention + one unused import + two bare `catch` fixes; clears all 19 `no-unused-vars` errors. Remaining lint errors are pre-existing react-hooks issues in app-shell files, left for a separate change.

No SDK code change and no version bump — the contract and apply path are unchanged; this is documentation of existing behavior plus a test and a lint fix.

## Verification

Web: 412 core tests pass, `tsc` clean, 0 `no-unused-vars` lint errors. Android/iOS SDK source is unchanged (their existing `iceServersChanged` contract tests already cover the apply path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)