### PR TITLE
[codex] Harden SDK call recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ client-ios/Resources/GoogleService-Info.plist
 /client-ios/SerenadaCore/.swiftpm
 /client-ios/SerenadaCallUI/.swiftpm
 /.reviewlens
+.gstack/

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -20,8 +20,10 @@ import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.OkHttpClient
@@ -50,6 +52,7 @@ internal class SerenadaServerProvider(
     )
 
     private var reconnectAttempts = 0
+    private var iceRefreshGeneration = 0
     private var reconnectRunnable: Runnable? = null
     private var turnRefreshRunnable: Runnable? = null
     private var reconnectTokenRefreshRunnable: Runnable? = null
@@ -232,18 +235,7 @@ internal class SerenadaServerProvider(
                 if (ttlMs != null) {
                     scheduleTurnRefresh(ttlMs)
                 }
-                scope.launch {
-                    runCatching { getIceServers() }
-                        .onSuccess { iceServers -> listener?.onIceServersChanged(iceServers) }
-                        .onFailure { error ->
-                            listener?.onError(
-                                ErrorEvent(
-                                    code = "TURN_REFRESH_FAILED",
-                                    message = error.message ?: "TURN refresh failed",
-                                )
-                            )
-                        }
-                }
+                scope.launch { refreshIceServersWithRetry() }
             }
             "offer", "answer", "ice", "media_restart_request", "content_state", "participant_media_state" -> emitPeerMessage(message)
             "negotiation_dirty" -> {
@@ -262,6 +254,38 @@ internal class SerenadaServerProvider(
             }
             "pong" -> signaling.recordPong()
         }
+    }
+
+    private suspend fun refreshIceServersWithRetry() {
+        val generation = ++iceRefreshGeneration
+        var lastError: Exception? = null
+        for (delayMs in WebRtcResilienceConstants.ICE_FETCH_RETRY_DELAYS_MS) {
+            if (delayMs > 0) {
+                delay(delayMs)
+            }
+            if (closedByClient || generation != iceRefreshGeneration) {
+                return
+            }
+            try {
+                val servers = getIceServers()
+                if (closedByClient || generation != iceRefreshGeneration) {
+                    return
+                }
+                listener?.onIceServersChanged(servers)
+                return
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                lastError = error
+            }
+        }
+        // Non-fatal: the call keeps running on the existing credentials,
+        // and the next turn-refreshed message retries with a fresh token.
+        logger?.log(
+            SerenadaLogLevel.WARNING,
+            "Signaling",
+            "Failed to refresh ICE servers after retries: ${lastError?.message ?: "unknown error"}",
+        )
     }
 
     private fun handleJoined(message: SignalingMessage) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -230,12 +230,18 @@ internal class SerenadaServerProvider(
                 )
             }
             "turn-refreshed" -> {
-                currentTurnToken = message.payload?.optString("turnToken").orEmpty().ifBlank { null }
-                val ttlMs = message.payload?.optLong("turnTokenTTLMs", 0L)?.takeIf { it > 0L }
-                if (ttlMs != null) {
-                    scheduleTurnRefresh(ttlMs)
+                // Mirror web: a tokenless turn-refreshed must not clobber valid
+                // credentials (and strip TURN from the live connection); keep
+                // the current token and skip the refresh entirely.
+                val refreshedToken = message.payload?.optString("turnToken").orEmpty().ifBlank { null }
+                if (refreshedToken != null) {
+                    currentTurnToken = refreshedToken
+                    val ttlMs = message.payload?.optLong("turnTokenTTLMs", 0L)?.takeIf { it > 0L }
+                    if (ttlMs != null) {
+                        scheduleTurnRefresh(ttlMs)
+                    }
+                    scope.launch { refreshIceServersWithRetry() }
                 }
-                scope.launch { refreshIceServersWithRetry() }
             }
             "offer", "answer", "ice", "media_restart_request", "content_state", "participant_media_state" -> emitPeerMessage(message)
             "negotiation_dirty" -> {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -773,6 +773,11 @@ class SerenadaSession internal constructor(
         override fun onError(event: ErrorEvent) {
             runOnMain {
                 logger?.log(SerenadaLogLevel.DEBUG, "Session", "RX error ${event.code}")
+                if (event.code == "TURN_REFRESH_FAILED") {
+                    // Non-fatal: media keeps flowing on the existing credentials until expiry.
+                    logger?.log(SerenadaLogLevel.WARNING, "Session", "TURN refresh failed: ${event.message}")
+                    return@runOnMain
+                }
                 signalingMessageRouter.processErrorEvent(event)
             }
         }
@@ -881,10 +886,13 @@ class SerenadaSession internal constructor(
     /** Set a specific camera mode. Ignored when [mode] is not in the configured list. */
     fun setCameraMode(mode: LocalCameraMode) {
         assertMainThread()
-        if (mode == _state.value.localCameraMode) return
         if (mode !in availableCameraModes) return
+        // The session's state copy of the camera mode is posted asynchronously,
+        // so flipping in a loop must read the engine-side mode, which flipCamera
+        // updates synchronously.
         repeat(availableCameraModes.size) {
-            if (_state.value.localCameraMode == mode) return
+            val current = webRtcEngine.activeCameraMode() ?: _state.value.localCameraMode
+            if (current == mode) return
             flipCamera()
         }
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -135,7 +135,7 @@ internal class PeerConnectionSlot(
     @Volatile private var isClosing = false
     private var peerConnection: PeerConnection? = null
     private var audioSender: RtpSender? = null
-    private var remoteVideoTrack: VideoTrack? = null
+    @Volatile private var remoteVideoTrack: VideoTrack? = null
     @Volatile private var playbackDucked = false
     private var remoteDescriptionSet = false
     private val pendingIceCandidates = mutableListOf<IceCandidate>()
@@ -155,7 +155,7 @@ internal class PeerConnectionSlot(
                 logger?.log(
                     SerenadaLogLevel.DEBUG,
                     "PeerConnection",
-                    "[RemoteVideo][$remoteCid] syntheticBlack=${remoteBlackFrameAnalyzer.isSyntheticBlackDetected()} trackEnabled=${remoteVideoTrack?.enabled()}"
+                    "[RemoteVideo][$remoteCid] syntheticBlack=${remoteBlackFrameAnalyzer.isSyntheticBlackDetected()} trackPresent=${remoteVideoTrack != null}"
                 )
             }
         }
@@ -163,6 +163,19 @@ internal class PeerConnectionSlot(
 
     override fun setIceServers(servers: List<PeerConnection.IceServer>) {
         iceServers = servers
+        val pc = peerConnection
+        if (pc != null && !isClosing) {
+            // Apply refreshed credentials to the live connection so a later
+            // ICE restart gathers relay candidates with current (not expired)
+            // TURN credentials.
+            val config = PeerConnection.RTCConfiguration(servers).apply {
+                sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+            }
+            if (!pc.setConfiguration(config)) {
+                logger?.log(SerenadaLogLevel.WARNING, "PeerConnection", "[$remoteCid] Failed to apply refreshed ICE servers")
+            }
+            return
+        }
         ensurePeerConnection()
     }
 
@@ -662,8 +675,9 @@ internal class PeerConnectionSlot(
     override fun hasRemoteDescription(): Boolean = !isClosing && (remoteDescriptionSet || peerConnection?.remoteDescription != null)
 
     override fun isRemoteVideoTrackEnabled(): Boolean {
-        val track = remoteVideoTrack ?: return false
-        if (!track.enabled()) return false
+        // Do not call VideoTrack.enabled() here. It crosses into native WebRTC
+        // and can block the main-thread participant refresh path.
+        if (remoteVideoTrack == null) return false
         return !remoteBlackFrameAnalyzer.isVideoConsideredOff()
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -797,9 +797,12 @@ internal class PeerNegotiationEngine(
         if (slot.iceRestartTask != null) return
         // Inside the cooldown window, defer to its expiry instead of dropping:
         // ICE state changes are edge-triggered, so a dropped restart for a
-        // connection parked in FAILED would never be retried.
+        // connection parked in FAILED would never be retried. Clamp to one
+        // cooldown: nowMs() is wall-clock, so a backwards step would otherwise
+        // park the restart for the full skew.
         val cooldownRemainingMs = if (slot.lastIceRestartAt > 0) {
-            slot.lastIceRestartAt + WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS - clock.nowMs()
+            (slot.lastIceRestartAt + WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS - clock.nowMs())
+                .coerceIn(0L, WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS)
         } else {
             0L
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -218,15 +218,19 @@ internal class PeerNegotiationEngine(
         val slot = createSlotViaEngine(
             remoteCid,
             { cid: String, candidate: IceCandidate ->
-                val payload = JSONObject().apply {
-                    val candidateJson = JSONObject()
-                    candidateJson.put("candidate", candidate.sdp)
-                    candidateJson.put("sdpMid", candidate.sdpMid)
-                    candidateJson.put("sdpMLineIndex", candidate.sdpMLineIndex)
-                    put("candidate", candidateJson)
-                    currentLocalOfferId(cid)?.let { put("offerId", it) }
+                // Fires on the WebRTC signaling thread; negotiation state
+                // (offer ids) and the transport are main-thread-owned.
+                handler.post {
+                    val payload = JSONObject().apply {
+                        val candidateJson = JSONObject()
+                        candidateJson.put("candidate", candidate.sdp)
+                        candidateJson.put("sdpMid", candidate.sdpMid)
+                        candidateJson.put("sdpMLineIndex", candidate.sdpMLineIndex)
+                        put("candidate", candidateJson)
+                        currentLocalOfferId(cid)?.let { put("offerId", it) }
+                    }
+                    sendMessage("ice", payload, cid)
                 }
-                sendMessage("ice", payload, cid)
             },
             { _, _ ->
                 handler.post { onRemoteParticipantsChanged() }
@@ -583,12 +587,17 @@ internal class PeerNegotiationEngine(
         val started = slot.createOffer(
             iceRestart = iceRestart,
             onSdp = { sdp ->
-                val payload = JSONObject().apply {
-                    put("sdp", sdp)
-                    put("offerId", offerId)
+                // Fires on the WebRTC signaling thread; the transport and the
+                // offer-timeout bookkeeping are main-thread-owned.
+                handler.post {
+                    if (pendingLocalOfferIds[slot.remoteCid] != offerId) return@post
+                    val payload = JSONObject().apply {
+                        put("sdp", sdp)
+                        put("offerId", offerId)
+                    }
+                    sendMessage("offer", payload, slot.remoteCid)
+                    scheduleOfferTimeout(slot.remoteCid)
                 }
-                sendMessage("offer", payload, slot.remoteCid)
-                scheduleOfferTimeout(slot.remoteCid)
             },
             onComplete = { success ->
                 handler.post {
@@ -783,10 +792,17 @@ internal class PeerNegotiationEngine(
         val slot = getSlot(remoteCid) ?: return
         if (!canOffer(slot)) { slot.markPendingIceRestart(); return }
         if (slot.iceRestartTask != null) return
-        if (slot.lastIceRestartAt > 0 && clock.nowMs() - slot.lastIceRestartAt < WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS) return
+        // Inside the cooldown window, defer to its expiry instead of dropping:
+        // ICE state changes are edge-triggered, so a dropped restart for a
+        // connection parked in FAILED would never be retried.
+        val cooldownRemainingMs = if (slot.lastIceRestartAt > 0) {
+            slot.lastIceRestartAt + WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS - clock.nowMs()
+        } else {
+            0L
+        }
         val runnable = Runnable { slot.cancelIceRestartTask(); triggerIceRestart(remoteCid, reason) }
         slot.setIceRestartTask(runnable)
-        handler.postDelayed(runnable, delayMs)
+        handler.postDelayed(runnable, maxOf(delayMs, cooldownRemainingMs))
     }
 
     private fun clearIceRestartTimer(remoteCid: String? = null) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -215,12 +215,14 @@ internal class PeerNegotiationEngine(
 
     private fun getOrCreateSlot(remoteCid: String): PeerConnectionSlotProtocol {
         getSlot(remoteCid)?.let { return it }
+        var callbackSlot: PeerConnectionSlotProtocol? = null
         val slot = createSlotViaEngine(
             remoteCid,
             { cid: String, candidate: IceCandidate ->
                 // Fires on the WebRTC signaling thread; negotiation state
                 // (offer ids) and the transport are main-thread-owned.
                 handler.post {
+                    if (getSlot(cid) !== callbackSlot) return@post
                     val payload = JSONObject().apply {
                         val candidateJson = JSONObject()
                         candidateJson.put("candidate", candidate.sdp)
@@ -291,6 +293,7 @@ internal class PeerNegotiationEngine(
                 }
             }
         )
+        callbackSlot = slot
         setSlot(remoteCid, slot)
         return slot
     }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SessionMediaEngine.kt
@@ -15,6 +15,12 @@ internal interface SessionMediaEngine {
     fun toggleAudio(enabled: Boolean)
     fun toggleVideo(enabled: Boolean): Boolean
     fun flipCamera()
+    /**
+     * Engine-side camera mode, updated synchronously by [flipCamera]. The
+     * session's state copy is posted asynchronously, so callers that flip in
+     * a loop must consult this instead. Null when the engine has no camera.
+     */
+    fun activeCameraMode(): LocalCameraMode? = null
     fun startScreenShare(intent: Intent): Boolean
     fun stopScreenShare(): Boolean
     fun setIceServers(servers: List<PeerConnection.IceServer>)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -291,6 +291,8 @@ internal class WebRtcEngine(
         cameraController.flipCamera(videoSource)
     }
 
+    override fun activeCameraMode(): LocalCameraMode = cameraController.activeCameraMode()
+
     override fun adjustWorldCameraZoom(scaleFactor: Float): Boolean {
         return cameraController.adjustWorldCameraZoom(scaleFactor)
     }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
@@ -412,6 +412,49 @@ class SerenadaServerProviderTest {
     }
 
     @Test
+    fun `tokenless turn-refreshed keeps the current turn token`() = runBlocking {
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "local-cid",
+                to = null,
+                payload = JSONObject().apply {
+                    put("hostCid", "local-cid")
+                    put("turnToken", "turn-token")
+                    put(
+                        "participants",
+                        JSONArray().put(
+                            JSONObject().apply {
+                                put("cid", "local-cid")
+                                put("joinedAt", 1L)
+                            }
+                        )
+                    )
+                },
+            )
+        )
+
+        signaling.receive(
+            SignalingMessage(
+                type = "turn-refreshed",
+                rid = "room-1",
+                sid = null,
+                cid = "local-cid",
+                to = null,
+                payload = JSONObject().apply { put("turnToken", "") },
+            )
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        val iceServers = provider.getIceServers()
+
+        assertEquals(listOf("serenada.app" to "turn-token"), apiClient.fetchTurnCredentialsCalls)
+        assertEquals(listOf("turn:turn.example.com:3478"), iceServers.flatMap { it.urls })
+    }
+
+    @Test
     fun `room state emits participant diffs and room ended uses payload fields`() {
         signaling.receive(
             SignalingMessage(

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -313,6 +313,37 @@ class SessionNegotiationTest {
         assertTrue("Higher peer ID should not offer", factory.fakeProvider.sentMessages("offer").isEmpty())
     }
 
+    @Test
+    fun `deferred ICE restart cooldown is capped when the wall clock moves backwards`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull(fakeSlot)
+        // A backwards wall-clock step after a previous restart leaves
+        // lastIceRestartAt far in the future relative to nowMs().
+        fakeSlot!!.recordIceRestart(factory.fakeClock.nowMs() + WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS * 10)
+        val offersBefore = fakeSlot.createOfferCalls
+
+        fakeSlot.simulateConnectionStateChange(PeerConnection.PeerConnectionState.FAILED)
+        ShadowLooper.idleMainLooper()
+        assertNotNull("ICE restart should be deferred, not dropped", fakeSlot.iceRestartTask)
+
+        ShadowLooper.idleMainLooper(WebRtcResilienceConstants.ICE_RESTART_COOLDOWN_MS, TimeUnit.MILLISECONDS)
+        ShadowLooper.idleMainLooper()
+
+        // The deferred runnable clears the task when it fires; an unclamped
+        // deferral would still be parked here (10x the cooldown away).
+        assertNull(
+            "Deferred restart must fire within one cooldown despite clock regression",
+            fakeSlot.iceRestartTask,
+        )
+        assertTrue(
+            "Restart offer should be sent once the clamped cooldown elapses",
+            fakeSlot.createOfferCalls > offersBefore,
+        )
+        assertEquals(true, fakeSlot.createOfferIceRestartFlags.last())
+    }
+
     // Group 7: Timer-Based (Android-specific via ShadowLooper)
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -91,6 +91,30 @@ class SessionNegotiationTest {
     }
 
     @Test
+    fun `stale local ICE from replaced slot is not sent`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+
+        val staleSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull("Original slot should be created", staleSlot)
+
+        factory.simulateRoomState(participants = listOf("alpha" to 1L), hostCid = "alpha")
+        factory.simulateRoomState(participants = listOf("alpha" to 1L, "remote" to 3L), hostCid = "alpha")
+        val replacementSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull("Replacement slot should be created", replacementSlot)
+        assertNotSame("Room rejoin should replace the slot", staleSlot, replacementSlot)
+
+        val iceMessagesBefore = factory.fakeProvider.sentMessages("ice").size
+        staleSlot!!.simulateLocalIceCandidate("candidate:stale-old-slot")
+        ShadowLooper.idleMainLooper()
+
+        val iceMessages = factory.fakeProvider.sentMessages("ice")
+        assertEquals("Stale slot ICE must not be sent", iceMessagesBefore, iceMessages.size)
+        assertFalse("Stale candidate must not be tagged onto replacement negotiation", iceMessages.any {
+            it.payload?.optJSONObject("candidate")?.optString("candidate") == "candidate:stale-old-slot"
+        })
+    }
+
+    @Test
     fun `local peer waits then answers when its peer ID sorts later`() {
         factory.advanceToInCallWithTurn(localCid = "zulu", remoteCid = "alpha", localJoinedAt = 2, remoteJoinedAt = 1)
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -75,6 +75,22 @@ class SessionNegotiationTest {
     }
 
     @Test
+    fun `stale deferred local offer is not sent after pending offer clears`() {
+        factory.fakeMedia.deferNextCreatedSlotOfferSdp = true
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["remote"]
+        assertNotNull("Slot should be created", fakeSlot)
+        assertTrue("Deferred offer should not be sent yet", factory.fakeProvider.sentMessages("offer").isEmpty())
+
+        factory.simulateRoomState(participants = listOf("alpha" to 1L), hostCid = "alpha")
+        fakeSlot!!.flushPendingOfferSdp()
+        ShadowLooper.idleMainLooper()
+
+        assertTrue("Stale offer must not be sent after peer leaves", factory.fakeProvider.sentMessages("offer").isEmpty())
+    }
+
+    @Test
     fun `local peer waits then answers when its peer ID sorts later`() {
         factory.advanceToInCallWithTurn(localCid = "zulu", remoteCid = "alpha", localJoinedAt = 2, remoteJoinedAt = 1)
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -24,6 +24,7 @@ internal class FakeMediaEngine : SessionMediaEngine {
     val removedSlots = mutableListOf<PeerConnectionSlotProtocol>()
     val fakeSlots = mutableMapOf<String, FakePeerConnectionSlot>()
     var failNextCreatedSlotRemoteOffer = false
+    var deferNextCreatedSlotOfferSdp = false
 
     private var _iceServers: List<PeerConnection.IceServer>? = null
 
@@ -71,6 +72,10 @@ internal class FakeMediaEngine : SessionMediaEngine {
         if (failNextCreatedSlotRemoteOffer) {
             slot.failNextRemoteOffer = true
             failNextCreatedSlotRemoteOffer = false
+        }
+        if (deferNextCreatedSlotOfferSdp) {
+            slot.deferNextOfferSdp = true
+            deferNextCreatedSlotOfferSdp = false
         }
         fakeSlots[remoteCid] = slot
         _iceServers?.let(slot::setIceServers)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -64,6 +64,7 @@ internal class FakeMediaEngine : SessionMediaEngine {
         createdSlotCids.add(remoteCid)
         val slot = FakePeerConnectionSlot(
             remoteCid = remoteCid,
+            onLocalIceCandidate = onLocalIceCandidate,
             onConnectionStateChange = onConnectionStateChange,
             onIceConnectionStateChange = onIceConnectionStateChange,
             onSignalingStateChange = onSignalingStateChange,

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -48,6 +48,8 @@ internal class FakePeerConnectionSlot(
     var failNextRemoteOffer = false
     var failNextAnswer = false
     var failNextRollback = false
+    var deferNextOfferSdp = false
+    private var pendingOfferSdp: (() -> Unit)? = null
 
     // Offer lifecycle
     override fun beginOffer() { isMakingOffer = true }
@@ -90,9 +92,22 @@ internal class FakePeerConnectionSlot(
         }
         signalingState = PeerConnection.SignalingState.HAVE_LOCAL_OFFER
         onSignalingStateChange?.invoke(remoteCid, signalingState)
-        onSdp("fake-offer-sdp")
-        onComplete?.invoke(true)
+        val complete: () -> Unit = {
+            onSdp("fake-offer-sdp")
+            onComplete?.invoke(true)
+        }
+        if (deferNextOfferSdp) {
+            deferNextOfferSdp = false
+            pendingOfferSdp = complete
+        } else {
+            complete()
+        }
         return true
+    }
+
+    fun flushPendingOfferSdp() {
+        pendingOfferSdp?.invoke()
+        pendingOfferSdp = null
     }
 
     override fun createAnswer(onSdp: (String) -> Unit, onComplete: ((Boolean) -> Unit)?) {

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -14,6 +14,7 @@ import org.webrtc.VideoTrack
 
 internal class FakePeerConnectionSlot(
     override val remoteCid: String,
+    private val onLocalIceCandidate: ((String, IceCandidate) -> Unit)? = null,
     private val onConnectionStateChange: ((String, PeerConnection.PeerConnectionState) -> Unit)? = null,
     private val onIceConnectionStateChange: ((String, PeerConnection.IceConnectionState) -> Unit)? = null,
     private val onSignalingStateChange: ((String, PeerConnection.SignalingState) -> Unit)? = null,
@@ -219,6 +220,10 @@ internal class FakePeerConnectionSlot(
     fun simulateIceConnectionStateChange(state: PeerConnection.IceConnectionState) {
         iceConnectionState = state
         onIceConnectionStateChange?.invoke(remoteCid, state)
+    }
+
+    fun simulateLocalIceCandidate(candidate: String = "candidate:local") {
+        onLocalIceCandidate?.invoke(remoteCid, IceCandidate("0", 0, candidate))
     }
 
     fun simulateRenegotiationNeeded() {

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -131,6 +131,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
     private let onIceConnectionStateChange: (String, String) -> Void
     private let onSignalingStateChange: (String, String) -> Void
     private let onRenegotiationNeeded: (String) -> Void
+    private let logger: SerenadaLogger?
     private let rendererAttachmentQueue: DispatchQueue
 
     private var peerConnection: RTCPeerConnection?
@@ -161,7 +162,8 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
         onConnectionStateChange: @escaping (String, String) -> Void,
         onIceConnectionStateChange: @escaping (String, String) -> Void,
         onSignalingStateChange: @escaping (String, String) -> Void,
-        onRenegotiationNeeded: @escaping (String) -> Void
+        onRenegotiationNeeded: @escaping (String) -> Void,
+        logger: SerenadaLogger? = nil
     ) {
         self.remoteCid = remoteCid
         self.factory = factory
@@ -174,6 +176,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
         self.onIceConnectionStateChange = onIceConnectionStateChange
         self.onSignalingStateChange = onSignalingStateChange
         self.onRenegotiationNeeded = onRenegotiationNeeded
+        self.logger = logger
         self.rendererAttachmentQueue = DispatchQueue(
             label: "serenada.ios.webrtc.slot-renderer-\(remoteCid)",
             qos: .userInitiated
@@ -197,7 +200,9 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
                 RTCIceServer(urlStrings: $0.urls, username: $0.username, credential: $0.credential)
             }
             config.sdpSemantics = .unifiedPlan
-            _ = peerConnection.setConfiguration(config)
+            if !peerConnection.setConfiguration(config) {
+                logger?.log(.warning, tag: "PeerConnection", "[\(remoteCid)] Failed to apply refreshed ICE servers")
+            }
             return
         }
         _ = ensurePeerConnection()

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -188,6 +188,18 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
     public func setIceServers(_ servers: [IceServerConfig]) {
 #if canImport(WebRTC)
         iceServers = servers
+        if let peerConnection {
+            // Apply refreshed credentials to the live connection so a later
+            // ICE restart gathers relay candidates with current (not expired)
+            // TURN credentials.
+            let config = RTCConfiguration()
+            config.iceServers = servers.map {
+                RTCIceServer(urlStrings: $0.urls, username: $0.username, credential: $0.credential)
+            }
+            config.sdpSemantics = .unifiedPlan
+            _ = peerConnection.setConfiguration(config)
+            return
+        }
         _ = ensurePeerConnection()
 #endif
     }

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -939,13 +939,19 @@ final class PeerNegotiationEngine {
 
         guard slot.iceRestartTask == nil else { return }
 
+        // Inside the cooldown window, defer to its expiry instead of dropping:
+        // ICE state changes are edge-triggered, so a dropped restart for a
+        // connection parked in failed would never be retried.
         let now = Double(clock.nowMs())
-        guard slot.lastIceRestartAt <= 0 || now - slot.lastIceRestartAt >= Double(WebRtcResilience.iceRestartCooldownMs) else { return }
+        let cooldownRemainingMs = slot.lastIceRestartAt > 0
+            ? slot.lastIceRestartAt + Double(WebRtcResilience.iceRestartCooldownMs) - now
+            : 0
+        let effectiveDelayMs = max(Double(delayMs), cooldownRemainingMs)
 
         slot.setIceRestartTask(Task { [weak self] in
             guard let clock = self?.clock else { return }
-            if delayMs > 0 {
-                try? await clock.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
+            if effectiveDelayMs > 0 {
+                try? await clock.sleep(nanoseconds: UInt64(effectiveDelayMs) * 1_000_000)
             }
             guard !Task.isCancelled else { return }
             await MainActor.run {

--- a/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerNegotiationEngine.swift
@@ -941,10 +941,12 @@ final class PeerNegotiationEngine {
 
         // Inside the cooldown window, defer to its expiry instead of dropping:
         // ICE state changes are edge-triggered, so a dropped restart for a
-        // connection parked in failed would never be retried.
+        // connection parked in failed would never be retried. Clamp to one
+        // cooldown: nowMs() is wall-clock, so a backwards step would otherwise
+        // park the restart for the full skew.
         let now = Double(clock.nowMs())
         let cooldownRemainingMs = slot.lastIceRestartAt > 0
-            ? slot.lastIceRestartAt + Double(WebRtcResilience.iceRestartCooldownMs) - now
+            ? min(Double(WebRtcResilience.iceRestartCooldownMs), max(0, slot.lastIceRestartAt + Double(WebRtcResilience.iceRestartCooldownMs) - now))
             : 0
         let effectiveDelayMs = max(Double(delayMs), cooldownRemainingMs)
 

--- a/client-ios/SerenadaCore/Sources/Call/SerenadaAudioCoordinator.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SerenadaAudioCoordinator.swift
@@ -135,6 +135,12 @@ public enum AudioCoordinatorEvent: Sendable {
     case externalAudioStarted
     /// Host-owned external audio ended and normal call audio may resume.
     case externalAudioEnded
+    /// The host re-activated the call audio session after a same-app audio owner (for example a
+    /// PTT framework transmit) held and released it. Same-app session takeovers post no
+    /// `AVAudioSession.interruptionNotification`, so WebRTC's internal interruption recovery never
+    /// runs; on this event the SDK restarts its audio unit so capture and playback resume, in
+    /// addition to the ``externalAudioEnded`` policy reset.
+    case audioSessionRestarted
     /// Another audio owner requested playback ducking without interrupting local capture.
     case playbackDuckingStarted
     /// Playback ducking is no longer needed.

--- a/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
@@ -6,6 +6,9 @@ protocol SessionMediaEngine: AnyObject {
     func startLocalMedia(preferVideo: Bool)
     func release()
     func toggleAudio(_ enabled: Bool)
+    /// Restart the audio unit after the host re-activated the audio session that a same-app owner
+    /// (no interruption notification) held and released. See ``AudioCoordinatorEvent/audioSessionRestarted``.
+    func restartAudioUnit()
     @discardableResult func toggleVideo(_ enabled: Bool) -> Bool
     func flipCamera()
     func setHdVideoExperimentalEnabled(_ enabled: Bool)

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -351,7 +351,8 @@ internal final class WebRtcEngine: SessionMediaEngine {
             onConnectionStateChange: onConnectionStateChange,
             onIceConnectionStateChange: onIceConnectionStateChange,
             onSignalingStateChange: onSignalingStateChange,
-            onRenegotiationNeeded: onRenegotiationNeeded
+            onRenegotiationNeeded: onRenegotiationNeeded,
+            logger: logger
         )
         peerSlots.append(slot)
         return slot

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -372,6 +372,21 @@ internal final class WebRtcEngine: SessionMediaEngine {
 #endif
     }
 
+    /// Restarts the audio unit by bouncing `RTCAudioSession.isAudioEnabled`, mirroring the
+    /// media-services-reset recovery in `DefaultAudioCoordinator`. Needed after a same-app audio
+    /// owner held and released the session: that takeover posts no interruption notification, so
+    /// WebRTC never restarts the unit on its own. No-op when local media is not running.
+    public func restartAudioUnit() {
+#if canImport(WebRTC)
+        guard localAudioTrack != nil else { return }
+        let audioSession = RTCAudioSession.sharedInstance()
+        audioSession.lockForConfiguration()
+        defer { audioSession.unlockForConfiguration() }
+        audioSession.isAudioEnabled = false
+        audioSession.isAudioEnabled = true
+#endif
+    }
+
     @discardableResult
     public func toggleVideo(_ enabled: Bool) -> Bool {
 #if canImport(WebRTC)

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -607,6 +607,17 @@ public final class SerenadaSession: ObservableObject {
                 playbackDuckingActive = false
                 peerSlots.values.forEach { $0.duckPlayback(ducked: false) }
             }
+        case .audioSessionRestarted:
+            // External-audio policy reset (as in .externalAudioEnded), plus an audio-unit restart:
+            // a same-app owner held and released the session with no interruption notification, so
+            // WebRTC will not recover capture/playback on its own.
+            self.externalAudioMuted = false
+            self.updateEffectiveMicState()
+            if playbackDuckingActive {
+                playbackDuckingActive = false
+                peerSlots.values.forEach { $0.duckPlayback(ducked: false) }
+            }
+            webRtcEngine.restartAudioUnit()
         case .playbackDuckingStarted:
             if config.audioIntent.duckDuringExternalAudio {
                 playbackDuckingActive = true

--- a/client-ios/SerenadaCore/Sources/Utils/Backoff.swift
+++ b/client-ios/SerenadaCore/Sources/Utils/Backoff.swift
@@ -3,7 +3,11 @@ import Foundation
 enum Backoff {
     static func reconnectDelayMs(attempt: Int) -> Int {
         let normalized = max(1, attempt)
-        let value = Int(Double(WebRtcResilience.reconnectBackoffBaseMs) * pow(2.0, Double(normalized - 1)))
+        // Clamp the exponent (matching Android's shift clamp) so the
+        // Double-to-Int conversion can never trap on overflow after many
+        // consecutive reconnect failures; 2^13 x base is far beyond the cap.
+        let exponent = min(normalized - 1, 13)
+        let value = Int(Double(WebRtcResilience.reconnectBackoffBaseMs) * pow(2.0, Double(exponent)))
         return min(value, WebRtcResilience.reconnectBackoffCapMs)
     }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -10,6 +10,7 @@ final class FakeMediaEngine: SessionMediaEngine {
     private(set) var startLocalMediaCalls: [Bool] = []
     private(set) var releaseCalls = 0
     private(set) var toggleAudioCalls: [Bool] = []
+    private(set) var restartAudioUnitCalls = 0
     private(set) var toggleVideoCalls: [Bool] = []
     private(set) var iceServersSet = false
     private(set) var createdSlotCids: [String] = []
@@ -33,6 +34,10 @@ final class FakeMediaEngine: SessionMediaEngine {
 
     func toggleAudio(_ enabled: Bool) {
         toggleAudioCalls.append(enabled)
+    }
+
+    func restartAudioUnit() {
+        restartAudioUnitCalls += 1
     }
 
     @discardableResult

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
@@ -53,6 +53,10 @@ private final class RetainedStreamAudioCoordinator: @unchecked Sendable, Serenad
     func deactivateCallSession() async {}
     func applyRouting(_ device: AudioDevice) async throws {}
     func setMicMuted(_ muted: Bool) async throws {}
+
+    func emit(_ event: AudioCoordinatorEvent) {
+        eventsContinuation?.yield(event)
+    }
 }
 
 @MainActor
@@ -134,6 +138,39 @@ final class SerenadaSessionTests: XCTestCase {
 
         await waitUntil { !media.startLocalMediaCalls.isEmpty }
         XCTAssertEqual(media.startLocalMediaCalls.first, false)
+        session.cancelJoin()
+    }
+
+    func testAudioSessionRestartedRestartsAudioUnitAndClearsExternalMute() async {
+        let provider = FakeSignalingProvider()
+        let media = FakeMediaEngine()
+        let coordinator = RetainedStreamAudioCoordinator()
+        let session = SerenadaSession(
+            roomId: "provider-room",
+            config: SerenadaConfig(
+                signalingProvider: provider,
+                audioCoordinator: coordinator
+            ),
+            initialSignalingProvider: provider,
+            mediaEngine: media
+        )
+
+        await yieldToMainActor()
+        if session.state.phase == .awaitingPermissions {
+            session.resumeJoin()
+            await yieldToMainActor()
+        }
+        await waitUntil { !media.startLocalMediaCalls.isEmpty }
+
+        coordinator.emit(.externalAudioStarted)
+        await waitUntil { session.isMicMutedByExternalAudio }
+        XCTAssertTrue(session.isMicMutedByExternalAudio, "externalAudioStarted should mute the WebRTC mic")
+
+        coordinator.emit(.audioSessionRestarted)
+        await waitUntil { media.restartAudioUnitCalls == 1 }
+        XCTAssertEqual(media.restartAudioUnitCalls, 1, "audioSessionRestarted must restart the audio unit (no interruption notification fires for a same-app takeover)")
+        XCTAssertFalse(session.isMicMutedByExternalAudio, "audioSessionRestarted should clear the external-audio mute")
+
         session.cancelJoin()
     }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionNegotiationTests.swift
@@ -330,6 +330,42 @@ final class SessionNegotiationTests: XCTestCase {
         XCTAssertTrue(offersAfter > offersBefore || hasTask || hasPending, "FAILED should trigger ICE restart")
     }
 
+    func testDeferredIceRestartCooldownCappedWhenClockMovesBackwards() async throws {
+        await harness.advanceToInCallWithTurn(
+            localCid: "local",
+            remoteCid: "remote",
+            localJoinedAt: 1,
+            remoteJoinedAt: 2
+        )
+
+        let fakeSlot = harness.fakeMedia.fakeSlots["remote"]
+        XCTAssertNotNil(fakeSlot)
+        // A backwards wall-clock step after a previous restart leaves
+        // lastIceRestartAt far in the future relative to nowMs().
+        fakeSlot?.recordIceRestart(nowMs: harness.fakeClock.nowMs() + Int64(WebRtcResilience.iceRestartCooldownMs) * 10)
+        let offersBefore = fakeSlot?.createOfferCalls ?? 0
+
+        fakeSlot?.simulateConnectionStateChange(.failed)
+        await waitForIceRestartTask(fakeSlot)
+        XCTAssertNotNil(fakeSlot?.iceRestartTask, "ICE restart should be deferred, not dropped")
+
+        await harness.fakeClock.advance(byMs: Int64(WebRtcResilience.iceRestartCooldownMs))
+        await harness.yieldToMainActor()
+
+        // triggerIceRestart clears the task when the deferred sleep completes;
+        // an unclamped deferral would still be parked here (10x the cooldown away).
+        XCTAssertNil(
+            fakeSlot?.iceRestartTask,
+            "Deferred restart must fire within one cooldown despite clock regression"
+        )
+        XCTAssertGreaterThan(
+            fakeSlot?.createOfferCalls ?? 0,
+            offersBefore,
+            "Restart offer should be sent once the clamped cooldown elapses"
+        )
+        XCTAssertEqual(fakeSlot?.createOfferIceRestartFlags.last, true)
+    }
+
     func testConnectedClearsIceRestart() async throws {
         await harness.advanceToInCallWithTurn(
             localCid: "local",

--- a/client/packages/core/src/SerenadaServerProvider.ts
+++ b/client/packages/core/src/SerenadaServerProvider.ts
@@ -11,7 +11,7 @@ import {
 } from './signaling/payloads.js';
 import type { RoomParticipant, SignalingMessage } from './signaling/types.js';
 import type { TransportKind } from './signaling/transports/types.js';
-import { TURN_FETCH_TIMEOUT_MS } from './constants.js';
+import { ICE_FETCH_RETRY_DELAYS_MS, TURN_FETCH_TIMEOUT_MS } from './constants.js';
 import { formatError } from './formatError.js';
 import { buildApiUrl, resolveServerUrls } from './serverUrls.js';
 
@@ -40,6 +40,7 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
     private previousParticipants = new Map<string, SignalingProviderParticipant>();
     private currentHostPeerId: string | null = null;
     private disconnected = false;
+    private iceRefreshGeneration = 0;
 
     constructor(config: SerenadaServerProviderConfig) {
         super();
@@ -313,16 +314,32 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
     }
 
     private async refreshIceServers(): Promise<void> {
-        try {
-            const servers = await this.getIceServers();
-            this.emit('iceServersChanged', servers);
-        } catch (error) {
-            this.logger?.log('warning', 'Signaling', `Failed to refresh ICE servers: ${formatError(error)}`);
-            this.emit('error', {
-                code: 'TURN_REFRESH_FAILED',
-                message: formatError(error),
-            });
+        const generation = this.iceRefreshGeneration + 1;
+        this.iceRefreshGeneration = generation;
+        let lastError: unknown = null;
+
+        for (const delayMs of ICE_FETCH_RETRY_DELAYS_MS) {
+            if (delayMs > 0) {
+                await wait(delayMs);
+            }
+            if (this.disconnected || generation !== this.iceRefreshGeneration) {
+                return;
+            }
+            try {
+                const servers = await this.getIceServers();
+                if (this.disconnected || generation !== this.iceRefreshGeneration) {
+                    return;
+                }
+                this.emit('iceServersChanged', servers);
+                return;
+            } catch (error) {
+                lastError = error;
+            }
         }
+
+        // Non-fatal: the call keeps running on the existing credentials,
+        // and the next turn-refreshed message retries with a fresh token.
+        this.logger?.log('warning', 'Signaling', `Failed to refresh ICE servers after retries: ${formatError(lastError)}`);
     }
 }
 
@@ -336,6 +353,12 @@ function mapParticipant(participant: RoomParticipant): SignalingProviderParticip
         videoEnabled: participant.videoEnabled,
         connectionStatus: participant.connectionStatus,
     };
+}
+
+function wait(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+        globalThis.setTimeout(resolve, delayMs);
+    });
 }
 
 function toParticipantMap(participants: SignalingProviderParticipant[]): Map<string, SignalingProviderParticipant> {

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -73,6 +73,10 @@ function mapErrorCode(serverCode: string): CallErrorCode {
             return 'roomEnded';
         case 'INVALID_RECONNECT_TOKEN':
             return 'sessionExpired';
+        case 'PERMISSION_DENIED':
+            return 'permissionDenied';
+        case 'MEDIA_UNSUPPORTED':
+            return 'webrtcUnavailable';
         case 'CONNECTION_FAILED':
             return 'connectionFailed';
         case 'ICE_SERVER_FETCH_FAILED':
@@ -81,7 +85,6 @@ function mapErrorCode(serverCode: string): CallErrorCode {
         case 'UNSUPPORTED_VERSION':
         case 'INVALID_ROOM_ID':
         case 'SERVER_NOT_CONFIGURED':
-        case 'TURN_REFRESH_FAILED':
         case 'NOT_IN_ROOM':
         case 'NOT_HOST':
             return 'serverError';
@@ -448,9 +451,14 @@ export class SerenadaSession implements SerenadaSessionHandle {
         }
         this.permissionCheckDone = true;
         const stream = await this.media.startLocalMedia();
+        if (this.isInactive) {
+            return;
+        }
         if (stream) {
             this.broadcastLocalMediaState();
             this.rebuildState();
+        } else {
+            this.failOnLocalMediaError();
         }
     }
 
@@ -754,6 +762,11 @@ export class SerenadaSession implements SerenadaSessionHandle {
 
     private readonly handleError = (event: SignalingErrorEvent): void => {
         if (this.isInactive) {
+            return;
+        }
+        if (event.code === 'TURN_REFRESH_FAILED') {
+            // Non-fatal: media keeps flowing on the existing credentials until expiry.
+            this.config.logger?.log('warning', 'Session', `TURN refresh failed: ${event.message}`);
             return;
         }
         this.failWithError(event);
@@ -1404,8 +1417,32 @@ export class SerenadaSession implements SerenadaSessionHandle {
 
         this.permissionCheckDone = true;
         this.permissionCheckInFlight = false;
-        await this.media.startLocalMedia();
+        const stream = await this.media.startLocalMedia();
+        if (this.isInactive) {
+            return;
+        }
+        if (!stream) {
+            this.failOnLocalMediaError();
+            return;
+        }
         this.rebuildState();
+    }
+
+    /**
+     * Surface a failed local-media acquisition as a terminal error instead of
+     * silently joining without media (or hanging in `awaitingPermissions`).
+     * A null stream without a recorded error means the attempt was superseded
+     * (e.g. concurrent stop) — not a failure.
+     */
+    private failOnLocalMediaError(): void {
+        const mediaError = this.media.lastLocalMediaError;
+        if (!mediaError) {
+            return;
+        }
+        const code = mediaError.name === 'NotAllowedError' || mediaError.name === 'PermissionDeniedError' || mediaError.name === 'SecurityError'
+            ? 'PERMISSION_DENIED'
+            : (mediaError.name === 'NotSupportedError' ? 'MEDIA_UNSUPPORTED' : 'LOCAL_MEDIA_FAILED');
+        this.failWithError({ code, message: mediaError.message });
     }
 
     private ensureStatsCollection(): void {

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -933,7 +933,10 @@ export class MediaEngine {
         // Inside the cooldown window, defer to its expiry instead of dropping:
         // ICE state changes are edge-triggered, so a dropped restart for a
         // connection parked in `failed` would never be retried.
-        const cooldownRemainingMs = peer.lastIceRestartAt + ICE_RESTART_COOLDOWN_MS - Date.now();
+        const cooldownRemainingMs = Math.min(
+            ICE_RESTART_COOLDOWN_MS,
+            Math.max(0, peer.lastIceRestartAt + ICE_RESTART_COOLDOWN_MS - Date.now()),
+        );
         peer.iceRestartTimer = window.setTimeout(() => {
             peer.iceRestartTimer = null;
             void this.triggerIceRestart(remoteCid, reason);

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -259,6 +259,12 @@ export class MediaEngine {
         }
     }
 
+    /** Details of the last failed local-media acquisition, if any. */
+    get lastLocalMediaError(): { name: string; message: string } | null {
+        return this._lastLocalMediaError;
+    }
+    private _lastLocalMediaError: { name: string; message: string } | null = null;
+
     async startLocalMedia(): Promise<MediaStream | null> {
         if (this.localStream) return this.localStream;
         if (this.localMediaStartPromise) return this.localMediaStartPromise;
@@ -278,9 +284,11 @@ export class MediaEngine {
         this.mediaRequestId = requestId;
 
         this.requestingMedia = true;
+        this._lastLocalMediaError = null;
         try {
             if (!navigator.mediaDevices?.getUserMedia) {
                 this.requestingMedia = false;
+                this._lastLocalMediaError = { name: 'NotSupportedError', message: 'getUserMedia is not supported' };
                 return null;
             }
             const initialDevices = await this.enumerateMediaDevices();
@@ -330,6 +338,10 @@ export class MediaEngine {
             return activeStream;
         } catch (err) {
             this.logger?.log('error', 'WebRTC', `Error accessing media: ${formatError(err)}`);
+            this._lastLocalMediaError = {
+                name: err instanceof DOMException ? err.name : 'Error',
+                message: formatError(err),
+            };
             this.requestingMedia = false;
             return null;
         }
@@ -918,11 +930,14 @@ export class MediaEngine {
         if (!peer) return;
         if (!this.isSignalingConnected || !this.isParticipantActive(remoteCid)) { peer.pendingIceRestart = true; return; }
         if (peer.iceRestartTimer) return;
-        if (Date.now() - peer.lastIceRestartAt < ICE_RESTART_COOLDOWN_MS) return;
+        // Inside the cooldown window, defer to its expiry instead of dropping:
+        // ICE state changes are edge-triggered, so a dropped restart for a
+        // connection parked in `failed` would never be retried.
+        const cooldownRemainingMs = peer.lastIceRestartAt + ICE_RESTART_COOLDOWN_MS - Date.now();
         peer.iceRestartTimer = window.setTimeout(() => {
             peer.iceRestartTimer = null;
             void this.triggerIceRestart(remoteCid, reason);
-        }, delayMs);
+        }, Math.max(delayMs, cooldownRemainingMs));
     }
 
     private async triggerIceRestart(remoteCid: string, reason: string): Promise<void> {

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MediaEngine } from '../../src/media/MediaEngine.js';
-import { OFFER_TIMEOUT_MS, OUTBOUND_MEDIA_RECOVERY_COOLDOWN_MS, OUTBOUND_MEDIA_STALL_SAMPLES } from '../../src/constants.js';
+import { ICE_RESTART_COOLDOWN_MS, OFFER_TIMEOUT_MS, OUTBOUND_MEDIA_RECOVERY_COOLDOWN_MS, OUTBOUND_MEDIA_STALL_SAMPLES } from '../../src/constants.js';
 
 interface SharedNegotiationScenario {
     id: string;
@@ -1657,6 +1657,39 @@ describe('MediaEngine', () => {
         expect(iceSpy).toHaveBeenCalledWith('zeta', 'negotiation-dirty', 0);
 
         iceSpy.mockRestore();
+    });
+
+    it('caps deferred ICE restart cooldown when the wall clock moves backwards', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000_000);
+        const engine = new MediaEngine({}, () => {});
+
+        engine.updateSignalingConnected(true);
+        engine.updateRoomState({
+            hostCid: 'alpha',
+            participants: [{ cid: 'alpha' }, { cid: 'zeta' }],
+        }, 'alpha');
+
+        const internals = engine as unknown as {
+            peers: Map<string, { lastIceRestartAt: number; iceRestartTimer: number | null }>;
+            scheduleIceRestart: (cid: string, reason: string, delay: number) => void;
+            triggerIceRestart: (cid: string, reason: string) => Promise<void>;
+        };
+        const peer = internals.peers.get('zeta');
+        expect(peer).toBeDefined();
+        peer!.lastIceRestartAt = Date.now() + ICE_RESTART_COOLDOWN_MS * 10;
+        const restartSpy = vi.spyOn(internals, 'triggerIceRestart').mockResolvedValue(undefined);
+
+        internals.scheduleIceRestart('zeta', 'clock-regressed', 0);
+
+        expect(peer!.iceRestartTimer).not.toBeNull();
+        await vi.advanceTimersByTimeAsync(ICE_RESTART_COOLDOWN_MS - 1);
+        expect(restartSpy).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(restartSpy).toHaveBeenCalledWith('zeta', 'clock-regressed');
+
+        restartSpy.mockRestore();
+        engine.destroy();
     });
 
     it('scheduleDirtyPairRestart is a no-op when local should not offer', () => {


### PR DESCRIPTION
## Summary

- keep TURN refresh failures and ICE restart cooldowns from tearing down otherwise healthy calls across SDKs
- surface web media acquisition failures instead of leaving sessions stuck in permission flow
- harden Android negotiation callbacks, camera mode switching, refreshed ICE server propagation, stale offer handling, and the ANR-prone remote video state query
- update iOS peer configuration refresh and clamp reconnect backoff growth

## Root Cause

Several recovery paths treated transient refresh/restart failures as terminal or dropped recovery work when cooldowns were active. Android also posted WebRTC callbacks back to the session handler without re-checking whether delayed offer state was still current, and participant refresh synchronously called into `VideoTrack.enabled()`, which can block inside native WebRTC on the main thread.

## Impact

Calls should survive transient TURN refresh failures, ICE restart requests within cooldown are deferred instead of lost, live peer connections receive refreshed TURN credentials, and Android participant refresh no longer blocks input dispatch on the native remote video-track getter.

## Validation

- `git diff --check`
- `npm run build` in `client`
- `./gradlew :serenada-core:testDebugUnitTest --tests app.serenada.core.SessionNegotiationTest --console=plain`
- `./gradlew :serenada-core:testDebugUnitTest --tests app.serenada.core.SessionNegotiationTest --tests app.serenada.core.SnapshotCaptureTest --console=plain`
- `./gradlew :app:installDebug --console=plain`, then launched and foreground-verified `app.serenada.android/.MainActivity` on `A065`
- `xcodegen generate` and `./scripts/deploy_to_device.sh --udid 00008101-001E795E2620001E`, then process-verified `app.serenada.ios` on iPhone 12

Excluded from this PR: `docs/sdk-bug-backlog-2026-06.md`.

Co-authored by Codex (GPT-5 high)