### PR TITLE
[codex] Add iOS audio session restarted coordinator event

### DIFF
--- a/client-ios/SerenadaCore/Sources/Call/SerenadaAudioCoordinator.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SerenadaAudioCoordinator.swift
@@ -135,6 +135,12 @@ public enum AudioCoordinatorEvent: Sendable {
     case externalAudioStarted
     /// Host-owned external audio ended and normal call audio may resume.
     case externalAudioEnded
+    /// The host re-activated the call audio session after a same-app audio owner (for example a
+    /// PTT framework transmit) held and released it. Same-app session takeovers post no
+    /// `AVAudioSession.interruptionNotification`, so WebRTC's internal interruption recovery never
+    /// runs; on this event the SDK restarts its audio unit so capture and playback resume, in
+    /// addition to the ``externalAudioEnded`` policy reset.
+    case audioSessionRestarted
     /// Another audio owner requested playback ducking without interrupting local capture.
     case playbackDuckingStarted
     /// Playback ducking is no longer needed.

--- a/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SessionMediaEngine.swift
@@ -6,6 +6,9 @@ protocol SessionMediaEngine: AnyObject {
     func startLocalMedia(preferVideo: Bool)
     func release()
     func toggleAudio(_ enabled: Bool)
+    /// Restart the audio unit after the host re-activated the audio session that a same-app owner
+    /// (no interruption notification) held and released. See ``AudioCoordinatorEvent/audioSessionRestarted``.
+    func restartAudioUnit()
     @discardableResult func toggleVideo(_ enabled: Bool) -> Bool
     func flipCamera()
     func setHdVideoExperimentalEnabled(_ enabled: Bool)

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -372,6 +372,21 @@ internal final class WebRtcEngine: SessionMediaEngine {
 #endif
     }
 
+    /// Restarts the audio unit by bouncing `RTCAudioSession.isAudioEnabled`, mirroring the
+    /// media-services-reset recovery in `DefaultAudioCoordinator`. Needed after a same-app audio
+    /// owner held and released the session: that takeover posts no interruption notification, so
+    /// WebRTC never restarts the unit on its own. No-op when local media is not running.
+    public func restartAudioUnit() {
+#if canImport(WebRTC)
+        guard localAudioTrack != nil else { return }
+        let audioSession = RTCAudioSession.sharedInstance()
+        audioSession.lockForConfiguration()
+        defer { audioSession.unlockForConfiguration() }
+        audioSession.isAudioEnabled = false
+        audioSession.isAudioEnabled = true
+#endif
+    }
+
     @discardableResult
     public func toggleVideo(_ enabled: Bool) -> Bool {
 #if canImport(WebRTC)

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -607,6 +607,17 @@ public final class SerenadaSession: ObservableObject {
                 playbackDuckingActive = false
                 peerSlots.values.forEach { $0.duckPlayback(ducked: false) }
             }
+        case .audioSessionRestarted:
+            // External-audio policy reset (as in .externalAudioEnded), plus an audio-unit restart:
+            // a same-app owner held and released the session with no interruption notification, so
+            // WebRTC will not recover capture/playback on its own.
+            self.externalAudioMuted = false
+            self.updateEffectiveMicState()
+            if playbackDuckingActive {
+                playbackDuckingActive = false
+                peerSlots.values.forEach { $0.duckPlayback(ducked: false) }
+            }
+            webRtcEngine.restartAudioUnit()
         case .playbackDuckingStarted:
             if config.audioIntent.duckDuringExternalAudio {
                 playbackDuckingActive = true

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -10,6 +10,7 @@ final class FakeMediaEngine: SessionMediaEngine {
     private(set) var startLocalMediaCalls: [Bool] = []
     private(set) var releaseCalls = 0
     private(set) var toggleAudioCalls: [Bool] = []
+    private(set) var restartAudioUnitCalls = 0
     private(set) var toggleVideoCalls: [Bool] = []
     private(set) var iceServersSet = false
     private(set) var createdSlotCids: [String] = []
@@ -33,6 +34,10 @@ final class FakeMediaEngine: SessionMediaEngine {
 
     func toggleAudio(_ enabled: Bool) {
         toggleAudioCalls.append(enabled)
+    }
+
+    func restartAudioUnit() {
+        restartAudioUnitCalls += 1
     }
 
     @discardableResult

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
@@ -53,6 +53,10 @@ private final class RetainedStreamAudioCoordinator: @unchecked Sendable, Serenad
     func deactivateCallSession() async {}
     func applyRouting(_ device: AudioDevice) async throws {}
     func setMicMuted(_ muted: Bool) async throws {}
+
+    func emit(_ event: AudioCoordinatorEvent) {
+        eventsContinuation?.yield(event)
+    }
 }
 
 @MainActor
@@ -134,6 +138,39 @@ final class SerenadaSessionTests: XCTestCase {
 
         await waitUntil { !media.startLocalMediaCalls.isEmpty }
         XCTAssertEqual(media.startLocalMediaCalls.first, false)
+        session.cancelJoin()
+    }
+
+    func testAudioSessionRestartedRestartsAudioUnitAndClearsExternalMute() async {
+        let provider = FakeSignalingProvider()
+        let media = FakeMediaEngine()
+        let coordinator = RetainedStreamAudioCoordinator()
+        let session = SerenadaSession(
+            roomId: "provider-room",
+            config: SerenadaConfig(
+                signalingProvider: provider,
+                audioCoordinator: coordinator
+            ),
+            initialSignalingProvider: provider,
+            mediaEngine: media
+        )
+
+        await yieldToMainActor()
+        if session.state.phase == .awaitingPermissions {
+            session.resumeJoin()
+            await yieldToMainActor()
+        }
+        await waitUntil { !media.startLocalMediaCalls.isEmpty }
+
+        coordinator.emit(.externalAudioStarted)
+        await waitUntil { session.isMicMutedByExternalAudio }
+        XCTAssertTrue(session.isMicMutedByExternalAudio, "externalAudioStarted should mute the WebRTC mic")
+
+        coordinator.emit(.audioSessionRestarted)
+        await waitUntil { media.restartAudioUnitCalls == 1 }
+        XCTAssertEqual(media.restartAudioUnitCalls, 1, "audioSessionRestarted must restart the audio unit (no interruption notification fires for a same-app takeover)")
+        XCTAssertFalse(session.isMicMutedByExternalAudio, "audioSessionRestarted should clear the external-audio mute")
+
         session.cancelJoin()
     }
 


### PR DESCRIPTION
## Summary
- Add `AudioCoordinatorEvent.audioSessionRestarted` so custom iOS audio coordinators can report same-app audio-session takeovers that do not emit interruption notifications.
- Reset external-audio mute/ducking policy and restart the WebRTC audio unit when that event is received.
- Add iOS session coverage using the fake media engine.

## Base
Stacked on `codex/sdk-resilience-bug-sweep` at `1a33d661`, not `main`.

## Testing
- `cd client-ios && xcodegen generate && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' test`

Note: the live-room UI tests were skipped because no live-room override was supplied.