### PR TITLE
Address SDK resilience review backlog (R1-R4, R7, R10)

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaServerProvider.kt
@@ -277,6 +277,12 @@ internal class SerenadaServerProvider(
                 if (closedByClient || generation != iceRefreshGeneration) {
                     return
                 }
+                if (servers.isEmpty()) {
+                    // A degenerate refresh must not strip TURN from the live
+                    // connection; treat it as a failed attempt and retry.
+                    lastError = IllegalStateException("ICE server refresh returned no servers")
+                    continue
+                }
                 listener?.onIceServersChanged(servers)
                 return
             } catch (error: CancellationException) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerNegotiationEngine.kt
@@ -420,11 +420,18 @@ internal class PeerNegotiationEngine(
                     flushPendingRemoteIce(remoteCid, offerId, targetSlot)
                     targetSlot.createAnswer(
                         onSdp = { answerSdp ->
-                            val payload = JSONObject().apply {
-                                put("sdp", answerSdp)
-                                put("offerId", offerId)
+                            // Fires on the WebRTC signaling thread; the transport and
+                            // negotiation bookkeeping are main-thread-owned (same hop
+                            // the offer and ICE callbacks make).
+                            handler.post {
+                                if (getSlot(remoteCid) !== targetSlot) return@post
+                                if (acceptedRemoteOfferIds[remoteCid] != offerId) return@post
+                                val payload = JSONObject().apply {
+                                    put("sdp", answerSdp)
+                                    put("offerId", offerId)
+                                }
+                                sendMessage("answer", payload, remoteCid)
                             }
-                            sendMessage("answer", payload, remoteCid)
                         },
                         onComplete = { answerSuccess ->
                             handler.post {

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import app.serenada.core.call.SessionSignaling
 import app.serenada.core.call.SignalingMessage
 import app.serenada.core.fakes.FakeAPIClient
+import app.serenada.core.network.TurnCredentials
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import org.json.JSONArray
@@ -77,6 +78,7 @@ class SerenadaServerProviderTest {
         val roomEndedEvents = mutableListOf<RoomEndedEvent>()
         val errors = mutableListOf<ErrorEvent>()
         val reconnectTokenRefreshedEvents = mutableListOf<ReconnectTokenRefreshedEvent>()
+        val iceServersChangedEvents = mutableListOf<List<org.webrtc.PeerConnection.IceServer>>()
 
         override fun onConnected(info: ConnectionInfo) {
             connectionInfos += info
@@ -112,6 +114,10 @@ class SerenadaServerProviderTest {
 
         override fun onReconnectTokenRefreshed(event: ReconnectTokenRefreshedEvent) {
             reconnectTokenRefreshedEvents += event
+        }
+
+        override fun onIceServersChanged(iceServers: List<org.webrtc.PeerConnection.IceServer>) {
+            iceServersChangedEvents += iceServers
         }
     }
 
@@ -452,6 +458,113 @@ class SerenadaServerProviderTest {
 
         assertEquals(listOf("serenada.app" to "turn-token"), apiClient.fetchTurnCredentialsCalls)
         assertEquals(listOf("turn:turn.example.com:3478"), iceServers.flatMap { it.urls })
+    }
+
+    private fun deliverJoined(turnToken: String = "turn-token") {
+        signaling.receive(
+            SignalingMessage(
+                type = "joined",
+                rid = "room-1",
+                sid = null,
+                cid = "local-cid",
+                to = null,
+                payload = JSONObject().apply {
+                    put("hostCid", "local-cid")
+                    put("turnToken", turnToken)
+                    put(
+                        "participants",
+                        JSONArray().put(
+                            JSONObject().apply {
+                                put("cid", "local-cid")
+                                put("joinedAt", 1L)
+                            }
+                        )
+                    )
+                },
+            )
+        )
+    }
+
+    private fun deliverTurnRefreshed(turnToken: String) {
+        signaling.receive(
+            SignalingMessage(
+                type = "turn-refreshed",
+                rid = "room-1",
+                sid = null,
+                cid = "local-cid",
+                to = null,
+                payload = JSONObject().apply { put("turnToken", turnToken) },
+            )
+        )
+    }
+
+    @Test
+    fun `turn-refreshed fetches and emits refreshed ice servers`() {
+        deliverJoined()
+
+        deliverTurnRefreshed("fresh-token")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(listOf("serenada.app" to "fresh-token"), apiClient.fetchTurnCredentialsCalls)
+        assertEquals(1, listener.iceServersChangedEvents.size)
+        assertEquals(
+            listOf("turn:turn.example.com:3478"),
+            listener.iceServersChangedEvents.single().flatMap { it.urls },
+        )
+        assertTrue(listener.errors.isEmpty())
+    }
+
+    @Test
+    fun `failed turn refresh retries and recovers without surfacing an error event`() {
+        deliverJoined()
+        apiClient.turnCredentialsResult = Result.failure(RuntimeException("network blip"))
+
+        deliverTurnRefreshed("fresh-token")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, apiClient.fetchTurnCredentialsCalls.size)
+        assertTrue(listener.iceServersChangedEvents.isEmpty())
+
+        apiClient.turnCredentialsResult = Result.success(
+            TurnCredentials(username = "user", password = "pass", uris = listOf("turn:turn.example.com:3478"), ttl = 3600)
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(1_000L, TimeUnit.MILLISECONDS)
+
+        assertEquals(2, apiClient.fetchTurnCredentialsCalls.size)
+        assertEquals(1, listener.iceServersChangedEvents.size)
+        assertTrue("TURN refresh failures must never surface as error events", listener.errors.isEmpty())
+    }
+
+    @Test
+    fun `exhausted turn refresh retries log only - no error event, no emission`() {
+        deliverJoined()
+        apiClient.turnCredentialsResult = Result.failure(RuntimeException("still down"))
+
+        deliverTurnRefreshed("fresh-token")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(8_000L, TimeUnit.MILLISECONDS)
+
+        assertEquals(4, apiClient.fetchTurnCredentialsCalls.size)
+        assertTrue(listener.iceServersChangedEvents.isEmpty())
+        assertTrue("TURN refresh exhaustion must never surface as an error event", listener.errors.isEmpty())
+    }
+
+    @Test
+    fun `empty ice server refresh result is retried, not applied`() {
+        deliverJoined()
+        apiClient.turnCredentialsResult = Result.success(
+            TurnCredentials(username = "user", password = "pass", uris = emptyList(), ttl = 3600)
+        )
+
+        deliverTurnRefreshed("fresh-token")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertTrue("Empty server list must not be applied to the live call", listener.iceServersChangedEvents.isEmpty())
+
+        apiClient.turnCredentialsResult = Result.success(
+            TurnCredentials(username = "user", password = "pass", uris = listOf("turn:turn.example.com:3478"), ttl = 3600)
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(1_000L, TimeUnit.MILLISECONDS)
+
+        assertEquals(1, listener.iceServersChangedEvents.size)
     }
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SessionNegotiationTest.kt
@@ -91,6 +91,57 @@ class SessionNegotiationTest {
     }
 
     @Test
+    fun `stale deferred answer is not sent after the peer leaves`() {
+        factory.fakeMedia.deferNextCreatedSlotAnswerSdp = true
+        factory.advanceToInCallWithTurn(localCid = "zulu", remoteCid = "alpha", localJoinedAt = 2, remoteJoinedAt = 1)
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["alpha"]
+        assertNotNull("Slot should be created", fakeSlot)
+
+        factory.simulateOfferFromRemote("alpha")
+        assertTrue("Answer SDP should be deferred, not sent", factory.fakeProvider.sentMessages("answer").isEmpty())
+
+        factory.simulateRoomState(participants = listOf("zulu" to 2L), hostCid = "zulu")
+        fakeSlot!!.flushPendingAnswerSdp()
+        ShadowLooper.idleMainLooper()
+
+        assertTrue("Stale answer must not be sent after the peer leaves", factory.fakeProvider.sentMessages("answer").isEmpty())
+    }
+
+    @Test
+    fun `TURN_REFRESH_FAILED provider error is non-fatal`() {
+        factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
+        assertEquals(CallPhase.InCall, factory.session.state.value.phase)
+
+        factory.fakeProvider.simulateError("TURN_REFRESH_FAILED", "credential fetch failed")
+        ShadowLooper.idleMainLooper()
+
+        assertEquals("Call must survive a TURN refresh failure", CallPhase.InCall, factory.session.state.value.phase)
+
+        factory.fakeProvider.simulateError("CONNECTION_FAILED", "gone")
+        ShadowLooper.idleMainLooper()
+
+        assertTrue("Other error codes must still terminate", factory.session.state.value.phase != CallPhase.InCall)
+    }
+
+    @Test
+    fun `deferred answer for a current negotiation is sent after the async hop`() {
+        factory.fakeMedia.deferNextCreatedSlotAnswerSdp = true
+        factory.advanceToInCallWithTurn(localCid = "zulu", remoteCid = "alpha", localJoinedAt = 2, remoteJoinedAt = 1)
+
+        val fakeSlot = factory.fakeMedia.fakeSlots["alpha"]
+        assertNotNull("Slot should be created", fakeSlot)
+
+        factory.simulateOfferFromRemote("alpha")
+        assertTrue("Answer SDP should be deferred, not sent", factory.fakeProvider.sentMessages("answer").isEmpty())
+
+        fakeSlot!!.flushPendingAnswerSdp()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals("Current answer must still be sent", 1, factory.fakeProvider.sentMessages("answer").size)
+    }
+
+    @Test
     fun `stale local ICE from replaced slot is not sent`() {
         factory.advanceToInCallWithTurn(localCid = "alpha", remoteCid = "remote", localJoinedAt = 1, remoteJoinedAt = 2)
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -25,6 +25,7 @@ internal class FakeMediaEngine : SessionMediaEngine {
     val fakeSlots = mutableMapOf<String, FakePeerConnectionSlot>()
     var failNextCreatedSlotRemoteOffer = false
     var deferNextCreatedSlotOfferSdp = false
+    var deferNextCreatedSlotAnswerSdp = false
 
     private var _iceServers: List<PeerConnection.IceServer>? = null
 
@@ -77,6 +78,10 @@ internal class FakeMediaEngine : SessionMediaEngine {
         if (deferNextCreatedSlotOfferSdp) {
             slot.deferNextOfferSdp = true
             deferNextCreatedSlotOfferSdp = false
+        }
+        if (deferNextCreatedSlotAnswerSdp) {
+            slot.deferNextAnswerSdp = true
+            deferNextCreatedSlotAnswerSdp = false
         }
         fakeSlots[remoteCid] = slot
         _iceServers?.let(slot::setIceServers)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakePeerConnectionSlot.kt
@@ -51,6 +51,8 @@ internal class FakePeerConnectionSlot(
     var failNextRollback = false
     var deferNextOfferSdp = false
     private var pendingOfferSdp: (() -> Unit)? = null
+    var deferNextAnswerSdp = false
+    private var pendingAnswerSdp: (() -> Unit)? = null
 
     // Offer lifecycle
     override fun beginOffer() { isMakingOffer = true }
@@ -118,10 +120,23 @@ internal class FakePeerConnectionSlot(
             onComplete?.invoke(false)
             return
         }
-        onSdp("fake-answer-sdp")
-        signalingState = PeerConnection.SignalingState.STABLE
-        onSignalingStateChange?.invoke(remoteCid, signalingState)
-        onComplete?.invoke(true)
+        val complete: () -> Unit = {
+            onSdp("fake-answer-sdp")
+            signalingState = PeerConnection.SignalingState.STABLE
+            onSignalingStateChange?.invoke(remoteCid, signalingState)
+            onComplete?.invoke(true)
+        }
+        if (deferNextAnswerSdp) {
+            deferNextAnswerSdp = false
+            pendingAnswerSdp = complete
+        } else {
+            complete()
+        }
+    }
+
+    fun flushPendingAnswerSdp() {
+        pendingAnswerSdp?.invoke()
+        pendingAnswerSdp = null
     }
 
     override fun setRemoteDescription(type: SessionDescription.Type, sdp: String, onComplete: ((Boolean) -> Unit)?) {

--- a/client-ios/SerenadaCore/Sources/Call/TurnManager.swift
+++ b/client-ios/SerenadaCore/Sources/Call/TurnManager.swift
@@ -20,6 +20,9 @@ final class TurnManager {
     private var turnTokenExpiresAtMs: Int64?
     private var hasInitializedIceSetupForAttempt = false
     private var lastTurnTokenForAttempt: String?
+    // Bumped per fetch so a newer turn-refreshed supersedes an in-flight
+    // retry loop (mirrors the web/Android generation guard).
+    private var iceRefreshGeneration = 0
 
     /// Returns `false` to skip this refresh cycle — typically because all
     /// peers are on direct ICE paths and TURN credentials are unused.
@@ -94,45 +97,72 @@ final class TurnManager {
         turnRefreshTask = nil
     }
 
+    private enum TurnFetchOutcome {
+        case success(TurnCredentials)
+        case failed
+        case timedOut
+    }
+
     private func fetchTurnCredentials(token: String, applyDefaultOnFailure: Bool = true) {
         let roomIdAtFetchStart = getRoomId()
         let joinAttemptAtFetchStart = getJoinAttemptSerial()
-
-        enum TurnFetchOutcome {
-            case success(TurnCredentials)
-            case failed
-            case timedOut
-        }
+        iceRefreshGeneration += 1
+        let generation = iceRefreshGeneration
 
         Task {
-            let outcome = await withTaskGroup(of: TurnFetchOutcome.self) { group in
-                group.addTask { [apiClient, serverHost] in
-                    do {
-                        return .success(try await apiClient.fetchTurnCredentials(host: serverHost, token: token))
-                    } catch {
-                        return .failed
-                    }
+            // Retry over the shared delay schedule (matches web/Android):
+            // a transient blip at refresh time must not leave the call on
+            // aging credentials until the next TTL cycle.
+            for delayMs in WebRtcResilience.iceFetchRetryDelaysMs {
+                if delayMs > 0 {
+                    try? await self.clock.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
                 }
-                group.addTask { [clock] in
-                    try? await clock.sleep(nanoseconds: WebRtcResilience.turnFetchTimeoutNs)
-                    return .timedOut
+                guard self.iceRefreshGeneration == generation,
+                      self.getRoomId() == roomIdAtFetchStart,
+                      self.getJoinAttemptSerial() == joinAttemptAtFetchStart else { return }
+
+                let outcome = await self.performTurnFetch(token: token)
+
+                guard self.iceRefreshGeneration == generation,
+                      self.getRoomId() == roomIdAtFetchStart,
+                      self.getJoinAttemptSerial() == joinAttemptAtFetchStart else { return }
+
+                if case .success(let credentials) = outcome, !credentials.uris.isEmpty {
+                    self.applyTurnCredentials(credentials)
+                    return
                 }
-                let first = await group.next() ?? .failed
-                group.cancelAll()
-                return first
+                // Failed, timed out, or empty (a degenerate refresh must not
+                // strip TURN from the live call): retry on the next delay.
             }
 
-            guard self.getRoomId() == roomIdAtFetchStart else { return }
-            guard self.getJoinAttemptSerial() == joinAttemptAtFetchStart else { return }
+            // Exhausted: non-fatal — the call keeps running on the existing
+            // credentials. Clear the token latch so a re-delivered identical
+            // token is retried instead of deduped.
+            if self.lastTurnTokenForAttempt == token {
+                self.lastTurnTokenForAttempt = nil
+            }
+            if applyDefaultOnFailure {
+                self.applyDefaultIceServers()
+            }
+        }
+    }
 
-            switch outcome {
-            case .success(let credentials):
-                self.applyTurnCredentials(credentials)
-            case .timedOut, .failed:
-                if applyDefaultOnFailure {
-                    self.applyDefaultIceServers()
+    private func performTurnFetch(token: String) async -> TurnFetchOutcome {
+        await withTaskGroup(of: TurnFetchOutcome.self) { group in
+            group.addTask { [apiClient, serverHost] in
+                do {
+                    return .success(try await apiClient.fetchTurnCredentials(host: serverHost, token: token))
+                } catch {
+                    return .failed
                 }
             }
+            group.addTask { [clock] in
+                try? await clock.sleep(nanoseconds: WebRtcResilience.turnFetchTimeoutNs)
+                return .timedOut
+            }
+            let first = await group.next() ?? .failed
+            group.cancelAll()
+            return first
         }
     }
 

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -1132,6 +1132,13 @@ public final class SerenadaSession: ObservableObject {
     }
 
     fileprivate func handleProviderError(_ event: ErrorEvent) {
+        if event.code == "TURN_REFRESH_FAILED" {
+            // Non-fatal: media keeps flowing on the existing credentials until
+            // expiry. Built-in providers no longer emit this code, but custom
+            // SignalingProviders may (web and Android take the same early-out).
+            logger?.log(.warning, tag: "Session", "TURN refresh failed: \(event.message)")
+            return
+        }
         signalingMessageRouter?.processErrorEvent(event)
     }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/BackoffTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/BackoffTests.swift
@@ -10,4 +10,10 @@ final class BackoffTests: XCTestCase {
         XCTAssertEqual(Backoff.reconnectDelayMs(attempt: 5), 5000)
         XCTAssertEqual(Backoff.reconnectDelayMs(attempt: 10), 5000)
     }
+
+    func testReconnectBackoffDoesNotTrapOnHugeAttemptCounts() {
+        // Pre-clamp, pow(2, attempt - 1) * base overflowed the Double-to-Int
+        // conversion and trapped after enough consecutive reconnect failures.
+        XCTAssertEqual(Backoff.reconnectDelayMs(attempt: 10_000), WebRtcResilience.reconnectBackoffCapMs)
+    }
 }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
@@ -49,6 +49,20 @@ final class SerenadaServerProviderTests: XCTestCase {
         func signalingProviderDidRefreshReconnectToken(_ event: ReconnectTokenRefreshedEvent) {
             reconnectTokenRefreshedEvents.append(event)
         }
+
+        var iceServersChangedEvents: [[IceServerConfig]] = []
+
+        func signalingProviderDidChangeIceServers(_ iceServers: [IceServerConfig]) {
+            iceServersChangedEvents.append(iceServers)
+        }
+
+        /// Ice-server change events that actually carry TURN credentials
+        /// (TurnManager's first ensure also emits a default STUN apply).
+        var turnServerEvents: [[IceServerConfig]] {
+            iceServersChangedEvents.filter { servers in
+                servers.contains { $0.urls.contains { $0.hasPrefix("turn") } }
+            }
+        }
     }
 
     private var signaling: FakeSessionSignaling!
@@ -298,6 +312,124 @@ final class SerenadaServerProviderTests: XCTestCase {
         XCTAssertEqual(apiClient.fetchTurnCredentialsCalls.first?.token, "turn-token")
         XCTAssertEqual(iceServers.map(\.urls), [["turn:turn-a.example.com:3478"], ["turns:turn-b.example.com:5349"]])
         XCTAssertEqual(delegate.joinedEvents.last?.peerId, "local-cid")
+    }
+
+    /// Waits until exactly one sleep is parked on the fake clock and the count
+    /// holds across several main-actor yields. The transient single sleep
+    /// (the about-to-be-cancelled fetch-timeout) is drained by the yields, so
+    /// a stable count of one means the retry delay is parked and its deadline
+    /// is anchored at the current fake time.
+    private func waitForStableRetrySleep() async {
+        for _ in 0..<32 {
+            await waitUntil { self.fakeClock.pendingSleepCount == 1 }
+            var stable = true
+            for _ in 0..<8 {
+                await Task.yield()
+                if fakeClock.pendingSleepCount != 1 {
+                    stable = false
+                    break
+                }
+            }
+            if stable {
+                return
+            }
+        }
+        XCTFail("Retry sleep never stabilized on the fake clock")
+    }
+
+    private func settle(yields: Int = 16) async {
+        for _ in 0..<yields {
+            await Task.yield()
+        }
+    }
+
+    private func deliverTurnRefreshed(token: String) {
+        signaling.simulateMessage(
+            SignalingMessage(
+                type: "turn-refreshed",
+                rid: "room-1",
+                cid: "local-cid",
+                payload: .object(["turnToken": .string(token)])
+            )
+        )
+    }
+
+    func testTurnRefreshRetriesAfterTransientFailureWithoutErrorEvent() async throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        apiClient.turnCredentialsResult = .failure(URLError(.networkConnectionLost))
+
+        deliverTurnRefreshed(token: "fresh-token")
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 1 }
+        XCTAssertTrue(delegate.turnServerEvents.isEmpty)
+
+        apiClient.turnCredentialsResult = .success(
+            TurnCredentials(username: "user", password: "pass", uris: ["turn:turn.example.com:3478"], ttl: 3600)
+        )
+        // Wait for the retry delay to be parked on the fake clock before advancing.
+        await waitForStableRetrySleep()
+        await fakeClock.advance(byMs: 1_000)
+        await waitUntil { self.delegate.turnServerEvents.count == 1 }
+
+        XCTAssertEqual(apiClient.fetchTurnCredentialsCalls.count, 2)
+        XCTAssertEqual(delegate.turnServerEvents.count, 1)
+        XCTAssertTrue(delegate.errorEvents.isEmpty, "TURN refresh failures must never surface as error events")
+    }
+
+    func testExhaustedTurnRefreshAllowsTheSameTokenToRetry() async throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        apiClient.turnCredentialsResult = .failure(URLError(.networkConnectionLost))
+
+        deliverTurnRefreshed(token: "fresh-token")
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 1 }
+        await waitForStableRetrySleep()
+        await fakeClock.advance(byMs: 1_000)
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 2 }
+        await waitForStableRetrySleep()
+        await fakeClock.advance(byMs: 2_000)
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 3 }
+        await waitForStableRetrySleep()
+        await fakeClock.advance(byMs: 4_000)
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 4 }
+        // Let the exhausted loop clear the token latch before re-delivering.
+        await settle()
+
+        XCTAssertEqual(apiClient.fetchTurnCredentialsCalls.count, 4)
+        XCTAssertTrue(delegate.turnServerEvents.isEmpty)
+        XCTAssertTrue(delegate.errorEvents.isEmpty)
+
+        // The server re-sends the same token (it has no fresher one until the
+        // TTL rolls). Exhaustion must clear the dedupe latch so this retries.
+        apiClient.turnCredentialsResult = .success(
+            TurnCredentials(username: "user", password: "pass", uris: ["turn:turn.example.com:3478"], ttl: 3600)
+        )
+        deliverTurnRefreshed(token: "fresh-token")
+        await waitUntil { self.delegate.turnServerEvents.count == 1 }
+
+        XCTAssertEqual(apiClient.fetchTurnCredentialsCalls.count, 5)
+        XCTAssertEqual(delegate.turnServerEvents.count, 1)
+    }
+
+    func testEmptyTurnCredentialRefreshIsRetriedNotApplied() async throws {
+        provider.joinRoom("room-1", options: JoinOptions(maxParticipants: 4))
+        apiClient.turnCredentialsResult = .success(
+            TurnCredentials(username: "user", password: "pass", uris: [], ttl: 3600)
+        )
+
+        deliverTurnRefreshed(token: "fresh-token")
+        await waitUntil { self.apiClient.fetchTurnCredentialsCalls.count == 1 }
+        XCTAssertTrue(
+            delegate.turnServerEvents.isEmpty,
+            "An empty credential list must not strip TURN from the live call"
+        )
+
+        apiClient.turnCredentialsResult = .success(
+            TurnCredentials(username: "user", password: "pass", uris: ["turn:turn.example.com:3478"], ttl: 3600)
+        )
+        await waitForStableRetrySleep()
+        await fakeClock.advance(byMs: 1_000)
+        await waitUntil { self.delegate.turnServerEvents.count == 1 }
+
+        XCTAssertEqual(delegate.turnServerEvents.count, 1)
     }
 
     func testRoomStateEmitsParticipantDiffsAndRoomEndedUsesPayloadFields() {

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionOrchestrationTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SessionOrchestrationTests.swift
@@ -134,6 +134,33 @@ final class SessionOrchestrationTests: XCTestCase {
         XCTAssertGreaterThan(harness.fakeProvider.disconnectCalls, 0, "Provider should be disconnected on error")
     }
 
+    func testTurnRefreshFailedErrorIsNonFatal() async {
+        await harness.advancePastPermissions()
+        harness.openSignaling()
+        harness.simulateJoinedResponse(
+            cid: "my-cid",
+            participants: [
+                (cid: "my-cid", joinedAt: 1),
+                (cid: "remote-cid", joinedAt: 2)
+            ],
+            hostCid: "my-cid"
+        )
+        await harness.yieldToMainActor()
+        XCTAssertEqual(harness.session.state.phase, .inCall)
+
+        // Built-in providers no longer emit this code, but custom
+        // SignalingProviders may; web and Android already survive it.
+        harness.simulateError(code: "TURN_REFRESH_FAILED", message: "credential fetch failed")
+        await harness.yieldToMainActor()
+
+        XCTAssertEqual(harness.session.state.phase, .inCall, "Call must survive a TURN refresh failure")
+        XCTAssertNil(harness.session.state.error)
+
+        harness.simulateError(code: "ROOM_CAPACITY_UNSUPPORTED", message: "boom")
+        await harness.yieldToMainActor()
+        XCTAssertEqual(harness.session.state.phase, .error, "Other error codes must still terminate")
+    }
+
     // MARK: - Test 5: Room State Update
 
     func testRoomStateUpdate() async {

--- a/client/packages/core/src/SerenadaServerProvider.ts
+++ b/client/packages/core/src/SerenadaServerProvider.ts
@@ -330,6 +330,12 @@ export class SerenadaServerProvider extends SignalingProviderEmitter {
                 if (this.disconnected || generation !== this.iceRefreshGeneration) {
                     return;
                 }
+                if (servers.length === 0) {
+                    // A degenerate refresh must not strip TURN from the live
+                    // connection; treat it as a failed attempt and retry.
+                    lastError = new Error('ICE server refresh returned no servers');
+                    continue;
+                }
                 this.emit('iceServersChanged', servers);
                 return;
             } catch (error) {

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -77,6 +77,8 @@ function mapErrorCode(serverCode: string): CallErrorCode {
             return 'permissionDenied';
         case 'MEDIA_UNSUPPORTED':
             return 'webrtcUnavailable';
+        case 'LOCAL_MEDIA_FAILED':
+            return 'mediaUnavailable';
         case 'CONNECTION_FAILED':
             return 'connectionFailed';
         case 'ICE_SERVER_FETCH_FAILED':

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -92,6 +92,7 @@ export type CallErrorCode =
     | 'permissionDenied'
     | 'serverError'
     | 'webrtcUnavailable'
+    | 'mediaUnavailable'
     | 'unknown';
 
 /** Error with a machine-readable code and human-readable message. */

--- a/client/packages/core/test/SerenadaServerProvider.test.ts
+++ b/client/packages/core/test/SerenadaServerProvider.test.ts
@@ -259,6 +259,136 @@ describe('SerenadaServerProvider', () => {
         });
     });
 
+    it('retries a failed mid-call ICE refresh and emits after a later success', async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchMock = vi.fn()
+                .mockRejectedValueOnce(new Error('network blip'))
+                .mockResolvedValue({
+                    ok: true,
+                    json: async () => ({
+                        username: 'turn-user',
+                        password: 'turn-pass',
+                        uris: ['turn:turn.example.com:3478'],
+                    }),
+                });
+            vi.stubGlobal('fetch', fetchMock);
+
+            const provider = new SerenadaServerProvider({ serverHost: 'serenada.app' });
+            const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;
+            const iceServersChanged = vi.fn();
+            const errors = vi.fn();
+            provider.on('iceServersChanged', iceServersChanged);
+            provider.on('error', errors);
+
+            engine.emitMessage({ v: 1, type: 'turn-refreshed', rid: 'room-1', payload: { turnToken: 'turn-token' } });
+
+            await vi.advanceTimersByTimeAsync(0);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(iceServersChanged).not.toHaveBeenCalled();
+
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(iceServersChanged).toHaveBeenCalledTimes(1);
+            expect(errors).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('exhausted ICE refresh retries log instead of emitting an error event', async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchMock = vi.fn().mockRejectedValue(new Error('still down'));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const provider = new SerenadaServerProvider({ serverHost: 'serenada.app' });
+            const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;
+            const iceServersChanged = vi.fn();
+            const errors = vi.fn();
+            provider.on('iceServersChanged', iceServersChanged);
+            provider.on('error', errors);
+
+            engine.emitMessage({ v: 1, type: 'turn-refreshed', rid: 'room-1', payload: { turnToken: 'turn-token' } });
+
+            await vi.advanceTimersByTimeAsync(0);
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.advanceTimersByTimeAsync(2000);
+            await vi.advanceTimersByTimeAsync(4000);
+            await vi.advanceTimersByTimeAsync(10_000);
+
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+            expect(iceServersChanged).not.toHaveBeenCalled();
+            expect(errors).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('a newer turn-refreshed supersedes an in-flight ICE refresh retry loop', async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchMock = vi.fn()
+                .mockRejectedValueOnce(new Error('blip for token-a'))
+                .mockResolvedValue({
+                    ok: true,
+                    json: async () => ({
+                        username: 'turn-user',
+                        password: 'turn-pass',
+                        uris: ['turn:turn.example.com:3478'],
+                    }),
+                });
+            vi.stubGlobal('fetch', fetchMock);
+
+            const provider = new SerenadaServerProvider({ serverHost: 'serenada.app' });
+            const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;
+            const iceServersChanged = vi.fn();
+            provider.on('iceServersChanged', iceServersChanged);
+
+            engine.emitMessage({ v: 1, type: 'turn-refreshed', rid: 'room-1', payload: { turnToken: 'token-a' } });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            // Second refresh arrives while the first loop waits out its retry
+            // delay; the first loop must yield to the newer generation.
+            engine.emitMessage({ v: 1, type: 'turn-refreshed', rid: 'room-1', payload: { turnToken: 'token-b' } });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(iceServersChanged).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(10_000);
+            // The superseded loop must not have fetched again after its delay.
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(iceServersChanged).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('disconnect during an ICE refresh retry stops the loop', async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchMock = vi.fn().mockRejectedValue(new Error('blip'));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const provider = new SerenadaServerProvider({ serverHost: 'serenada.app' });
+            const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;
+            const iceServersChanged = vi.fn();
+            provider.on('iceServersChanged', iceServersChanged);
+
+            engine.emitMessage({ v: 1, type: 'turn-refreshed', rid: 'room-1', payload: { turnToken: 'turn-token' } });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            provider.disconnect();
+            await vi.advanceTimersByTimeAsync(10_000);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(iceServersChanged).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('omits roomEnded.by when neither payload nor room state provide an owner', () => {
         const provider = new SerenadaServerProvider({ serverHost: 'serenada.app' });
         const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -315,6 +315,90 @@ describe('SerenadaSession', () => {
             restore();
         });
 
+        it('resumeJoin surfaces a permission-denied media failure as terminal permissionDenied', async () => {
+            const restore = stubPermissionsPrompt();
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(harness.state.phase).toBe('awaitingPermissions');
+
+            harness.media.startLocalMediaResult = null;
+            harness.media.lastLocalMediaError = { name: 'NotAllowedError', message: 'denied' };
+            await harness.session.resumeJoin();
+
+            const sigState = harness.state.signalingState;
+            expect(sigState.kind).toBe('failed');
+            if (sigState.kind === 'failed') {
+                expect(sigState.reason).toBe('permissionDenied');
+            }
+            restore();
+        });
+
+        it('resumeJoin maps unsupported media to webrtcUnavailable and other failures to mediaUnavailable', async () => {
+            const restore = stubPermissionsPrompt();
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+
+            harness.media.startLocalMediaResult = null;
+            harness.media.lastLocalMediaError = { name: 'NotSupportedError', message: 'no gUM' };
+            await harness.session.resumeJoin();
+            let sigState = harness.state.signalingState;
+            expect(sigState.kind).toBe('failed');
+            if (sigState.kind === 'failed') {
+                expect(sigState.reason).toBe('webrtcUnavailable');
+            }
+            restore();
+
+            // NotReadableError (camera held by another app) must not surface
+            // as 'unknown' — it maps through LOCAL_MEDIA_FAILED to
+            // mediaUnavailable.
+            const restore2 = stubPermissionsPrompt();
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+
+            harness.media.startLocalMediaResult = null;
+            harness.media.lastLocalMediaError = { name: 'NotReadableError', message: 'camera busy' };
+            await harness.session.resumeJoin();
+            sigState = harness.state.signalingState;
+            expect(sigState.kind).toBe('failed');
+            if (sigState.kind === 'failed') {
+                expect(sigState.reason).toBe('mediaUnavailable');
+            }
+            restore2();
+        });
+
+        it('resumeJoin with a superseded (errorless) null stream does not fail the session', async () => {
+            const restore = stubPermissionsPrompt();
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+
+            harness.media.startLocalMediaResult = null;
+            harness.media.lastLocalMediaError = null;
+            await harness.session.resumeJoin();
+
+            expect(harness.state.signalingState.kind).not.toBe('failed');
+            restore();
+        });
+
+        it('initial-join media failure is surfaced without an awaitingPermissions stop', async () => {
+            // Permissions already granted (no prompt stub): the join path calls
+            // startLocalMedia directly and must surface a failure terminally.
+            harness = new TestSessionHarness();
+            harness.media.startLocalMediaResult = null;
+            harness.media.lastLocalMediaError = { name: 'NotReadableError', message: 'camera busy' };
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+
+            const sigState = harness.state.signalingState;
+            expect(sigState.kind).toBe('failed');
+            if (sigState.kind === 'failed') {
+                expect(sigState.reason).toBe('mediaUnavailable');
+            }
+        });
+
         it('fires onPermissionsRequired callback', async () => {
             const restore = stubPermissionsPrompt();
             harness = new TestSessionHarness();
@@ -1172,6 +1256,21 @@ describe('SerenadaSession', () => {
             if (sigState.kind === 'failed') {
                 expect(sigState.reason).toBe('roomEnded');
             }
+        });
+
+        it('TURN_REFRESH_FAILED from the provider is non-fatal', async () => {
+            // Built-in providers no longer emit this code, but custom
+            // SignalingProviders may; the call must survive it.
+            harness = new TestSessionHarness();
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+            const phaseBefore = harness.state.phase;
+
+            harness.simulateError('credential fetch failed', 'TURN_REFRESH_FAILED');
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(harness.state.signalingState.kind).not.toBe('failed');
+            expect(harness.state.phase).toBe(phaseBefore);
         });
     });
 

--- a/client/packages/core/test/helpers/FakeMediaEngine.ts
+++ b/client/packages/core/test/helpers/FakeMediaEngine.ts
@@ -45,6 +45,13 @@ export class FakeMediaEngine {
         getVideoTracks: () => [],
     } as unknown as MediaStream;
 
+    /**
+     * Mirrors MediaEngine.lastLocalMediaError. Set alongside
+     * startLocalMediaResult = null to simulate a failed (vs superseded)
+     * acquisition.
+     */
+    lastLocalMediaError: { name: string; message: string } | null = null;
+
     setOnChange(cb: () => void): void {
         this.onChange = cb;
     }

--- a/client/packages/core/test/media/MediaEngine.test.ts
+++ b/client/packages/core/test/media/MediaEngine.test.ts
@@ -411,6 +411,44 @@ describe('MediaEngine', () => {
         });
     });
 
+    it('records the DOMException name when getUserMedia rejects and clears it on a later success', async () => {
+        const getUserMedia = vi.fn().mockRejectedValueOnce(new DOMException('denied', 'NotAllowedError'))
+            .mockResolvedValue(createMediaStream());
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                mediaDevices: {
+                    getUserMedia,
+                    enumerateDevices: vi.fn().mockResolvedValue([]),
+                    addEventListener() {},
+                    removeEventListener() {},
+                },
+            },
+            configurable: true,
+        });
+        const engine = new MediaEngine({ initialVideoEnabled: false }, () => {});
+
+        const failed = await engine.startLocalMedia();
+        expect(failed).toBeNull();
+        expect(engine.lastLocalMediaError?.name).toBe('NotAllowedError');
+
+        const stream = await engine.startLocalMedia();
+        expect(stream).not.toBeNull();
+        expect(engine.lastLocalMediaError).toBeNull();
+    });
+
+    it('records NotSupportedError when getUserMedia is unavailable', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { mediaDevices: {} },
+            configurable: true,
+        });
+        const engine = new MediaEngine({}, () => {});
+
+        const stream = await engine.startLocalMedia();
+
+        expect(stream).toBeNull();
+        expect(engine.lastLocalMediaError?.name).toBe('NotSupportedError');
+    });
+
     it('starts local media with the default audio input when it is available before capture', async () => {
         const getUserMedia = vi.fn().mockResolvedValue(createMediaStream({ audioSettings: { deviceId: 'bt-mic', groupId: 'bluetooth' } }));
         const devices = [


### PR DESCRIPTION
## Summary

Closes out the fixable findings from the #126 pre-merge review (R-series in the local sweep backlog doc):

- **R1 (web):** `LOCAL_MEDIA_FAILED` now maps to a new public `mediaUnavailable` error code instead of falling through to `'unknown'` — this is the code for the most common real failures (`NotReadableError` camera-in-use, `NotFoundError` no devices). The code was added to web's `CallErrorCode` only; extending the Android/iOS public enums for a code nothing emits there would itself be a source-breaking enum addition (the R6 pattern).
- **R2 (Android):** `createAnswer`'s `onSdp` callback now hops to the main handler before sending, gated on the negotiation still being current — the same WebRTC-signaling-thread fix #126 applied to offers and ICE candidates, which had missed the answer path. Fires on every accepted remote offer.
- **R3 (iOS):** the mid-call TURN refresh in `TurnManager` now retries over the shared `iceFetchRetryDelaysMs` schedule with a generation guard, and only latches `lastTurnTokenForAttempt` on success — a transient fetch failure no longer leaves the call on aging credentials until the server mints a different token.
- **R4 (iOS):** `TURN_REFRESH_FAILED` from a custom signaling provider is non-fatal, matching web/Android.
- **R7 (all three):** an empty ICE-server refresh result is treated as a retryable failure instead of being applied to the live connection (which stripped TURN mid-call).
- **R10:** regression tests for the above plus the backfill gaps: web TURN-refresh retry loop (retry/exhaustion/generation-supersede/disconnect), failed local-media surfacing on both web join paths, `MediaEngine.lastLocalMediaError` population, TURN_REFRESH_FAILED non-fatal on all three platforms, and the iOS `Backoff` overflow clamp (traps pre-#126).

Not in this PR: R5 turned out to be a false positive (the parity script auto-discovers constants and has been enforcing `ICE_FETCH_RETRY_DELAYS_MS` all along), R6 is a release-note action for the next version bump, and R8/R9 are decided-and-documented as future work in the sweep backlog doc.

## Validation

- `npm run build` + `npm run test` in `client` (430 tests)
- `./gradlew :serenada-core:testDebugUnitTest` (full core suite)
- `xcodebuild test` on iPhone 16 simulator (371 tests, 0 failures)
- `node scripts/check-resilience-constants.mjs` (27 match) and `node scripts/check-version-parity.mjs` (0.8.4 across 9 sources)
- Red-first validation: the Android stale-answer and empty-refresh tests were run against the pre-fix source and fail there; the iOS retry tests assert call counts the pre-fix single-attempt code cannot produce

## Before merge

- [ ] On-device pass for the Android answer-path change (R2) — same threading territory as the #126 offer/ICE changes that were device-verified
- [ ] Optional: same-token TURN refresh recovery on a physical iPhone (R3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)