### PR TITLE
Release Serenada SDK 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.5] — 2026-06-12
+
+### Added
+- iOS: host audio coordinators can report `audioSessionRestarted` after
+  same-app `AVAudioSession` takeovers, allowing the SDK to restart the
+  WebRTC audio unit when the host reactivates audio.
+
+### Fixed
+- Web, Android, iOS: call recovery is more robust around late local-media
+  attachment, duplicate/stale negotiation answers, deferred ICE restarts,
+  and peer replacement cleanup.
+- Web, Android, iOS: TURN credential refresh no longer clears live relay
+  configuration on empty or failed refreshes, and iOS now retries failed
+  mid-call refreshes before the current credentials age out.
+- Web: local media failures now surface as `mediaUnavailable` instead of
+  `unknown` when camera or microphone capture cannot start.
+- Android: answer SDP callbacks are delivered on the signaling thread only
+  while the negotiation is still current.
+
 ## [0.8.4] — 2026-06-05
 
 ### Fixed

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.4`
-- `app.serenada:core:0.8.4`
-- `app.serenada:call-ui:0.8.4`
+- `app.serenada:libwebrtc-7827-universal:0.8.5`
+- `app.serenada:core:0.8.5`
+- `app.serenada:call-ui:0.8.5`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.4"
+                version = "0.8.5"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.4"
+val sdkVersion = "0.8.5"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.8.4"
+        const val VERSION = "0.8.5"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.4"
+val sdkVersion = "0.8.5"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.4"
+    public static let version = "0.8.5"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.4",
-        "@agatx/serenada-react-ui": "0.8.4",
+        "@agatx/serenada-core": "0.8.5",
+        "@agatx/serenada-react-ui": "0.8.5",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.4"
+        "@agatx/serenada-core": "0.8.5"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.4",
+        "@agatx/serenada-core": "^0.8.5",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.4",
-    "@agatx/serenada-react-ui": "0.8.4",
+    "@agatx/serenada-core": "0.8.5",
+    "@agatx/serenada-react-ui": "0.8.5",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.4';
+export const SERENADA_CORE_VERSION = '0.8.5';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.4",
+    "@agatx/serenada-core": "^0.8.5",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.4"
+    "@agatx/serenada-core": "0.8.5"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.4")
-    implementation("app.serenada:call-ui:0.8.4")
+    implementation("app.serenada:core:0.8.5")
+    implementation("app.serenada:call-ui:0.8.5")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.4 @agatx/serenada-react-ui@0.8.4 lucide-react
+npm install @agatx/serenada-core@0.8.5 @agatx/serenada-react-ui@0.8.5 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.4"
+        "@agatx/serenada-core": "0.8.5"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.4",
+        "@agatx/serenada-core": "^0.8.5",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
Summary
- Bump Serenada SDK packages and runtime constants to 0.8.5 across web, Android, and iOS.
- Update integration docs, Android publish docs, sample web lockfile, and changelog for the 0.8.5 release.

Validation
- node scripts/check-version-parity.mjs
- node scripts/check-signaling-protocol-constants.mjs
- node scripts/check-resilience-constants.mjs
- cd client && npm test
- cd client && npm run build
- cd client && npm run build:publish --workspace @agatx/serenada-core
- cd client && npm run build:publish --workspace @agatx/serenada-react-ui
- cd client && npm pack --dry-run --workspace @agatx/serenada-core
- cd client && npm pack --dry-run --workspace @agatx/serenada-react-ui
- cd samples/web && npm ci --ignore-scripts && npm run build

Co-authored by Codex (GPT-5 medium)