### PR TITLE
[codex] Bump Serenada SDK to 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.6] — 2026-06-14
+
+### Fixed
+- iOS: system Picture in Picture now stops as the app returns to the
+  foreground, restoring the inline call UI without briefly leaving the PiP
+  placeholder over the active video tile.
+
 ## [0.8.5] — 2026-06-12
 
 ### Added

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.5`
-- `app.serenada:core:0.8.5`
-- `app.serenada:call-ui:0.8.5`
+- `app.serenada:libwebrtc-7827-universal:0.8.6`
+- `app.serenada:core:0.8.6`
+- `app.serenada:call-ui:0.8.6`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.5"
+                version = "0.8.6"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.5"
+val sdkVersion = "0.8.6"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.8.5"
+        const val VERSION = "0.8.6"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.5"
+val sdkVersion = "0.8.6"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -425,7 +425,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         init(rendererProvider: CallRendererProvider) {
             self.rendererProvider = rendererProvider
             super.init()
-            registerForegroundObservers()
+            registerForegroundObserver()
         }
 
         deinit {
@@ -503,7 +503,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             currentParticipant = nil
             currentAvatarImage = nil
             isStoppingForForegroundActivation = false
-            removeForegroundObservers()
+            removeForegroundObserver()
         }
 
         private func ensureController() {
@@ -579,9 +579,9 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             isStoppingForForegroundActivation = false
         }
 
-        private func registerForegroundObservers() {
+        private func registerForegroundObserver() {
             foregroundObserver = NotificationCenter.default.addObserver(
-                forName: UIApplication.willEnterForegroundNotification,
+                forName: UIApplication.didBecomeActiveNotification,
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
@@ -591,7 +591,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             }
         }
 
-        private func removeForegroundObservers() {
+        private func removeForegroundObserver() {
             if let foregroundObserver {
                 NotificationCenter.default.removeObserver(foregroundObserver)
                 self.foregroundObserver = nil

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -419,10 +419,13 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         private var attachedSource: SystemPictureInPictureSource?
         private var currentParticipant: SystemPictureInPictureParticipant?
         private var currentAvatarImage: UIImage?
+        private var foregroundObservers: [NSObjectProtocol] = []
+        private var isStoppingForForegroundActivation = false
 
         init(rendererProvider: CallRendererProvider) {
             self.rendererProvider = rendererProvider
             super.init()
+            registerForegroundObservers()
         }
 
         func configure(sourceView: SystemPictureInPictureSourceView) {
@@ -493,6 +496,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             contentController = nil
             currentParticipant = nil
             currentAvatarImage = nil
+            removeForegroundObservers()
         }
 
         private func ensureController() {
@@ -557,12 +561,39 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         }
 
         func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-            updateSourcePlaceholder(visible: true, animated: false)
+            updateSourcePlaceholder(visible: !isStoppingForForegroundActivation, animated: false)
         }
 
         func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
             updateSourcePlaceholder(visible: false, animated: true)
             detachRenderer()
+            isStoppingForForegroundActivation = false
+        }
+
+        private func registerForegroundObservers() {
+            let notifications = [
+                UIApplication.willEnterForegroundNotification,
+                UIApplication.didBecomeActiveNotification
+            ]
+            foregroundObservers = notifications.map { name in
+                NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.stopPictureInPictureForForegroundActivation()
+                    }
+                }
+            }
+        }
+
+        private func removeForegroundObservers() {
+            foregroundObservers.forEach(NotificationCenter.default.removeObserver)
+            foregroundObservers.removeAll()
+        }
+
+        private func stopPictureInPictureForForegroundActivation() {
+            guard controller?.isPictureInPictureActive == true else { return }
+            isStoppingForForegroundActivation = true
+            sourceView?.setPlaceholderVisible(false, animated: false)
+            controller?.stopPictureInPicture()
         }
 
         private func updateSourcePlaceholder(visible: Bool, animated: Bool) {

--- a/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
+++ b/client-ios/SerenadaCallUI/Sources/SystemPictureInPicture.swift
@@ -419,13 +419,19 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         private var attachedSource: SystemPictureInPictureSource?
         private var currentParticipant: SystemPictureInPictureParticipant?
         private var currentAvatarImage: UIImage?
-        private var foregroundObservers: [NSObjectProtocol] = []
+        private var foregroundObserver: NSObjectProtocol?
         private var isStoppingForForegroundActivation = false
 
         init(rendererProvider: CallRendererProvider) {
             self.rendererProvider = rendererProvider
             super.init()
             registerForegroundObservers()
+        }
+
+        deinit {
+            if let foregroundObserver {
+                NotificationCenter.default.removeObserver(foregroundObserver)
+            }
         }
 
         func configure(sourceView: SystemPictureInPictureSourceView) {
@@ -439,7 +445,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             sourceView?.update(
                 participant: participant,
                 avatarImage: avatarImage,
-                placeholderVisible: controller?.isPictureInPictureActive == true
+                placeholderVisible: controller?.isPictureInPictureActive == true && !isStoppingForForegroundActivation
             )
 
             guard enabled else {
@@ -496,6 +502,7 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
             contentController = nil
             currentParticipant = nil
             currentAvatarImage = nil
+            isStoppingForForegroundActivation = false
             removeForegroundObservers()
         }
 
@@ -551,11 +558,13 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         }
 
         func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            isStoppingForForegroundActivation = false
             updateSourcePlaceholder(visible: true, animated: false)
             attachCurrentRenderer()
         }
 
         func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+            isStoppingForForegroundActivation = false
             updateSourcePlaceholder(visible: true, animated: false)
             attachCurrentRenderer()
         }
@@ -571,26 +580,27 @@ private struct SystemPictureInPictureHost: UIViewRepresentable {
         }
 
         private func registerForegroundObservers() {
-            let notifications = [
-                UIApplication.willEnterForegroundNotification,
-                UIApplication.didBecomeActiveNotification
-            ]
-            foregroundObservers = notifications.map { name in
-                NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                    Task { @MainActor [weak self] in
-                        self?.stopPictureInPictureForForegroundActivation()
-                    }
+            foregroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.stopPictureInPictureForForegroundActivation()
                 }
             }
         }
 
         private func removeForegroundObservers() {
-            foregroundObservers.forEach(NotificationCenter.default.removeObserver)
-            foregroundObservers.removeAll()
+            if let foregroundObserver {
+                NotificationCenter.default.removeObserver(foregroundObserver)
+                self.foregroundObserver = nil
+            }
         }
 
         private func stopPictureInPictureForForegroundActivation() {
-            guard controller?.isPictureInPictureActive == true else { return }
+            guard controller?.isPictureInPictureActive == true,
+                  !isStoppingForForegroundActivation else { return }
             isStoppingForForegroundActivation = true
             sourceView?.setPlaceholderVisible(false, animated: false)
             controller?.stopPictureInPicture()

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.5"
+    public static let version = "0.8.6"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.5",
-        "@agatx/serenada-react-ui": "0.8.5",
+        "@agatx/serenada-core": "0.8.6",
+        "@agatx/serenada-react-ui": "0.8.6",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.5"
+        "@agatx/serenada-core": "0.8.6"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.5",
+        "@agatx/serenada-core": "^0.8.6",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.5",
-    "@agatx/serenada-react-ui": "0.8.5",
+    "@agatx/serenada-core": "0.8.6",
+    "@agatx/serenada-react-ui": "0.8.6",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.5';
+export const SERENADA_CORE_VERSION = '0.8.6';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.5",
+    "@agatx/serenada-core": "^0.8.6",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.5"
+    "@agatx/serenada-core": "0.8.6"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -73,7 +73,7 @@ Provider mode does not expose Serenada server helpers. These APIs require `serve
 | `inviteControlsEnabled` | Bool | `true` | Show/hide the built-in QR code and share-link UI in the waiting screen |
 | `debugOverlayEnabled` | Bool | `false` | Show/hide the in-call debug toggle and diagnostics panel |
 | `autoHideControls` | Bool | `true` | When `true`, the call controls bar fades out after a few seconds of idle time and a tap on the stage brings it back. When `false`, the controls stay visible for the entire call and the idle timer never runs. |
-| `systemPictureInPictureEnabled` | Bool | `false` | Android and iOS. Enables system Picture-in-Picture for waiting and active calls on supported mobile platforms. Android host apps must also set activity PiP manifest flags; iOS host apps must include background audio/VoIP modes. The SDK opts iOS capture sessions into multitasking camera access when supported and closes Android PiP by finishing the activity if the call ends while still in PiP. Custom PiP actions are not used, so call controls remain available after returning to the app. |
+| `systemPictureInPictureEnabled` | Bool | `false` | Android and iOS. Enables system Picture-in-Picture for waiting and active calls on supported mobile platforms. Android host apps must also set activity PiP manifest flags; iOS host apps must include background audio/VoIP modes. The SDK opts iOS capture sessions into multitasking camera access when supported, stops iOS system PiP as the app returns foreground, and closes Android PiP by finishing the activity if the call ends while still in PiP. Custom PiP actions are not used, so call controls remain available after returning to the app. |
 
 ### iOS
 

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -73,7 +73,7 @@ Provider mode does not expose Serenada server helpers. These APIs require `serve
 | `inviteControlsEnabled` | Bool | `true` | Show/hide the built-in QR code and share-link UI in the waiting screen |
 | `debugOverlayEnabled` | Bool | `false` | Show/hide the in-call debug toggle and diagnostics panel |
 | `autoHideControls` | Bool | `true` | When `true`, the call controls bar fades out after a few seconds of idle time and a tap on the stage brings it back. When `false`, the controls stay visible for the entire call and the idle timer never runs. |
-| `systemPictureInPictureEnabled` | Bool | `false` | Android and iOS. Enables system Picture-in-Picture for waiting and active calls on supported mobile platforms. Android host apps must also set activity PiP manifest flags; iOS host apps must include background audio/VoIP modes. The SDK opts iOS capture sessions into multitasking camera access when supported, stops iOS system PiP as the app returns foreground, and closes Android PiP by finishing the activity if the call ends while still in PiP. Custom PiP actions are not used, so call controls remain available after returning to the app. |
+| `systemPictureInPictureEnabled` | Bool | `false` | Android and iOS. Enables system Picture-in-Picture for waiting and active calls on supported mobile platforms. Android host apps must also set activity PiP manifest flags; iOS host apps must include the background audio mode. The SDK opts iOS capture sessions into multitasking camera access when supported, stops iOS system PiP as the app returns to the foreground, and closes Android PiP by finishing the activity if the call ends while still in PiP. Custom PiP actions are not used, so call controls remain available after returning to the app. |
 
 ### iOS
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.5")
-    implementation("app.serenada:call-ui:0.8.5")
+    implementation("app.serenada:core:0.8.6")
+    implementation("app.serenada:call-ui:0.8.6")
 }
 ```
 

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -70,13 +70,12 @@ URL-first frontline calls start audio-first and use the camera order `world -> s
 
 ### Optional System Picture in Picture
 
-The prebuilt call UI can configure iOS video-call Picture in Picture for waiting and active calls. Host apps must include background audio/VoIP modes in their app `Info.plist`:
+The prebuilt call UI can configure iOS video-call Picture in Picture for waiting and active calls. Host apps must include the background audio mode in their app `Info.plist`:
 
 ```xml
 <key>UIBackgroundModes</key>
 <array>
     <string>audio</string>
-    <string>voip</string>
 </array>
 ```
 
@@ -90,7 +89,7 @@ SerenadaCallFlow(
 )
 ```
 
-When enabled on a supported iOS device, the SDK keeps the active large video feed or avatar visible in system PiP and lets the system return control bring the user back to the app. As the app becomes active again, the SDK stops the system PiP session and restores the inline call UI. The SDK enables multitasking camera access on its capture sessions when iOS reports support, so local camera video can continue in PiP on supported devices. iOS does not support custom in-window PiP actions for video calls, so End Call remains available only after returning to the app.
+When enabled on a supported iOS device, the SDK keeps the active large video feed or avatar visible in system PiP and lets the system return the user to the app. As the app returns to the foreground, the SDK stops the system PiP session and restores the inline call UI. The SDK enables multitasking camera access on its capture sessions when iOS reports support, so local camera video can continue in PiP on supported devices. iOS does not support custom in-window PiP actions for video calls, so End Call remains available only after returning to the app.
 
 ## Session-First (Pre-Observation)
 

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -90,7 +90,7 @@ SerenadaCallFlow(
 )
 ```
 
-When enabled on a supported iOS device, the SDK keeps the active large video feed or avatar visible in system PiP and lets the system return control bring the user back to the app. The SDK enables multitasking camera access on its capture sessions when iOS reports support, so local camera video can continue in PiP on supported devices. iOS does not support custom in-window PiP actions for video calls, so End Call remains available only after returning to the app.
+When enabled on a supported iOS device, the SDK keeps the active large video feed or avatar visible in system PiP and lets the system return control bring the user back to the app. As the app becomes active again, the SDK stops the system PiP session and restores the inline call UI. The SDK enables multitasking camera access on its capture sessions when iOS reports support, so local camera video can continue in PiP on supported devices. iOS does not support custom in-window PiP actions for video calls, so End Call remains available only after returning to the app.
 
 ## Session-First (Pre-Observation)
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.5 @agatx/serenada-react-ui@0.8.5 lucide-react
+npm install @agatx/serenada-core@0.8.6 @agatx/serenada-react-ui@0.8.6 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/ios/README.md
+++ b/samples/ios/README.md
@@ -9,6 +9,7 @@ Minimal iOS host app demonstrating Serenada SDK integration with SwiftUI.
 - Starts a provider-mode demo backed by a local in-memory `SignalingProvider`
 - Shows incremental `peerJoined` events and peer-message delivery without Serenada transport
 - Demonstrates injecting a custom `SerenadaAudioCoordinator` for host-owned audio policy
+- Enables system Picture in Picture so the sample covers foreground return from PiP
 - Runs as a standalone XcodeGen app inside this repository
 - Resolves `SerenadaCore` and `SerenadaCallUI` directly from local source in `client-ios/`
 
@@ -32,7 +33,7 @@ xcodebuild \
   build
 ```
 
-The simulator is enough to verify project setup and call flow wiring. Use a physical device to validate camera and microphone behavior.
+The simulator is enough to verify project setup and call flow wiring. Use a physical device to validate camera, microphone, and system Picture in Picture behavior.
 For physical-device runs, set your Apple development team in Xcode signing settings first.
 
 If you change [project.yml](project.yml), regenerate the checked-in project with:

--- a/samples/ios/Resources/Info.plist
+++ b/samples/ios/Resources/Info.plist
@@ -28,6 +28,11 @@
 	<string>Serenada Sample needs microphone access for audio calls.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 </dict>

--- a/samples/ios/Resources/Info.plist
+++ b/samples/ios/Resources/Info.plist
@@ -31,7 +31,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>voip</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/samples/ios/SampleApp/SampleApp.swift
+++ b/samples/ios/SampleApp/SampleApp.swift
@@ -6,7 +6,8 @@ import SwiftUI
 private let sampleServerHost = "serenada.app"
 private let sampleCallFlowConfig = SerenadaCallFlowConfig(
     screenSharingEnabled: false,
-    inviteControlsEnabled: false
+    inviteControlsEnabled: false,
+    systemPictureInPictureEnabled: true
 )
 
 private enum ActiveCall {

--- a/samples/ios/project.yml
+++ b/samples/ios/project.yml
@@ -33,7 +33,6 @@ targets:
         UIApplicationSupportsIndirectInputEvents: YES
         UIBackgroundModes:
           - audio
-          - voip
         UILaunchScreen: {}
         NSCameraUsageDescription: Serenada Sample needs camera access for video calls.
         NSMicrophoneUsageDescription: Serenada Sample needs microphone access for audio calls.

--- a/samples/ios/project.yml
+++ b/samples/ios/project.yml
@@ -31,6 +31,9 @@ targets:
         CFBundleVersion: "1"
         CFBundleDisplayName: Serenada Sample
         UIApplicationSupportsIndirectInputEvents: YES
+        UIBackgroundModes:
+          - audio
+          - voip
         UILaunchScreen: {}
         NSCameraUsageDescription: Serenada Sample needs camera access for video calls.
         NSMicrophoneUsageDescription: Serenada Sample needs microphone access for audio calls.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.5"
+        "@agatx/serenada-core": "0.8.6"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.5",
+        "@agatx/serenada-core": "^0.8.6",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary
- Stop iOS system Picture in Picture when the app returns to foreground so the inline call UI is restored cleanly.
- Bump shared Serenada SDK version surfaces to `0.8.6` and refresh local lockfile metadata.
- Update PiP docs and enable system PiP in the iOS sample with the required background modes.

## Release Scope
- iOS-only fix.
- No `web-release-*` tag was created or pushed, so this PR does not publish web packages.

## Validation
- `node scripts/check-version-parity.mjs`
- `plutil -lint samples/ios/Resources/Info.plist`
- `cd samples/ios && xcodegen generate`
- `cd samples/ios && xcodebuild -project SerenadaiOSSample.xcodeproj -scheme SerenadaiOSSample -destination 'generic/platform=iOS Simulator' build`

Co-authored by Codex (GPT-5 medium)