### PR TITLE
[codex] Add strict audio-only media mode

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/CallState.kt
@@ -82,8 +82,8 @@ data class CallState(
     /**
      * Camera modes the user can cycle through, in preference order. Derived
      * from [SerenadaConfig.cameraModes] minus modes unsupported on this
-     * device. Empty means video is unavailable — call UIs should hide the
-     * video toggle.
+     * device. Empty means camera video is unavailable — call UIs should hide
+     * the camera video toggle.
      */
     val availableCameraModes: List<LocalCameraMode> = DEFAULT_CAMERA_MODES,
     /** Current error, if any. */

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaConfig.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaConfig.kt
@@ -24,13 +24,21 @@ data class SerenadaConfig(
     /** Whether video starts enabled (default true). */
     val defaultVideoEnabled: Boolean = true,
     /**
+     * Whether this call can negotiate any video media. Set false for strict
+     * audio-only calls such as PSTN: camera capture, screen sharing, and
+     * remote video are all disabled. Defaults to true.
+     */
+    val videoMediaEnabled: Boolean = true,
+    /**
      * Camera modes available in the call UI, in preference order. The first
      * entry is the initial mode. When only one mode is listed the flip-camera
-     * control is hidden; an empty list disables video entirely (the video
-     * toggle is hidden and the camera is never requested). Modes unsupported
-     * on the current device are silently dropped (`COMPOSITE` is dropped on
-     * devices without multi-cam). `SCREEN_SHARE` is always ignored — screen
-     * sharing is controlled separately. Defaults to `[SELFIE, WORLD, COMPOSITE]`.
+     * control is hidden; an empty list disables camera capture (the video
+     * toggle is hidden and the camera is never requested). Remote video and
+     * screen sharing remain available unless [videoMediaEnabled] is false.
+     * Modes unsupported on the current device are silently dropped
+     * (`COMPOSITE` is dropped on devices without multi-cam). `SCREEN_SHARE` is
+     * always ignored — screen sharing is controlled separately. Defaults to
+     * `[SELFIE, WORLD, COMPOSITE]`.
      */
     val cameraModes: List<LocalCameraMode>? = null,
     /** Enable experimental HD video capture. */

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -478,8 +478,9 @@ class SerenadaSession internal constructor(
     private var outboundMediaWatchdogRunnable: Runnable? = null
     private var iceFetchGeneration = 0
     private var cpuWakeLock: PowerManager.WakeLock? = null
+    private val videoMediaEnabled: Boolean = config.videoMediaEnabled
     private val availableCameraModes: List<LocalCameraMode> = resolveAvailableCameraModes()
-    private val videoCaptureSupported: Boolean = availableCameraModes.isNotEmpty()
+    private val videoCaptureSupported: Boolean = videoMediaEnabled && availableCameraModes.isNotEmpty()
     private var userPreferredVideoEnabled = videoCaptureSupported && config.defaultVideoEnabled
     private var isVideoPausedByProximity = false
     private val isMediaEngineInjected = mediaEngine != null
@@ -494,6 +495,7 @@ class SerenadaSession internal constructor(
     private var localMediaReadyForNegotiation = false
 
     private fun resolveAvailableCameraModes(): List<LocalCameraMode> {
+        if (!config.videoMediaEnabled) return emptyList()
         val configuredModes = resolveCameraModes(config.cameraModes)
         if (LocalCameraMode.COMPOSITE !in configuredModes) return configuredModes
         val compositeAvailable = CameraCaptureController.isCompositeCameraModeAvailable(appContext, logger)
@@ -900,6 +902,7 @@ class SerenadaSession internal constructor(
     /** Start screen sharing using the given media projection intent. */
     fun startScreenShare(intent: Intent) {
         assertMainThread()
+        if (!videoMediaEnabled) return
         if (_diagnostics.value.isScreenSharing) return
         val wasVideoPreferred = userPreferredVideoEnabled
         userPreferredVideoEnabled = true
@@ -1281,6 +1284,7 @@ class SerenadaSession internal constructor(
                 }
             },
             isHdVideoExperimentalEnabled = config.isHdVideoExperimentalEnabled,
+            videoMediaEnabled = videoMediaEnabled,
             availableCameraModes = availableCameraModes,
             logger = logger,
         )
@@ -1865,7 +1869,7 @@ class SerenadaSession internal constructor(
         clientId = null; hostCid = null; currentRoomState = null; callStartTimeMs = null
         pendingJoinRoom = null; pendingMessages.clear(); remoteMediaStates.clear()
         connectionStatusTracker.cancelTimer()
-        userPreferredVideoEnabled = config.defaultVideoEnabled; isVideoPausedByProximity = false
+        userPreferredVideoEnabled = videoCaptureSupported && config.defaultVideoEnabled; isVideoPausedByProximity = false
         reconnectToken = null; reconnectTokenTTLMs = null; reconnectRecoveryPending = false; hasInitialIceServers = false
         cancelPostReconnectResync()
         clearAllRemoteSuspensionTracking()

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CameraCaptureController.kt
@@ -84,6 +84,9 @@ internal class CameraCaptureController(
 
     val availableCameraModes: List<LocalCameraMode> = availableCameraModes
 
+    /** True when this device has at least one camera mode available to capture video with. */
+    val canCaptureVideo: Boolean get() = availableCameraModes.isNotEmpty()
+
     init {
         currentCameraSource =
             cameraSourceFromMode(this.availableCameraModes.firstOrNull() ?: LocalCameraMode.SELFIE)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -29,6 +29,7 @@ internal class PeerConnectionSlot(
     private var iceServers: List<PeerConnection.IceServer>?,
     private var localAudioTrack: AudioTrack?,
     private var localVideoTrack: VideoTrack?,
+    private val videoReceiveEnabled: Boolean = true,
     private val onLocalIceCandidate: (String, IceCandidate) -> Unit,
     private val onRemoteVideoTrack: (String, VideoTrack?) -> Unit,
     private val onConnectionStateChange: (String, PeerConnection.PeerConnectionState) -> Unit,
@@ -207,6 +208,14 @@ internal class PeerConnectionSlot(
                     track.setVolume(if (playbackDucked) 0.15 else 1.0)
                 }
                 if (track is VideoTrack) {
+                    if (!videoReceiveEnabled) {
+                        logger?.log(
+                            SerenadaLogLevel.INFO,
+                            "PeerConnection",
+                            "[$remoteCid] Ignoring remote video track because video media is disabled"
+                        )
+                        return
+                    }
                     remoteVideoTrack?.removeSink(remoteVideoStateSink)
                     remoteSinks.forEach { sink -> remoteVideoTrack?.removeSink(sink) }
                     remoteVideoTrack = track
@@ -749,7 +758,7 @@ internal class PeerConnectionSlot(
                 RtpTransceiver.RtpTransceiverInit(RtpTransceiver.RtpTransceiverDirection.RECV_ONLY)
             )
         }
-        if (localVideoTrack == null) {
+        if (videoReceiveEnabled && localVideoTrack == null) {
             pc.addTransceiver(
                 MediaStreamTrack.MediaType.MEDIA_TYPE_VIDEO,
                 RtpTransceiver.RtpTransceiverInit(RtpTransceiver.RtpTransceiverDirection.RECV_ONLY)

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
@@ -69,7 +69,7 @@ internal class ScreenShareController(
             runCatching { capturer.dispose() }
             runCatching { textureHelper.dispose() }
             val videoSource = videoSourceProvider()
-            if (cameraController.availableCameraModes.isNotEmpty() &&
+            if (cameraController.canCaptureVideo &&
                 !cameraController.restartVideoCapturer(previousSource, videoSource)) {
                 cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)
             }
@@ -84,7 +84,7 @@ internal class ScreenShareController(
         cameraController.isScreenSharing = false
         cameraController.cameraSourceBeforeScreenShare = null
         cameraController.disposeVideoCapturer()
-        if (cameraController.availableCameraModes.isEmpty()) return true
+        if (!cameraController.canCaptureVideo) return true
         val videoSource = videoSourceProvider()
         if (!cameraController.restartVideoCapturer(sourceToRestore, videoSource) &&
             !cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ScreenShareController.kt
@@ -69,7 +69,8 @@ internal class ScreenShareController(
             runCatching { capturer.dispose() }
             runCatching { textureHelper.dispose() }
             val videoSource = videoSourceProvider()
-            if (!cameraController.restartVideoCapturer(previousSource, videoSource)) {
+            if (cameraController.availableCameraModes.isNotEmpty() &&
+                !cameraController.restartVideoCapturer(previousSource, videoSource)) {
                 cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)
             }
             false
@@ -83,6 +84,7 @@ internal class ScreenShareController(
         cameraController.isScreenSharing = false
         cameraController.cameraSourceBeforeScreenShare = null
         cameraController.disposeVideoCapturer()
+        if (cameraController.availableCameraModes.isEmpty()) return true
         val videoSource = videoSourceProvider()
         if (!cameraController.restartVideoCapturer(sourceToRestore, videoSource) &&
             !cameraController.restartVideoCapturer(CameraCaptureController.LocalCameraSource.SELFIE, videoSource)) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -40,6 +40,7 @@ internal class WebRtcEngine(
     private val onFeatureDegradation: (FeatureDegradationState) -> Unit = {},
     private var isHdVideoExperimentalEnabled: Boolean = false,
     private var isRemoteBlackFrameAnalysisEnabled: Boolean = true,
+    private val videoMediaEnabled: Boolean = true,
     availableCameraModes: List<LocalCameraMode> = app.serenada.core.DEFAULT_CAMERA_MODES,
     private val logger: SerenadaLogger? = null,
 ) : SessionMediaEngine {
@@ -211,14 +212,14 @@ internal class WebRtcEngine(
         applyAudioTrackHints()
         localAudioTrack?.let { audioPipelinePrimer.start(it) }
 
-        if (cameraController.availableCameraModes.isEmpty()) {
+        if (!videoMediaEnabled || cameraController.availableCameraModes.isEmpty()) {
             peerSlots.forEach { slot ->
                 slot.attachLocalTracks(localAudioTrack, null)
             }
             return
         }
 
-        videoSource = peerConnectionFactory.createVideoSource(false)
+        ensureVideoSource()
         cameraController.resetCameraSourceToInitial()
         val startedVideo = startVideoCapture && restartVideoCapturerWithFallback(cameraController.currentCameraSource)
         if (!startedVideo) {
@@ -228,14 +229,32 @@ internal class WebRtcEngine(
                 logger?.log(SerenadaLogLevel.INFO, "WebRTC", "Camera starts disabled; continuing audio-only")
             }
         }
-        localVideoTrack = peerConnectionFactory.createVideoTrack("ARDAMSv0", videoSource)
-        localVideoTrack?.setEnabled(startedVideo)
-        localSinks.forEach { sink ->
-            localVideoTrack?.addSink(sink)
-        }
+        ensureLocalVideoTrack(enabled = startedVideo)
         peerSlots.forEach { slot ->
             slot.attachLocalTracks(localAudioTrack, localVideoTrack)
         }
+    }
+
+    private fun ensureVideoSource(): org.webrtc.VideoSource {
+        return videoSource ?: peerConnectionFactory.createVideoSource(false).also { videoSource = it }
+    }
+
+    private fun ensureLocalVideoTrack(enabled: Boolean): VideoTrack {
+        return localVideoTrack ?: peerConnectionFactory.createVideoTrack("ARDAMSv0", ensureVideoSource()).also { track ->
+            track.setEnabled(enabled)
+            localSinks.forEach { sink -> track.addSink(sink) }
+            localVideoTrack = track
+        }
+    }
+
+    private fun disposeLocalVideoTrack() {
+        localVideoTrack?.let { track ->
+            localSinks.forEach { sink -> track.removeSink(sink) }
+            track.dispose()
+        }
+        localVideoTrack = null
+        videoSource?.dispose()
+        videoSource = null
     }
 
     fun stopLocalMedia() {
@@ -302,6 +321,10 @@ internal class WebRtcEngine(
     }
 
     override fun toggleVideo(enabled: Boolean): Boolean {
+        if (!videoMediaEnabled) {
+            localVideoTrack?.setEnabled(false)
+            return false
+        }
         if (enabled && cameraController.availableCameraModes.isEmpty() && !screenShareController.isScreenSharing) {
             localVideoTrack?.setEnabled(false)
             return false
@@ -364,11 +387,33 @@ internal class WebRtcEngine(
     }
 
     override fun startScreenShare(intent: Intent): Boolean {
-        return screenShareController.startScreenShare(intent)
+        if (!videoMediaEnabled) return false
+        val createdVideoTrack = localVideoTrack == null
+        ensureVideoSource()
+        ensureLocalVideoTrack(enabled = false)
+        val started = screenShareController.startScreenShare(intent)
+        if (!started) {
+            if (createdVideoTrack && cameraController.availableCameraModes.isEmpty()) {
+                disposeLocalVideoTrack()
+            }
+            return false
+        }
+        localVideoTrack?.setEnabled(true)
+        peerSlots.forEach { slot ->
+            slot.attachLocalTracks(localAudioTrack, localVideoTrack)
+        }
+        return true
     }
 
     override fun stopScreenShare(): Boolean {
-        return screenShareController.stopScreenShare()
+        val stopped = screenShareController.stopScreenShare()
+        if (stopped && cameraController.availableCameraModes.isEmpty()) {
+            localVideoTrack?.setEnabled(false)
+            peerSlots.forEach { slot ->
+                slot.attachLocalTracks(localAudioTrack, null)
+            }
+        }
+        return stopped
     }
 
     fun setRemoteBlackFrameAnalysisEnabled(enabled: Boolean) {
@@ -390,6 +435,7 @@ internal class WebRtcEngine(
             iceServers = iceServers,
             localAudioTrack = localAudioTrack,
             localVideoTrack = localVideoTrack,
+            videoReceiveEnabled = videoMediaEnabled,
             onLocalIceCandidate = onLocalIceCandidate,
             onRemoteVideoTrack = onRemoteVideoTrack,
             onConnectionStateChange = onConnectionStateChange,

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -240,7 +240,11 @@ internal class WebRtcEngine(
     }
 
     private fun ensureLocalVideoTrack(enabled: Boolean): VideoTrack {
-        return localVideoTrack ?: peerConnectionFactory.createVideoTrack("ARDAMSv0", ensureVideoSource()).also { track ->
+        localVideoTrack?.let { track ->
+            track.setEnabled(enabled)
+            return track
+        }
+        return peerConnectionFactory.createVideoTrack("ARDAMSv0", ensureVideoSource()).also { track ->
             track.setEnabled(enabled)
             localSinks.forEach { sink -> track.addSink(sink) }
             localVideoTrack = track

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -263,19 +263,13 @@ internal class WebRtcEngine(
         localVideoTrack?.setEnabled(false)
         localAudioTrack?.setEnabled(false)
         cameraController.disposeVideoCapturer()
-        localVideoTrack?.let { track ->
-            localSinks.forEach { sink -> track.removeSink(sink) }
-            track.dispose()
-        }
+        disposeLocalVideoTrack()
         // Tear down the primer before disposing its audio track — closing the
         // PC first releases the sender's reference to the track.
         audioPipelinePrimer.stop()
         localAudioTrack?.dispose()
-        videoSource?.dispose()
-        videoSource = null
         audioSource?.dispose()
         audioSource = null
-        localVideoTrack = null
         localAudioTrack = null
     }
 
@@ -389,11 +383,10 @@ internal class WebRtcEngine(
     override fun startScreenShare(intent: Intent): Boolean {
         if (!videoMediaEnabled) return false
         val createdVideoTrack = localVideoTrack == null
-        ensureVideoSource()
         ensureLocalVideoTrack(enabled = false)
         val started = screenShareController.startScreenShare(intent)
         if (!started) {
-            if (createdVideoTrack && cameraController.availableCameraModes.isEmpty()) {
+            if (createdVideoTrack && !cameraController.canCaptureVideo) {
                 disposeLocalVideoTrack()
             }
             return false
@@ -407,7 +400,7 @@ internal class WebRtcEngine(
 
     override fun stopScreenShare(): Boolean {
         val stopped = screenShareController.stopScreenShare()
-        if (stopped && cameraController.availableCameraModes.isEmpty()) {
+        if (stopped && !cameraController.canCaptureVideo) {
             localVideoTrack?.setEnabled(false)
             peerSlots.forEach { slot ->
                 slot.attachLocalTracks(localAudioTrack, null)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
@@ -10,6 +10,7 @@ import app.serenada.core.call.AudioDeviceStatus
 import app.serenada.core.call.AudioIntent
 import app.serenada.core.call.SerenadaAudioCoordinator
 import app.serenada.core.call.WebRtcResilienceConstants
+import android.content.Intent
 import android.os.Looper
 import app.serenada.core.fakes.TestSessionFactory
 import kotlinx.coroutines.CompletableDeferred
@@ -85,6 +86,41 @@ class SerenadaSessionContractTest {
 
         assertEquals(false, factory.fakeMedia.startVideoCaptureCalls.single())
         assertFalse(factory.session.state.value.localVideoEnabled)
+    }
+
+    @Test
+    fun `strict audio only starts without camera and blocks screen share`() {
+        factory.tearDown()
+        factory = TestSessionFactory(videoMediaEnabled = false)
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+        factory.session.startScreenShare(Intent())
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(false, factory.fakeMedia.startVideoCaptureCalls.single())
+        assertFalse(factory.session.state.value.localVideoEnabled)
+        assertTrue(factory.session.state.value.availableCameraModes.isEmpty())
+        assertEquals(0, factory.fakeMedia.startScreenShareCalls)
+    }
+
+    @Test
+    fun `empty camera modes can still request screen share`() {
+        factory.tearDown()
+        factory = TestSessionFactory(cameraModes = emptyList())
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+        factory.session.startScreenShare(Intent())
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(false, factory.fakeMedia.startVideoCaptureCalls.single())
+        assertTrue(factory.session.state.value.availableCameraModes.isEmpty())
+        assertEquals(1, factory.fakeMedia.startScreenShareCalls)
     }
 
     @Test

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/FakeMediaEngine.kt
@@ -30,6 +30,8 @@ internal class FakeMediaEngine : SessionMediaEngine {
     private var _iceServers: List<PeerConnection.IceServer>? = null
 
     val startVideoCaptureCalls = mutableListOf<Boolean>()
+    var startScreenShareCalls = 0
+        private set
 
     override fun startLocalMedia(startVideoCapture: Boolean) {
         startLocalMediaCalls++
@@ -42,7 +44,10 @@ internal class FakeMediaEngine : SessionMediaEngine {
         return enabled
     }
     override fun flipCamera() {}
-    override fun startScreenShare(intent: Intent): Boolean = false
+    override fun startScreenShare(intent: Intent): Boolean {
+        startScreenShareCalls++
+        return false
+    }
     override fun stopScreenShare(): Boolean = false
 
     override fun setIceServers(servers: List<PeerConnection.IceServer>) {

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
@@ -2,6 +2,7 @@ package app.serenada.core.fakes
 
 import app.serenada.core.SerenadaConfig
 import app.serenada.core.SerenadaSession
+import app.serenada.core.call.LocalCameraMode
 import app.serenada.core.call.SerenadaAudioCoordinator
 import app.serenada.core.call.SessionClock
 import okhttp3.OkHttpClient
@@ -22,6 +23,8 @@ internal class TestSessionFactory(
     val roomId: String = "test-room-id",
     val handlesReconnection: Boolean = false,
     defaultVideoEnabled: Boolean = true,
+    videoMediaEnabled: Boolean = true,
+    cameraModes: List<LocalCameraMode>? = null,
     deferInitialAnswer: Boolean = false,
     audioCoordinator: SerenadaAudioCoordinator? = null,
     config: SerenadaConfig? = null,
@@ -38,6 +41,8 @@ internal class TestSessionFactory(
         config = config ?: SerenadaConfig(
             signalingProvider = fakeProvider,
             defaultVideoEnabled = defaultVideoEnabled,
+            videoMediaEnabled = videoMediaEnabled,
+            cameraModes = cameraModes,
             deferInitialAnswer = deferInitialAnswer,
             audioCoordinator = audioCoordinator,
         ),

--- a/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CameraCaptureController.swift
@@ -32,6 +32,9 @@ final class CameraCaptureController {
     private(set) var currentZoomFactor: CGFloat = 1
     var availableCameraModes: [LocalCameraMode] = [.selfie, .world, .composite]
 
+    /// True when this device has at least one camera mode available to capture video with.
+    var canCaptureVideo: Bool { !availableCameraModes.isEmpty }
+
 #if canImport(WebRTC)
     private(set) var localVideoCapturer: RTCCameraVideoCapturer?
     private(set) var compositeVideoCapturer: CompositeCameraVideoCapturer?

--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -131,6 +131,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
     private let onIceConnectionStateChange: (String, String) -> Void
     private let onSignalingStateChange: (String, String) -> Void
     private let onRenegotiationNeeded: (String) -> Void
+    private let videoReceiveEnabled: Bool
     private let logger: SerenadaLogger?
     private let rendererAttachmentQueue: DispatchQueue
 
@@ -157,6 +158,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
         iceServers: [IceServerConfig]?,
         localAudioTrack: RTCAudioTrack?,
         localVideoTrack: RTCVideoTrack?,
+        videoReceiveEnabled: Bool = true,
         onLocalIceCandidate: @escaping (String, IceCandidatePayload) -> Void,
         onRemoteVideoTrack: @escaping (String, RTCVideoTrack?) -> Void,
         onConnectionStateChange: @escaping (String, String) -> Void,
@@ -170,6 +172,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
         self.iceServers = iceServers
         self.localAudioTrack = localAudioTrack
         self.localVideoTrack = localVideoTrack
+        self.videoReceiveEnabled = videoReceiveEnabled
         self.onLocalIceCandidate = onLocalIceCandidate
         self.onRemoteVideoTrack = onRemoteVideoTrack
         self.onConnectionStateChange = onConnectionStateChange
@@ -265,6 +268,14 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
             onRemoteVideoTrack: { [weak self] track in
                 Task { @MainActor in
                     guard let self else { return }
+                    guard self.videoReceiveEnabled else {
+                        self.logger?.log(
+                            .info,
+                            tag: "PeerConnection",
+                            "[\(self.remoteCid)] Ignoring remote video track because video media is disabled"
+                        )
+                        return
+                    }
                     self.remoteVideoTrack = track
                     self.attachRemoteTrackToRegisteredRenderers()
                     self.onRemoteVideoTrack(self.remoteCid, track)
@@ -745,7 +756,7 @@ private extension PeerConnectionSlot {
             transceiverInit.direction = .recvOnly
             _ = peerConnection.addTransceiver(of: .audio, init: transceiverInit)
         }
-        if peerConnection.transceivers.contains(where: { $0.mediaType == .video }) == false {
+        if videoReceiveEnabled && peerConnection.transceivers.contains(where: { $0.mediaType == .video }) == false {
             let transceiverInit = RTCRtpTransceiverInit()
             transceiverInit.direction = .recvOnly
             _ = peerConnection.addTransceiver(of: .video, init: transceiverInit)

--- a/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
@@ -130,7 +130,7 @@ final class ScreenShareController {
             guard self.broadcastFrameReader === reader, !self.isScreenSharing else { return }
             self.broadcastFrameReader?.stopListening()
             self.broadcastFrameReader = nil
-            if self.cameraController.availableCameraModes.isEmpty == false {
+            if self.cameraController.canCaptureVideo {
                 _ = self.cameraController.restartVideoCapturer(source: previousSource)
             }
             self.cameraController.notifyCameraModeAndFlash()
@@ -161,7 +161,7 @@ final class ScreenShareController {
                 self.isScreenSharing = false
                 self.cameraController.isScreenSharing = false
                 self.onStateChanged(false)
-                if self.cameraController.availableCameraModes.isEmpty == false {
+                if self.cameraController.canCaptureVideo {
                     _ = self.cameraController.restartVideoCapturer(source: previousSource)
                 }
                 self.cameraController.notifyCameraModeAndFlash()
@@ -192,7 +192,7 @@ final class ScreenShareController {
             let restoreSource = cameraController.preScreenShareCameraSource
             cameraController.preScreenShareCameraSource = .selfie
 #if canImport(WebRTC)
-            if cameraController.availableCameraModes.isEmpty {
+            if !cameraController.canCaptureVideo {
                 setLocalVideoTrackEnabled(false)
                 cameraController.localCameraSource = restoreSource
                 cameraController.notifyCameraModeAndFlash()

--- a/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
+++ b/client-ios/SerenadaCore/Sources/Call/ScreenShareController.swift
@@ -130,7 +130,9 @@ final class ScreenShareController {
             guard self.broadcastFrameReader === reader, !self.isScreenSharing else { return }
             self.broadcastFrameReader?.stopListening()
             self.broadcastFrameReader = nil
-            _ = self.cameraController.restartVideoCapturer(source: previousSource)
+            if self.cameraController.availableCameraModes.isEmpty == false {
+                _ = self.cameraController.restartVideoCapturer(source: previousSource)
+            }
             self.cameraController.notifyCameraModeAndFlash()
             onComplete?(false)
         }
@@ -159,7 +161,9 @@ final class ScreenShareController {
                 self.isScreenSharing = false
                 self.cameraController.isScreenSharing = false
                 self.onStateChanged(false)
-                _ = self.cameraController.restartVideoCapturer(source: previousSource)
+                if self.cameraController.availableCameraModes.isEmpty == false {
+                    _ = self.cameraController.restartVideoCapturer(source: previousSource)
+                }
                 self.cameraController.notifyCameraModeAndFlash()
                 onComplete?(false)
             }
@@ -188,7 +192,11 @@ final class ScreenShareController {
             let restoreSource = cameraController.preScreenShareCameraSource
             cameraController.preScreenShareCameraSource = .selfie
 #if canImport(WebRTC)
-            if isLocalVideoTrackEnabled() {
+            if cameraController.availableCameraModes.isEmpty {
+                setLocalVideoTrackEnabled(false)
+                cameraController.localCameraSource = restoreSource
+                cameraController.notifyCameraModeAndFlash()
+            } else if isLocalVideoTrackEnabled() {
                 _ = cameraController.restartVideoCapturer(source: restoreSource)
             } else {
                 cameraController.localCameraSource = restoreSource

--- a/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
+++ b/client-ios/SerenadaCore/Sources/Call/WebRtcEngine.swift
@@ -102,6 +102,7 @@ internal enum SessionDescriptionType {
 @MainActor
 internal final class WebRtcEngine: SessionMediaEngine {
     private let logger: SerenadaLogger?
+    private let videoMediaEnabled: Bool
 
     private let cameraController: CameraCaptureController
     private var screenShareController: ScreenShareController!
@@ -137,9 +138,11 @@ internal final class WebRtcEngine: SessionMediaEngine {
         onFeatureDegradation: @escaping (FeatureDegradationState) -> Void = { _ in },
         logger: SerenadaLogger? = nil,
         isHdVideoExperimentalEnabled: Bool,
+        videoMediaEnabled: Bool = true,
         availableCameraModes: [LocalCameraMode] = defaultCameraModes
     ) {
         self.logger = logger
+        self.videoMediaEnabled = videoMediaEnabled
 
 #if canImport(WebRTC)
         self.cameraController = CameraCaptureController(
@@ -249,17 +252,22 @@ internal final class WebRtcEngine: SessionMediaEngine {
         localAudioSource = factory.audioSource(with: RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil))
         localAudioTrack = factory.audioTrack(with: localAudioSource!, trackId: "ARDAMSa0")
 
-        localVideoSource = factory.videoSource()
-        localVideoTrack = factory.videoTrack(with: localVideoSource!, trackId: "ARDAMSv0")
+        if videoMediaEnabled {
+            localVideoSource = factory.videoSource()
+            localVideoTrack = factory.videoTrack(with: localVideoSource!, trackId: "ARDAMSv0")
 
-        cameraController.updateLocalVideoSource(localVideoSource)
+            cameraController.updateLocalVideoSource(localVideoSource)
 
-        let videoCaptureSupported = !cameraController.availableCameraModes.isEmpty
-        if preferVideo && videoCaptureSupported {
-            let started = cameraController.restartVideoCapturerFromAvailableModes()
-            localVideoTrack?.isEnabled = started
+            let videoCaptureSupported = !cameraController.availableCameraModes.isEmpty
+            if preferVideo && videoCaptureSupported {
+                let started = cameraController.restartVideoCapturerFromAvailableModes()
+                localVideoTrack?.isEnabled = started
+            } else {
+                localVideoTrack?.isEnabled = false
+                cameraController.notifyCameraModeAndFlash()
+            }
         } else {
-            localVideoTrack?.isEnabled = false
+            cameraController.updateLocalVideoSource(nil)
             cameraController.notifyCameraModeAndFlash()
         }
 
@@ -344,6 +352,7 @@ internal final class WebRtcEngine: SessionMediaEngine {
             iceServers: iceServers,
             localAudioTrack: localAudioTrack,
             localVideoTrack: localVideoTrack,
+            videoReceiveEnabled: videoMediaEnabled,
             onLocalIceCandidate: onLocalIceCandidate,
             onRemoteVideoTrack: { remoteCid, track in
                 onRemoteVideoTrack(remoteCid, track)
@@ -391,6 +400,10 @@ internal final class WebRtcEngine: SessionMediaEngine {
     @discardableResult
     public func toggleVideo(_ enabled: Bool) -> Bool {
 #if canImport(WebRTC)
+        guard videoMediaEnabled else {
+            localVideoTrack?.isEnabled = false
+            return false
+        }
         if enabled && cameraController.availableCameraModes.isEmpty && !screenShareController.isScreenSharing {
             localVideoTrack?.isEnabled = false
             return false
@@ -422,7 +435,11 @@ internal final class WebRtcEngine: SessionMediaEngine {
     }
 
     public func startScreenShare(onComplete: ((Bool) -> Void)? = nil) -> Bool {
-        screenShareController.startScreenShare(onComplete: onComplete)
+        guard videoMediaEnabled else {
+            onComplete?(false)
+            return false
+        }
+        return screenShareController.startScreenShare(onComplete: onComplete)
     }
 
     public func stopScreenShare() -> Bool {

--- a/client-ios/SerenadaCore/Sources/Models/CallState.swift
+++ b/client-ios/SerenadaCore/Sources/Models/CallState.swift
@@ -35,8 +35,8 @@ public struct LocalParticipant: Equatable {
     public var cameraMode: LocalCameraMode = .selfie
     /// Camera modes the user can cycle through, in preference order.
     /// Derived from `SerenadaConfig.cameraModes` minus modes unsupported on
-    /// this device. Empty means video is unavailable — call UIs should hide
-    /// the video toggle.
+    /// this device. Empty means camera video is unavailable — call UIs should
+    /// hide the camera video toggle.
     public var availableCameraModes: [LocalCameraMode] = defaultCameraModes
     /// Whether this participant is the room host.
     public var isHost: Bool = false

--- a/client-ios/SerenadaCore/Sources/SerenadaConfig.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaConfig.swift
@@ -26,13 +26,18 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
     /// camera permission is not required for the initial join even when camera modes are
     /// available; the SDK requests camera access lazily if the user enables video later.
     public var defaultVideoEnabled: Bool
+    /// Whether this call can negotiate any video media. Set to `false` for strict
+    /// audio-only calls such as PSTN: camera capture, screen sharing, and remote
+    /// video are all disabled. Defaults to `true`.
+    public var videoMediaEnabled: Bool
     /// Camera modes available in the call UI, in preference order. The first
     /// entry is the initial mode. When only one mode is listed the flip-camera
-    /// control is hidden; an empty array disables video entirely (the video
-    /// toggle is hidden and the camera is never requested). Modes unsupported
-    /// on the current device are silently dropped (`.composite` is dropped on
-    /// devices without multi-cam). `.screenShare` is always ignored — screen
-    /// sharing is controlled separately. Defaults to `[.selfie, .world, .composite]`.
+    /// control is hidden; an empty array disables camera capture (the video
+    /// toggle is hidden and the camera is never requested). Remote video and
+    /// screen sharing remain available unless `videoMediaEnabled` is `false`.
+    /// Modes unsupported on the current device are silently dropped (`.composite`
+    /// is dropped on devices without multi-cam). `.screenShare` is always ignored
+    /// — screen sharing is controlled separately. Defaults to `[.selfie, .world, .composite]`.
     public var cameraModes: [LocalCameraMode]?
     /// When `true`, defer the initial-negotiation offer-timeout/ICE-restart while the host peer
     /// awaits its first answer. Use for app-owned calls whose answer is gated on a remote action
@@ -53,6 +58,7 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
         signalingProvider: SignalingProvider? = nil,
         defaultAudioEnabled: Bool = true,
         defaultVideoEnabled: Bool = true,
+        videoMediaEnabled: Bool = true,
         cameraModes: [LocalCameraMode]? = nil,
         deferInitialAnswer: Bool = false,
         transports: [SerenadaTransport] = [.ws, .sse],
@@ -64,6 +70,7 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
         self.signalingProvider = signalingProvider
         self.defaultAudioEnabled = defaultAudioEnabled
         self.defaultVideoEnabled = defaultVideoEnabled
+        self.videoMediaEnabled = videoMediaEnabled
         self.cameraModes = cameraModes
         self.deferInitialAnswer = deferInitialAnswer
         self.transports = transports
@@ -76,6 +83,7 @@ public struct SerenadaConfig: Equatable, @unchecked Sendable {
         lhs.serverHost == rhs.serverHost
             && lhs.defaultAudioEnabled == rhs.defaultAudioEnabled
             && lhs.defaultVideoEnabled == rhs.defaultVideoEnabled
+            && lhs.videoMediaEnabled == rhs.videoMediaEnabled
             && lhs.cameraModes == rhs.cameraModes
             && lhs.deferInitialAnswer == rhs.deferInitialAnswer
             && lhs.transports == rhs.transports

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -135,6 +135,7 @@ public final class SerenadaCore {
                 signalingProvider: nil,
                 defaultAudioEnabled: config.defaultAudioEnabled,
                 defaultVideoEnabled: config.defaultVideoEnabled,
+                videoMediaEnabled: config.videoMediaEnabled,
                 cameraModes: config.cameraModes,
                 deferInitialAnswer: config.deferInitialAnswer,
                 transports: config.transports,

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -655,15 +655,24 @@ public final class SerenadaSession: ObservableObject {
     public func startScreenShare() {
         guard config.videoMediaEnabled else { return }
         guard !diagnostics.isScreenSharing else { return }
-        _ = webRtcEngine.startScreenShare { [weak self] started in
+        let wasVideoPreferred = userPreferredVideoEnabled
+        userPreferredVideoEnabled = true
+        let startedRequest = webRtcEngine.startScreenShare { [weak self] started in
             Task { @MainActor in
-                guard let self, started else { return }
+                guard let self else { return }
+                guard started else {
+                    self.userPreferredVideoEnabled = wasVideoPreferred
+                    return
+                }
                 self.commitSnapshot { s, d in
                     d.isScreenSharing = true; s.localParticipant.cameraMode = .screenShare; d.cameraZoomFactor = 1
                 }
                 self.signalingMessageRouter?.broadcastContentState(active: true, contentType: ContentTypeWire.screenShare)
                 self.applyLocalVideoPreference()
             }
+        }
+        if !startedRequest {
+            userPreferredVideoEnabled = wasVideoPreferred
         }
     }
 

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -304,6 +304,7 @@ public final class SerenadaSession: ObservableObject {
                 signalingProvider: nil,
                 defaultAudioEnabled: config.defaultAudioEnabled,
                 defaultVideoEnabled: config.defaultVideoEnabled,
+                videoMediaEnabled: config.videoMediaEnabled,
                 cameraModes: config.cameraModes,
                 deferInitialAnswer: config.deferInitialAnswer,
                 transports: config.transports,
@@ -342,7 +343,7 @@ public final class SerenadaSession: ObservableObject {
         self.roomId = roomId
         self.roomUrl = roomUrl
         self.config = config
-        self.availableCameraModes = SerenadaSession.resolveAvailableCameraModes(config.cameraModes)
+        self.availableCameraModes = config.videoMediaEnabled ? SerenadaSession.resolveAvailableCameraModes(config.cameraModes) : []
         self.displayName = displayName
         self.peerId = peerId
         self.delegateProvider = delegateProvider
@@ -383,6 +384,7 @@ public final class SerenadaSession: ObservableObject {
             onFlashlightStateChanged: { _, _ in }, onScreenShareStopped: {},
             onZoomFactorChanged: { _ in }, onFeatureDegradation: { _ in },
             logger: logger, isHdVideoExperimentalEnabled: false,
+            videoMediaEnabled: config.videoMediaEnabled,
             availableCameraModes: self.availableCameraModes
         )
 
@@ -651,6 +653,7 @@ public final class SerenadaSession: ObservableObject {
 
     /// Start screen sharing via the broadcast upload extension.
     public func startScreenShare() {
+        guard config.videoMediaEnabled else { return }
         guard !diagnostics.isScreenSharing else { return }
         _ = webRtcEngine.startScreenShare { [weak self] started in
             Task { @MainActor in

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/Fakes/FakeMediaEngine.swift
@@ -49,7 +49,12 @@ final class FakeMediaEngine: SessionMediaEngine {
     func flipCamera() {}
     func setHdVideoExperimentalEnabled(_ enabled: Bool) {}
     @discardableResult func toggleFlashlight() -> Bool { false }
-    func startScreenShare(onComplete: ((Bool) -> Void)?) -> Bool { false }
+    private(set) var startScreenShareCalls = 0
+    func startScreenShare(onComplete: ((Bool) -> Void)?) -> Bool {
+        startScreenShareCalls += 1
+        onComplete?(false)
+        return false
+    }
     func stopScreenShare() -> Bool { false }
     private(set) var adjustCaptureZoomCalls: [CGFloat] = []
     var adjustCaptureZoomResult: Double? = 1.25

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTests.swift
@@ -141,6 +141,53 @@ final class SerenadaSessionTests: XCTestCase {
         session.cancelJoin()
     }
 
+    func testStrictAudioOnlyHidesCameraModesAndBlocksScreenShare() async {
+        let provider = FakeSignalingProvider()
+        let media = FakeMediaEngine()
+        let session = SerenadaSession(
+            roomId: "provider-room",
+            config: SerenadaConfig(
+                signalingProvider: provider,
+                videoMediaEnabled: false,
+                audioCoordinator: FakeAudioCoordinator()
+            ),
+            initialSignalingProvider: provider,
+            mediaEngine: media
+        )
+
+        await yieldToMainActor()
+        session.startScreenShare()
+        await yieldToMainActor()
+
+        XCTAssertTrue(session.state.localParticipant.availableCameraModes.isEmpty)
+        XCTAssertFalse(session.state.requiredPermissions?.contains(.camera) ?? false)
+        XCTAssertEqual(media.startScreenShareCalls, 0)
+        session.cancelJoin()
+    }
+
+    func testEmptyCameraModesCanStillRequestScreenShare() async {
+        let provider = FakeSignalingProvider()
+        let media = FakeMediaEngine()
+        let session = SerenadaSession(
+            roomId: "provider-room",
+            config: SerenadaConfig(
+                signalingProvider: provider,
+                cameraModes: [],
+                audioCoordinator: FakeAudioCoordinator()
+            ),
+            initialSignalingProvider: provider,
+            mediaEngine: media
+        )
+
+        await yieldToMainActor()
+        session.startScreenShare()
+        await yieldToMainActor()
+
+        XCTAssertTrue(session.state.localParticipant.availableCameraModes.isEmpty)
+        XCTAssertEqual(media.startScreenShareCalls, 1)
+        session.cancelJoin()
+    }
+
     func testAudioSessionRestartedRestartsAudioUnitAndClearsExternalMute() async {
         let provider = FakeSignalingProvider()
         let media = FakeMediaEngine()

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -334,7 +334,8 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.handlesReconnection = signaling.capabilities?.handlesReconnection === true;
         this.displayName = deps.displayName;
         this.appPeerId = deps.peerId;
-        this.availableCameraModes = Object.freeze(resolveCameraModes(config.cameraModes)) as ConfigurableCameraMode[];
+        const videoMediaEnabled = config.videoMediaEnabled !== false;
+        this.availableCameraModes = Object.freeze(videoMediaEnabled ? resolveCameraModes(config.cameraModes) : []) as ConfigurableCameraMode[];
         this.userPreferredVideoEnabled = this.availableCameraModes.length > 0 && config.defaultVideoEnabled !== false;
 
         this._state = {
@@ -358,6 +359,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
                 initialFacingMode: initialCameraMode === 'world' ? 'environment' : 'user',
                 initialVideoEnabled: this.userPreferredVideoEnabled,
                 videoCaptureSupported: this.availableCameraModes.length > 0,
+                videoMediaEnabled,
                 deferInitialAnswer: config.deferInitialAnswer === true,
             },
             (type, payload, to) => {
@@ -527,6 +529,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
 
     /** Start sharing the screen, replacing the camera video track. */
     async startScreenShare(): Promise<void> {
+        if (this.config.videoMediaEnabled === false) return;
         const wasScreenSharing = this.media.isScreenSharing;
         await this.media.startScreenShare();
         if (!this.isInactive && !wasScreenSharing && this.media.isScreenSharing) {

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -1080,6 +1080,9 @@ export class MediaEngine {
             }
             throw err;
         }
+        if (!this.videoMediaEnabled) {
+            this.rejectRemoteVideoTransceivers(peer.pc, fromCid);
+        }
         peer.acceptedRemoteOfferId = offerId;
         peer.currentNegotiationId = offerId;
         if (peer.offerTimeout) { window.clearTimeout(peer.offerTimeout); peer.offerTimeout = null; }
@@ -1475,11 +1478,30 @@ export class MediaEngine {
         }
     }
 
+    private rejectRemoteVideoTransceivers(pc: RTCPeerConnection, remoteCid: string): void {
+        for (const transceiver of pc.getTransceivers().filter(candidate => this.isTransceiverKind(candidate, 'video'))) {
+            try {
+                if (transceiver.direction !== 'inactive' && transceiver.direction !== 'stopped') {
+                    transceiver.direction = 'inactive';
+                }
+            } catch (err) {
+                this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Failed to reject remote video transceiver: ${formatError(err)}`);
+            }
+            if (transceiver.sender.track?.kind === 'video') {
+                void transceiver.sender.replaceTrack(null).catch(err => {
+                    this.logger?.log('warning', 'WebRTC', `[${remoteCid}] Failed to detach rejected video sender: ${formatError(err)}`);
+                });
+            }
+        }
+    }
+
     private findTransceiver(pc: RTCPeerConnection, kind: 'audio' | 'video'): RTCRtpTransceiver | undefined {
-        const transceivers = pc.getTransceivers().filter(transceiver => (
-            transceiver.receiver.track?.kind === kind || transceiver.sender.track?.kind === kind
-        ));
+        const transceivers = pc.getTransceivers().filter(transceiver => this.isTransceiverKind(transceiver, kind));
         return transceivers.find(transceiver => transceiver.mid !== null) ?? transceivers[0];
+    }
+
+    private isTransceiverKind(transceiver: RTCRtpTransceiver, kind: 'audio' | 'video'): boolean {
+        return transceiver.receiver.track?.kind === kind || transceiver.sender.track?.kind === kind;
     }
 
     private async attachLocalTracksToPeer(remoteCid: string, peer: PeerState, stream: MediaStream): Promise<void> {

--- a/client/packages/core/src/media/MediaEngine.ts
+++ b/client/packages/core/src/media/MediaEngine.ts
@@ -83,6 +83,8 @@ export interface MediaEngineConfig {
     initialVideoEnabled?: boolean;
     /** When `false`, the camera is never requested and video is always off. */
     videoCaptureSupported?: boolean;
+    /** When `false`, no video media is negotiated or received. */
+    videoMediaEnabled?: boolean;
     /** Defer initial offer timeout/ICE restart while awaiting the first answer. */
     deferInitialAnswer?: boolean;
 }
@@ -91,10 +93,11 @@ export class MediaEngine {
     localStream: MediaStream | null = null;
     remoteStreams = new Map<string, MediaStream>();
     isScreenSharing = false;
-    canScreenShare = !!navigator.mediaDevices?.getDisplayMedia;
+    canScreenShare = false;
     facingMode: 'user' | 'environment' = 'user';
     hasMultipleCameras = false;
     readonly videoCaptureSupported: boolean;
+    readonly videoMediaEnabled: boolean;
     iceConnectionState: RTCIceConnectionState = 'new';
     connectionState: RTCPeerConnectionState = 'new';
     signalingState: RTCSignalingState = 'stable';
@@ -151,7 +154,9 @@ export class MediaEngine {
         this.logger = config.logger;
         this.facingMode = config.initialFacingMode ?? 'user';
         this.initialVideoEnabled = config.initialVideoEnabled !== false;
-        this.videoCaptureSupported = config.videoCaptureSupported !== false;
+        this.videoMediaEnabled = config.videoMediaEnabled !== false;
+        this.videoCaptureSupported = this.videoMediaEnabled && config.videoCaptureSupported !== false;
+        this.canScreenShare = this.videoMediaEnabled && !!navigator.mediaDevices?.getDisplayMedia;
         this.sendSignalingMessage = sendMessage;
         this.setupEventListeners();
     }
@@ -717,6 +722,10 @@ export class MediaEngine {
         this.ensureMediaTransceivers(pc);
 
         pc.ontrack = (event) => {
+            if (event.track.kind === 'video' && !this.videoMediaEnabled) {
+                this.logger?.log('info', 'WebRTC', `[${remoteCid}] Ignoring remote video track because video media is disabled`);
+                return;
+            }
             this.logger?.log('debug', 'WebRTC', `[${remoteCid}] Remote track received`);
             let remoteStream: MediaStream;
             if (event.streams?.[0]) {
@@ -1272,7 +1281,7 @@ export class MediaEngine {
                 if (videoTransceiver) {
                     try {
                         await videoTransceiver.sender.replaceTrack(newTrack);
-                        if (videoTransceiver.direction !== 'sendrecv' && videoTransceiver.direction !== 'stopped' && this.videoCaptureSupported) {
+                        if (newTrack && videoTransceiver.direction !== 'sendrecv' && videoTransceiver.direction !== 'stopped' && this.videoMediaEnabled) {
                             videoTransceiver.direction = 'sendrecv';
                         }
                         if (newTrack && this.needsLocalTrackNegotiation(videoTransceiver)) {
@@ -1461,7 +1470,7 @@ export class MediaEngine {
         if (!this.findTransceiver(pc, 'audio') && !pc.getSenders().some(sender => sender.track?.kind === 'audio')) {
             pc.addTransceiver('audio', { direction: 'recvonly' });
         }
-        if (!this.findTransceiver(pc, 'video') && !pc.getSenders().some(sender => sender.track?.kind === 'video')) {
+        if (this.videoMediaEnabled && !this.findTransceiver(pc, 'video') && !pc.getSenders().some(sender => sender.track?.kind === 'video')) {
             pc.addTransceiver('video', { direction: this.videoCaptureSupported ? 'sendrecv' : 'recvonly' });
         }
     }

--- a/client/packages/core/src/types.ts
+++ b/client/packages/core/src/types.ts
@@ -75,8 +75,8 @@ export interface LocalParticipant {
     /**
      * Camera modes the user can cycle through, in preference order.
      * Derived from {@link SerenadaConfig.cameraModes} minus modes unsupported
-     * on this device/platform. An empty array means video is unavailable
-     * — the call UI should hide the video toggle.
+     * on this device/platform. An empty array means camera video is unavailable
+     * — the call UI should hide the camera video toggle.
      */
     availableCameraModes: ConfigurableCameraMode[];
     isHost: boolean;
@@ -192,12 +192,20 @@ export interface SerenadaConfig {
     /** Whether the camera is enabled when joining. Defaults to `true`. */
     defaultVideoEnabled?: boolean;
     /**
+     * Whether this call can negotiate any video media. Set to `false` for strict
+     * audio-only calls such as PSTN: camera capture, screen sharing, and remote
+     * video are all disabled. Defaults to `true`.
+     */
+    videoMediaEnabled?: boolean;
+    /**
      * Camera modes available in the call UI, in preference order. The first
      * entry is the initial mode. When only one mode is listed the flip-camera
-     * control is hidden; an empty array disables video entirely (the video
-     * toggle is hidden and the camera is never requested). Modes unsupported
-     * on the current platform or device are silently dropped (`'composite'`
-     * is always dropped on web). Defaults to `['selfie', 'world', 'composite']`.
+     * control is hidden; an empty array disables camera capture (the video
+     * toggle is hidden and the camera is never requested). Remote video and
+     * screen sharing remain available unless `videoMediaEnabled` is `false`.
+     * Modes unsupported on the current platform or device are silently dropped
+     * (`'composite'` is always dropped on web). Defaults to
+     * `['selfie', 'world', 'composite']`.
      */
     cameraModes?: ConfigurableCameraMode[];
     /**

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -1474,6 +1474,48 @@ describe('SerenadaSession', () => {
             expect(harness.state.localParticipant?.videoEnabled).toBe(true);
         });
 
+        it('allows screen share when camera modes are empty', async () => {
+            harness = new TestSessionHarness({
+                config: { cameraModes: [] },
+            });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-1' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = true;
+                harness.media.localStream = createMediaStream({ audio: true, video: true });
+            });
+
+            await harness.session.startScreenShare();
+
+            expect(harness.state.localParticipant?.availableCameraModes).toEqual([]);
+            expect(harness.media.startScreenShare).toHaveBeenCalledTimes(1);
+            expect(harness.state.localParticipant?.videoEnabled).toBe(true);
+        });
+
+        it('blocks screen share in strict audio-only mode', async () => {
+            harness = new TestSessionHarness({
+                config: { videoMediaEnabled: false },
+            });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-1' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = true;
+            });
+
+            await harness.session.startScreenShare();
+
+            expect(harness.state.localParticipant?.availableCameraModes).toEqual([]);
+            expect(harness.media.startScreenShare).not.toHaveBeenCalled();
+        });
+
         it('does not rebroadcast local media state when screen share start is a no-op', async () => {
             harness = new TestSessionHarness();
             harness.media.startLocalMediaResult = createMediaStream({ audio: true });


### PR DESCRIPTION
## Summary

Adds an explicit `videoMediaEnabled` SDK configuration across Android, iOS, and web so PSTN integrations can request strict audio-only calls without overloading `cameraModes`.

- `videoMediaEnabled: false` disables all video media: camera capture, screen sharing, remote video receive, and video negotiation.
- `cameraModes: []` now means no local camera capture while preserving remote video/screen-share support for P2P calls.
- Updates Android/iOS/web media engines, peer slots, session state docs, and focused tests for strict audio-only versus no-camera P2P behavior.

## Why

The previous Android-only approach used an empty camera-mode list as the signal to disable remote video negotiation for PSTN. That cleaned up PSTN calls, but it conflated two different modes: strict audio-only PSTN and no-camera/video-disabled P2P calls that should still support remote video and screen sharing.

## Validation

- `npm test -- --run packages/core/test/SerenadaSession.test.ts`
- `npm test -- --run packages/core/test/media/MediaEngine.test.ts`
- `npm run build`
- `./gradlew :serenada-core:testDebugUnitTest --tests app.serenada.core.SerenadaSessionContractTest`
- `xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaCore -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' build`

Notes: iOS XCTest was not runnable from the current project setup because the `SerenadaCore` scheme is not configured for the test action, and SwiftPM test is blocked by the existing UIKit package build limitation.

Co-authored by Codex (GPT-5 high effort)