### PR TITLE
Release Serenada SDK 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.7] — 2026-06-21
+
+### Added
+- Web, Android, iOS: `deferInitialAnswer` lets provider-owned calls keep
+  the first offer alive while waiting for a delayed first answer, such as a
+  PSTN pickup, then resumes normal renegotiation timing after that answer.
+- Web, Android, iOS: `videoMediaEnabled` adds strict audio-only media mode,
+  disabling camera capture, screen sharing, video transceivers, and remote
+  video for calls that must not negotiate video.
+
+### Changed
+- Web, Android, iOS: empty `cameraModes` now means no local camera capture;
+  screen sharing and remote video remain available unless
+  `videoMediaEnabled` is `false`.
+- Web, Android, iOS: deferred-answer two-party calls use host-based offerer
+  election so app-owned bridge/PSTN calls can reliably keep the app as the
+  initial offerer.
+
 ## [0.8.6] — 2026-06-14
 
 ### Fixed

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -84,9 +84,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.6`
-- `app.serenada:core:0.8.6`
-- `app.serenada:call-ui:0.8.6`
+- `app.serenada:libwebrtc-7827-universal:0.8.7`
+- `app.serenada:core:0.8.7`
+- `app.serenada:call-ui:0.8.7`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.6"
+                version = "0.8.7"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.6"
+val sdkVersion = "0.8.7"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.8.6"
+        const val VERSION = "0.8.7"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.6"
+val sdkVersion = "0.8.7"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.6"
+    public static let version = "0.8.7"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.6",
-        "@agatx/serenada-react-ui": "0.8.6",
+        "@agatx/serenada-core": "0.8.7",
+        "@agatx/serenada-react-ui": "0.8.7",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.6"
+        "@agatx/serenada-core": "0.8.7"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.6",
+        "@agatx/serenada-core": "^0.8.7",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.6",
+  "version": "0.8.7",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.6",
-    "@agatx/serenada-react-ui": "0.8.6",
+    "@agatx/serenada-core": "0.8.7",
+    "@agatx/serenada-react-ui": "0.8.7",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.6';
+export const SERENADA_CORE_VERSION = '0.8.7';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.6",
+    "@agatx/serenada-core": "^0.8.7",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.6"
+    "@agatx/serenada-core": "0.8.7"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-api-reference.md
+++ b/docs/sdk/sdk-api-reference.md
@@ -13,6 +13,15 @@ All SDKs validate `SerenadaConfig` at construction time. Provide exactly one of:
 
 Provider mode keeps the same session/call APIs, but server-bound helpers are unavailable. `createRoom()`, native `createRoomId()`, `RoomWatcher`, `validateServerHost()`, and `runConnectivityChecks()` require `serverHost` and fail with `requires serverHost` when used in provider mode.
 
+### Media and negotiation configuration
+
+All SDKs expose the same media/negotiation flags on `SerenadaConfig`:
+
+- `defaultVideoEnabled`: controls whether camera capture starts enabled when video capture is available.
+- `cameraModes`: restricts local camera capture modes and order. An empty list disables camera capture and hides camera controls, but does not disable screen sharing or remote video by itself.
+- `videoMediaEnabled`: set to `false` for strict audio-only calls. The SDK disables camera capture, screen sharing, video transceivers, and remote video.
+- `deferInitialAnswer`: set to `true` for provider-owned calls where the host peer may wait longer than the normal offer timeout for the first answer, such as PSTN pickup. The SDK suppresses first-answer offer-timeout/ICE-restart churn until the first answer is applied; later renegotiations use normal timing.
+
 ### `createRoom()`
 
 Create a new room. Returns the room URL and ID. Call `join()` to start the call.

--- a/docs/sdk/sdk-customization.md
+++ b/docs/sdk/sdk-customization.md
@@ -69,7 +69,7 @@ Provider mode does not expose Serenada server helpers. These APIs require `serve
 |---|---|---|---|
 | `uiVariant` | `SerenadaCallUiVariant` | `Standard` | Android and iOS. Selects the visual presentation for the prebuilt call UI. `Frontline` uses an audio-first layout optimized for large touch targets and field use, and keeps Frontline styling across lifecycle, 1:1, and multi-party states. |
 | `screenSharingEnabled` | Bool | `true` | Show/hide the screen-share control when the current browser/device supports screen capture |
-| `videoEnabled` | Bool | `true` | When `true`, the video on/off and camera-mode (flip) controls appear and the SDK requests camera permission on join. When `false`, both controls are hidden and URL-first call flows configure the internally-created session with no camera modes (camera is never requested). Session-first hosts that want audio-only should also pass `cameraModes: []` to `SerenadaConfig`. |
+| `videoEnabled` | Bool | `true` | When `true`, the video on/off and camera-mode (flip) controls appear and the SDK requests camera permission on join. When `false`, both controls are hidden and URL-first call flows configure the internally-created session with no camera modes (camera is never requested). Session-first hosts that need strict audio-only media should pass `videoMediaEnabled: false` / `videoMediaEnabled = false` to `SerenadaConfig`. |
 | `inviteControlsEnabled` | Bool | `true` | Show/hide the built-in QR code and share-link UI in the waiting screen |
 | `debugOverlayEnabled` | Bool | `false` | Show/hide the in-call debug toggle and diagnostics panel |
 | `autoHideControls` | Bool | `true` | When `true`, the call controls bar fades out after a few seconds of idle time and a tap on the stage brings it back. When `false`, the controls stay visible for the entire call and the idle timer never runs. |
@@ -192,11 +192,11 @@ Frontline v1 shows the current audio route as the first More sheet item. Android
 
 ## Camera Modes
 
-`SerenadaConfig.cameraModes` is a core-level setting that restricts which camera modes (`selfie`, `world`, `composite`) are available and in what order. It affects the call UI in three ways:
+`SerenadaConfig.cameraModes` is a core-level setting that restricts which camera modes (`selfie`, `world`, `composite`) are available and in what order. It controls camera capture only; set `videoMediaEnabled` to `false` for strict audio-only calls where the SDK must not negotiate or receive video media. It affects the call UI in three ways:
 
 - **Initial mode**: the first supported entry of the list is used when media starts.
 - **Flip-camera control**: hidden when only one mode is configured (nothing to cycle to). Also hidden while the local video is turned off.
-- **Video toggle & camera permission**: when the list is empty, the SDK treats the call as audio-only — the video toggle is hidden entirely and the camera is never requested. When camera modes are present but `defaultVideoEnabled` is `false`, the call joins with video off and requests camera access only if the user enables video.
+- **Video toggle & camera permission**: when the list is empty, the video toggle is hidden and the camera is never requested. Remote video and screen sharing can still work unless `videoMediaEnabled` is `false`. When camera modes are present but `defaultVideoEnabled` is `false`, the call joins with video off and requests camera access only if the user enables video.
 
 Platform-unsupported modes are dropped silently (`composite` on web; `composite` on devices without multi-camera support on iOS / Android). If a native camera source still fails at runtime, startup retries the remaining configured modes before continuing audio-only. `screenShare` is rejected — screen sharing is controlled separately.
 
@@ -205,7 +205,9 @@ Platform-unsupported modes are dropped silently (`composite` on web; `composite`
 | `[selfie, world, composite]` (default) | All supported camera modes available, start in selfie. |
 | `[world, selfie]` | Start in world (rear) camera; flip toggles between world and selfie. |
 | `[selfie]` | Selfie only — flip-camera control hidden. |
-| `[]` | Audio-only call — video toggle and camera controls hidden. |
+| `[]` | Camera capture disabled — video toggle and camera controls hidden; screen sharing and remote video remain available unless `videoMediaEnabled` is `false`. |
+
+For strict audio-only calls, such as PSTN bridge flows, set `videoMediaEnabled` to `false`. That disables camera capture, screen sharing, video transceivers, and remote video across web, Android, and iOS. If the provider may delay the first answer while waiting for a remote action such as human pickup, set `deferInitialAnswer` to `true`; the host peer keeps the initial offer alive and suppresses offer-timeout/ICE-restart churn until the first answer is applied.
 
 ### iOS
 

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.6")
-    implementation("app.serenada:call-ui:0.8.6")
+    implementation("app.serenada:core:0.8.7")
+    implementation("app.serenada:call-ui:0.8.7")
 }
 ```
 
@@ -490,7 +490,9 @@ val config = SerenadaConfig(
     serverHost = "serenada.app",      // required
     defaultAudioEnabled = true,       // mic on at join (default)
     defaultVideoEnabled = true,       // camera on at join (default)
-    cameraModes = DEFAULT_CAMERA_MODES, // available modes & cycle order; empty = audio-only (default: all supported modes)
+    videoMediaEnabled = true,          // set false for strict audio-only/PSTN calls
+    cameraModes = DEFAULT_CAMERA_MODES, // available camera modes & cycle order; empty = no camera capture
+    deferInitialAnswer = false,        // set true when a provider may delay the first answer
     transports = listOf(SerenadaTransport.WS, SerenadaTransport.SSE), // transport priority (default)
     audioCoordinator = null,          // custom SerenadaAudioCoordinator, or internal default
     audioIntent = AudioIntent(),      // audio policy passed to the coordinator

--- a/docs/sdk/sdk-integration-ios.md
+++ b/docs/sdk/sdk-integration-ios.md
@@ -402,7 +402,9 @@ let config = SerenadaConfig(
     serverHost: "serenada.app",       // required
     defaultAudioEnabled: true,        // mic on at join (default)
     defaultVideoEnabled: true,        // camera on at join (default)
-    cameraModes: [.selfie, .world, .composite], // available modes & cycle order; empty = audio-only (default: all supported modes)
+    videoMediaEnabled: true,        // set false for strict audio-only/PSTN calls
+    cameraModes: [.selfie, .world, .composite], // available camera modes & cycle order; empty = no camera capture
+    deferInitialAnswer: false,      // set true when a provider may delay the first answer
     transports: [.ws, .sse],          // transport priority (default)
     audioCoordinator: nil,            // custom SerenadaAudioCoordinator, or internal default
     audioIntent: AudioIntent()        // audio policy passed to the coordinator

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.6 @agatx/serenada-react-ui@0.8.6 lucide-react
+npm install @agatx/serenada-core@0.8.7 @agatx/serenada-react-ui@0.8.7 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.
@@ -360,7 +360,9 @@ const serenada = createSerenadaCore({
     serverHost: 'serenada.app',    // required; bare host or full origin
     defaultAudioEnabled: true,     // mic on at join (default)
     defaultVideoEnabled: true,     // camera on at join (default)
-    cameraModes: ['selfie', 'world', 'composite'], // available modes & cycle order; empty = audio-only (default: all supported modes)
+    videoMediaEnabled: true,       // set false for strict audio-only/PSTN calls
+    cameraModes: ['selfie', 'world', 'composite'], // available camera modes & cycle order; empty = no camera capture
+    deferInitialAnswer: false,     // set true when a provider may delay the first answer
     transports: ['ws', 'sse'],     // transport priority (default)
     turnsOnly: false,              // optional; only use TURN relays when true
 })

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.6"
+        "@agatx/serenada-core": "0.8.7"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.6",
+        "@agatx/serenada-core": "^0.8.7",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
Summary
- Bump Serenada SDK packages and runtime constants to 0.8.7 across web, Android, and iOS.
- Update integration/API/customization docs for videoMediaEnabled, deferInitialAnswer, and cameraModes semantics.
- Regenerate web app and sample lockfiles for the new local package versions.

Validation
- node scripts/check-version-parity.mjs
- node scripts/check-signaling-protocol-constants.mjs
- node scripts/check-resilience-constants.mjs
- cd client && npm test
- cd client && npm run build
- cd client && npm run build:publish --workspace @agatx/serenada-core
- cd client && npm run build:publish --workspace @agatx/serenada-react-ui
- cd client && npm pack --dry-run --workspace @agatx/serenada-core
- cd client && npm pack --dry-run --workspace @agatx/serenada-react-ui
- cd samples/web && npm run build
- cd client-android && ./gradlew :serenada-core:testDebugUnitTest --console=plain
- cd client-ios && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9 -only-testing:SerenadaiOSTests test CODE_SIGNING_ALLOWED=NO

Co-authored by Codex (GPT-5 medium)