### PR TITLE
Release Serenada SDK 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.9.0] — 2026-06-25
+
+### Added
+- Web, Android, iOS: independent screen-share content video support behind
+  `enableIndependentContentVideo`, allowing capable peers to keep camera video
+  active while sending or receiving screen share on a separate content stream.
+- Web, Android, iOS, server: `content_state` signaling and participant content
+  metadata advertise screen-share activity and revisions so UIs can render
+  dedicated content tiles across one-to-one and multi-party calls.
+
+### Changed
+- Web, Android, iOS: prebuilt call UIs now render independent content streams
+  separately from camera tiles when enabled, while legacy or flag-off peers
+  continue using the single-video screen-share fallback per connection.
+
 ## [0.8.7] — 2026-06-21
 
 ### Added

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -85,9 +85,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.8.7`
-- `app.serenada:core:0.8.7`
-- `app.serenada:call-ui:0.8.7`
+- `app.serenada:libwebrtc-7827-universal:0.9.0`
+- `app.serenada:core:0.9.0`
+- `app.serenada:call-ui:0.9.0`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -66,7 +66,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.8.7"
+                version = "0.9.0"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.7"
+val sdkVersion = "0.9.0"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.8.7"
+        const val VERSION = "0.9.0"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.8.7"
+val sdkVersion = "0.9.0"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.8.7"
+    public static let version = "0.9.0"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.8.7",
-        "@agatx/serenada-react-ui": "0.8.7",
+        "@agatx/serenada-core": "0.9.0",
+        "@agatx/serenada-react-ui": "0.9.0",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.7"
+        "@agatx/serenada-core": "0.9.0"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.7",
+        "@agatx/serenada-core": "^0.9.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.8.7",
+  "version": "0.9.0",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.8.7",
-    "@agatx/serenada-react-ui": "0.8.7",
+    "@agatx/serenada-core": "0.9.0",
+    "@agatx/serenada-react-ui": "0.9.0",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.8.7';
+export const SERENADA_CORE_VERSION = '0.9.0';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.8.7",
+    "@agatx/serenada-core": "^0.9.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.8.7"
+    "@agatx/serenada-core": "0.9.0"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.8.7")
-    implementation("app.serenada:call-ui:0.8.7")
+    implementation("app.serenada:core:0.9.0")
+    implementation("app.serenada:call-ui:0.9.0")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.8.7 @agatx/serenada-react-ui@0.8.7 lucide-react
+npm install @agatx/serenada-core@0.9.0 @agatx/serenada-react-ui@0.9.0 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.8.7"
+        "@agatx/serenada-core": "0.9.0"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.8.7",
+        "@agatx/serenada-core": "^0.9.0",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary
- bump Serenada SDK version references from 0.8.7 to 0.9.0 across web, Android, and iOS
- update web/Android integration docs, Android local publish docs, sample web lockfile, and changelog
- document 0.9.0 as the independent screen-share/content video SDK release

## Validation
- `node scripts/check-version-parity.mjs`
- `node scripts/check-signaling-protocol-constants.mjs`
- `node scripts/check-resilience-constants.mjs`
- `node scripts/check-telemetry-parity.mjs`
- `git diff --check`
- `cd client && npm ci --ignore-scripts`
- `cd client && npm test` (575 tests)
- `cd client && npm run build`
- `cd client && npm run build:publish --workspace @agatx/serenada-core && npm pack --dry-run --workspace @agatx/serenada-core`
- `cd client && npm run build:publish --workspace @agatx/serenada-react-ui && npm pack --dry-run --workspace @agatx/serenada-react-ui`
- `cd client && node -e "import('./packages/core/dist/index.js').then((m)=>{ if (m.SERENADA_CORE_VERSION !== '0.9.0') process.exit(1); console.log('core entrypoint ok', m.SERENADA_CORE_VERSION); })"`
- `cd client && node -e "import('./packages/react-ui/dist/index.js').then((m)=>{ if (!m.SerenadaCallFlow) process.exit(1); console.log('react-ui entrypoint ok'); })"`
- `cd samples/web && npm ci --ignore-scripts`
- `cd samples/web && npm run build`
- `cd server && go test ./...`
- `cd server && go build -o /tmp/serenada-server-sweep .`
- `cd client-android && ./gradlew --no-daemon assembleDebug :app:testDebugUnitTest :serenada-core:testDebugUnitTest --console=plain`
- `cd samples/android && ./gradlew --no-daemon :app:assembleDebug --console=plain`
- `cd client-ios && xcodebuild -project SerenadaiOS.xcodeproj -scheme SerenadaiOS -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' -only-testing:SerenadaiOSTests test CODE_SIGNING_ALLOWED=NO` (538 tests)
- `xcodebuild -project samples/ios/SerenadaiOSSample.xcodeproj -scheme SerenadaiOSSample -destination 'id=CA6FFD90-98C3-4580-BA33-11A912FC0BA9' build CODE_SIGNING_ALLOWED=NO`

Co-authored by Codex (GPT-5 medium)