### PR TITLE
IOS-4409: Add onMediaPermissionBlocked callback for denied in-call media toggles

### DIFF
--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -225,9 +225,9 @@ private struct URLFirstCallFlow: View {
             core = newCore
             let newSession = newCore.join(url: url)
             newSession.onPermissionsRequired = { permissions in
-                // Mirror the Android SDK: this callback covers both the join gate and in-call
-                // toggles. Disambiguate by phase so an in-call permission request never tears the
-                // live call down via cancelJoin().
+                // This callback covers both the join gate and in-call toggles. Disambiguate by
+                // phase so an in-call permission request never tears the live call down via
+                // cancelJoin().
                 let isJoin = newSession.state.phase == .awaitingPermissions
                 Task {
                     let granted = await SerenadaPermissions.request(permissions)

--- a/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
+++ b/client-ios/SerenadaCallUI/Sources/SerenadaCallFlow.swift
@@ -225,14 +225,25 @@ private struct URLFirstCallFlow: View {
             core = newCore
             let newSession = newCore.join(url: url)
             newSession.onPermissionsRequired = { permissions in
+                // Mirror the Android SDK: this callback covers both the join gate and in-call
+                // toggles. Disambiguate by phase so an in-call permission request never tears the
+                // live call down via cancelJoin().
+                let isJoin = newSession.state.phase == .awaitingPermissions
                 Task {
                     let granted = await SerenadaPermissions.request(permissions)
-                    if granted {
-                        newSession.resumeJoin()
-                    } else {
-                        newSession.cancelJoin()
-                        onDismiss?()
+                    if isJoin {
+                        if granted {
+                            newSession.resumeJoin()
+                        } else {
+                            newSession.cancelJoin()
+                            onDismiss?()
+                        }
+                    } else if granted {
+                        // Re-apply the in-call toggle that was blocked, now that access is granted.
+                        if permissions.contains(.camera) { newSession.toggleVideo() }
+                        if permissions.contains(.microphone) { newSession.toggleAudio() }
                     }
+                    // In-call + denied: leave the call running; the host UI may steer to Settings.
                 }
             }
             session = newSession

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -175,14 +175,12 @@ public final class SerenadaSession: ObservableObject {
         return true
     }
 
-    /// Callback invoked when camera/microphone permissions are needed before joining.
+    /// Callback invoked when camera/microphone permissions are needed — either before joining, or
+    /// when a user-initiated in-call toggle (enabling video, unmuting) requires a permission that
+    /// isn't currently usable. Mirrors the Android SDK, which routes both cases through this same
+    /// callback. Hosts disambiguate join vs. in-call via `state.phase` (`.awaitingPermissions`
+    /// signals join) and should request access or steer the user to Settings as appropriate.
     public var onPermissionsRequired: (([MediaCapability]) -> Void)?
-
-    /// Callback invoked when a user-initiated in-call media toggle (camera or microphone) cannot
-    /// proceed because the corresponding system permission is denied or restricted. The host
-    /// should surface a prompt steering the user to Settings. It is NOT fired for the
-    /// `.notDetermined` state — the session prompts for access in that case.
-    public var onMediaPermissionBlocked: ((MediaCapability) -> Void)?
 
     // Core dependencies
     private let signalingProvider: SignalingProvider
@@ -554,13 +552,14 @@ public final class SerenadaSession: ObservableObject {
     }
 
     /// Returns `true` when the microphone permission allows toggling audio. When the permission is
-    /// denied or restricted, fires `onMediaPermissionBlocked(.microphone)` so the host can steer
-    /// the user to Settings and returns `false` — the toggle is a no-op because audio can't be
-    /// captured without permission. `.notDetermined` is allowed through (the audio session prompts).
+    /// denied or restricted, routes through `onPermissionsRequired([.microphone])` so the host can
+    /// request access or steer the user to Settings, and returns `false` — the toggle is a no-op
+    /// because audio can't be captured without permission. `.notDetermined` is allowed through
+    /// (the audio session prompts).
     private func ensureMicrophonePermissionForAudioToggle() -> Bool {
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .denied, .restricted:
-            onMediaPermissionBlocked?(.microphone)
+            onPermissionsRequired?([.microphone])
             return false
         case .authorized, .notDetermined:
             return true
@@ -2018,7 +2017,7 @@ public final class SerenadaSession: ObservableObject {
             requestCameraPermissionForVideoEnable(broadcastMediaStateOnGrant: broadcastMediaStateOnGrant)
             return false
         case .denied, .restricted:
-            onMediaPermissionBlocked?(.camera)
+            onPermissionsRequired?([.camera])
             return false
         @unknown default:
             return false

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -178,6 +178,12 @@ public final class SerenadaSession: ObservableObject {
     /// Callback invoked when camera/microphone permissions are needed before joining.
     public var onPermissionsRequired: (([MediaCapability]) -> Void)?
 
+    /// Callback invoked when a user-initiated in-call media toggle (camera or microphone) cannot
+    /// proceed because the corresponding system permission is denied or restricted. The host
+    /// should surface a prompt steering the user to Settings. It is NOT fired for the
+    /// `.notDetermined` state — the session prompts for access in that case.
+    public var onMediaPermissionBlocked: ((MediaCapability) -> Void)?
+
     // Core dependencies
     private let signalingProvider: SignalingProvider
     private let providerDelegateProxy: SignalingProviderDelegateProxy
@@ -543,7 +549,24 @@ public final class SerenadaSession: ObservableObject {
 
     /// Toggle local audio on or off.
     public func toggleAudio() {
+        guard ensureMicrophonePermissionForAudioToggle() else { return }
         setMicMuted(!userMuted)
+    }
+
+    /// Returns `true` when the microphone permission allows toggling audio. When the permission is
+    /// denied or restricted, fires `onMediaPermissionBlocked(.microphone)` so the host can steer
+    /// the user to Settings and returns `false` — the toggle is a no-op because audio can't be
+    /// captured without permission. `.notDetermined` is allowed through (the audio session prompts).
+    private func ensureMicrophonePermissionForAudioToggle() -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .denied, .restricted:
+            onMediaPermissionBlocked?(.microphone)
+            return false
+        case .authorized, .notDetermined:
+            return true
+        @unknown default:
+            return true
+        }
     }
 
     /// Toggle local video on or off.
@@ -1995,6 +2018,7 @@ public final class SerenadaSession: ObservableObject {
             requestCameraPermissionForVideoEnable(broadcastMediaStateOnGrant: broadcastMediaStateOnGrant)
             return false
         case .denied, .restricted:
+            onMediaPermissionBlocked?(.camera)
             return false
         @unknown default:
             return false

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -177,9 +177,9 @@ public final class SerenadaSession: ObservableObject {
 
     /// Callback invoked when camera/microphone permissions are needed — either before joining, or
     /// when a user-initiated in-call toggle (enabling video, unmuting) requires a permission that
-    /// isn't currently usable. Mirrors the Android SDK, which routes both cases through this same
-    /// callback. Hosts disambiguate join vs. in-call via `state.phase` (`.awaitingPermissions`
-    /// signals join) and should request access or steer the user to Settings as appropriate.
+    /// isn't currently usable. Hosts disambiguate join vs. in-call via `state.phase`
+    /// (`.awaitingPermissions` signals join) and should request access or steer the user to
+    /// Settings as appropriate.
     public var onPermissionsRequired: (([MediaCapability]) -> Void)?
 
     // Core dependencies


### PR DESCRIPTION
When a user toggles camera or microphone during a call but the system permission is denied or restricted, the session previously failed silently. Add an `onMediaPermissionBlocked` callback that fires in those cases so host apps can surface a prompt steering the user to Settings, matching the guidance shown on Android.

- Camera: fired from `ensureCameraPermissionForVideoEnable` in the `.denied`/`.restricted` case.
- Microphone: `toggleAudio()` now guards on the audio authorization status and fires for `.denied`/`.restricted`. `.notDetermined` is unaffected — the session still prompts for access.

Client Support PR https://github.com/zelloptt/zello-ios-client/pull/10987