### PR TITLE
Release Serenada SDK 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Serenada SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.9.1] — 2026-07-04
+
+### Added
+- Android: Frontline call UI now has a tiny-screen layout for wearable-sized
+  displays, including compact controls, scrollable option sheets, and reachable
+  camera, snapshot, flashlight, and remote screen-share fullscreen actions.
+
+### Fixed
+- iOS: denied in-call camera and microphone toggles now surface through
+  `onPermissionsRequired`, so hosts can re-prompt instead of leaving the toggle
+  request silently blocked.
+
 ## [0.9.0] — 2026-06-25
 
 ### Added

--- a/client-android/README.md
+++ b/client-android/README.md
@@ -85,9 +85,9 @@ cd client-android
 ./gradlew publishSdkToMavenLocal
 ```
 This publishes:
-- `app.serenada:libwebrtc-7827-universal:0.9.0`
-- `app.serenada:core:0.9.0`
-- `app.serenada:call-ui:0.9.0`
+- `app.serenada:libwebrtc-7827-universal:0.9.1`
+- `app.serenada:core:0.9.1`
+- `app.serenada:call-ui:0.9.1`
 
 Release APK (signed):
 ```bash

--- a/client-android/serenada-call-ui/build.gradle.kts
+++ b/client-android/serenada-call-ui/build.gradle.kts
@@ -66,7 +66,7 @@ afterEvaluate {
 
                 groupId = "app.serenada"
                 artifactId = "call-ui"
-                version = "0.9.0"
+                version = "0.9.1"
 
                 pom {
                     name.set("Serenada Call UI")

--- a/client-android/serenada-core/build.gradle.kts
+++ b/client-android/serenada-core/build.gradle.kts
@@ -51,7 +51,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.9.0"
+val sdkVersion = "0.9.1"
 val mavenGroupId = "app.serenada"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "libs/$webRtcArtifactId.aar"

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaCore.kt
@@ -226,7 +226,7 @@ class SerenadaCore(
     }
 
     companion object {
-        const val VERSION = "0.9.0"
+        const val VERSION = "0.9.1"
     }
 }
 

--- a/client-android/serenada-webrtc/build.gradle.kts
+++ b/client-android/serenada-webrtc/build.gradle.kts
@@ -31,7 +31,7 @@ fun sha256Of(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-val sdkVersion = "0.9.0"
+val sdkVersion = "0.9.1"
 val webRtcArtifactId = "libwebrtc-7827-universal"
 val localWebRtcAarPath = "../serenada-core/libs/$webRtcArtifactId.aar"
 val localWebRtcAarFile = file(localWebRtcAarPath)

--- a/client-ios/SerenadaCore/Sources/SerenadaCore.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaCore.swift
@@ -72,7 +72,7 @@ public struct CreateRoomResult {
 @MainActor
 public final class SerenadaCore {
     /// SDK version string.
-    public static let version = "0.9.0"
+    public static let version = "0.9.1"
 
     /// SDK configuration.
     public let config: SerenadaConfig

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "workspaces": [
         "packages/core",
         "packages/react-ui"
       ],
       "dependencies": {
-        "@agatx/serenada-core": "0.9.0",
-        "@agatx/serenada-react-ui": "0.9.0",
+        "@agatx/serenada-core": "0.9.1",
+        "@agatx/serenada-react-ui": "0.9.1",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.562.0",
@@ -5410,21 +5410,21 @@
     },
     "packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT"
     },
     "packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.9.0"
+        "@agatx/serenada-core": "0.9.1"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.9.0",
+        "@agatx/serenada-core": "^0.9.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "workspaces": [
     "packages/core",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agatx/serenada-core": "0.9.0",
-    "@agatx/serenada-react-ui": "0.9.0",
+    "@agatx/serenada-core": "0.9.1",
+    "@agatx/serenada-react-ui": "0.9.1",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.562.0",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Headless WebRTC call engine for 1:1 and mesh multi-party video calls — vanilla TypeScript, no React dependency",
   "type": "module",
   "main": "dist/index.js",

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * @agatx/serenada-core — headless call engine.
  * Vanilla TypeScript — no React dependency.
  */
-export const SERENADA_CORE_VERSION = '0.9.0';
+export const SERENADA_CORE_VERSION = '0.9.1';
 
 // Public API
 export { SerenadaCore } from './SerenadaCore.js';

--- a/client/packages/react-ui/package.json
+++ b/client/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agatx/serenada-react-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pre-built React call UI components for Serenada video calls",
   "type": "module",
   "main": "dist/index.js",
@@ -28,13 +28,13 @@
     "react-qr-code": "^2.0.17"
   },
   "peerDependencies": {
-    "@agatx/serenada-core": "^0.9.0",
+    "@agatx/serenada-core": "^0.9.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "lucide-react": ">=0.300.0"
   },
   "devDependencies": {
-    "@agatx/serenada-core": "0.9.0"
+    "@agatx/serenada-core": "0.9.1"
   },
   "repository": {
     "type": "git",

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
 
 // app/build.gradle.kts
 dependencies {
-    implementation("app.serenada:core:0.9.0")
-    implementation("app.serenada:call-ui:0.9.0")
+    implementation("app.serenada:core:0.9.1")
+    implementation("app.serenada:call-ui:0.9.1")
 }
 ```
 

--- a/docs/sdk/sdk-integration-web.md
+++ b/docs/sdk/sdk-integration-web.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-npm install @agatx/serenada-core@0.9.0 @agatx/serenada-react-ui@0.9.0 lucide-react
+npm install @agatx/serenada-core@0.9.1 @agatx/serenada-react-ui@0.9.1 lucide-react
 ```
 
 `@agatx/serenada-core` is framework-agnostic vanilla TypeScript. `@agatx/serenada-react-ui` provides ready-made React components.

--- a/samples/web/package-lock.json
+++ b/samples/web/package-lock.json
@@ -26,21 +26,21 @@
     },
     "../../client/packages/core": {
       "name": "@agatx/serenada-core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT"
     },
     "../../client/packages/react-ui": {
       "name": "@agatx/serenada-react-ui",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "react-qr-code": "^2.0.17"
       },
       "devDependencies": {
-        "@agatx/serenada-core": "0.9.0"
+        "@agatx/serenada-core": "0.9.1"
       },
       "peerDependencies": {
-        "@agatx/serenada-core": "^0.9.0",
+        "@agatx/serenada-core": "^0.9.1",
         "lucide-react": ">=0.300.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary
- Bump Serenada SDK metadata to 0.9.1 across web, Android, and iOS
- Refresh web/sample lockfiles and SDK integration docs for 0.9.1
- Add 0.9.1 changelog notes for the Android Frontline tiny-screen UI and iOS denied-permission callback fix

## Validation
- git diff --check
- node scripts/check-version-parity.mjs
- node scripts/check-signaling-protocol-constants.mjs
- node scripts/check-resilience-constants.mjs
- node scripts/check-telemetry-parity.mjs
- cd client && npm ci --ignore-scripts && npm test && npm run build
- cd samples/web && npm ci --ignore-scripts && npm run build
- cd server && go test ./... && go build -o /tmp/serenada-server-sweep .
- cd client-android && ./gradlew --no-daemon clean --console=plain
- cd client-android && ./gradlew --no-daemon assembleDebug :app:testDebugUnitTest :serenada-core:testDebugUnitTest :serenada-call-ui:testDebugUnitTest --console=plain
- cd samples/android && ./gradlew --no-daemon :app:assembleDebug --console=plain
- cd client-android && ./gradlew --no-daemon publishSdkToMavenLocal --console=plain
- XcodeBuildMCP test_sim, SerenadaiOS scheme, iPhone 16 simulator, CODE_SIGNING_ALLOWED=NO
- XcodeBuildMCP build_sim, SerenadaiOSSample scheme, iPhone 16 simulator, CODE_SIGNING_ALLOWED=NO
- cd client && npm run build:publish --workspace @agatx/serenada-core && npm pack --dry-run --workspace @agatx/serenada-core
- cd client && npm run build:publish --workspace @agatx/serenada-react-ui && npm pack --dry-run --workspace @agatx/serenada-react-ui

Co-authored by Codex (GPT-5 medium)