### PR TITLE
fix: verify cert renewal end-to-end on deploy + external cert-health monitor

### DIFF
--- a/.github/workflows/cert-health.yml
+++ b/.github/workflows/cert-health.yml
@@ -1,0 +1,44 @@
+
+# Daily external TLS certificate health check.
+#
+# Let's Encrypt certs live 90 days and certbot renews them 30 days before
+# expiry. If any production endpoint gets within 21 days of expiry, renewal
+# has been failing for over a week — this workflow fails, and GitHub emails
+# the workflow author. This is the external safety net for on-host renewal
+# breakage that is otherwise only visible in journal logs nobody watches
+# (it has silently expired production certs twice: Apr 2026 and Jul 2026).
+name: cert-health
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-cert-expiry:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: serenada.app
+            port: 443
+          - host: serenada.app
+            port: 5349 # TURNS (coturn) — reloads separately from nginx
+          - host: serenada-app.ru
+            port: 443
+          - host: serenada-app.ru
+            port: 5349
+    steps:
+      - name: Check ${{ matrix.host }}:${{ matrix.port }} cert has >= 21 days left
+        run: |
+          set -o pipefail
+          MIN_DAYS=21
+          CERT=$(echo | timeout 30 openssl s_client \
+            -connect "${{ matrix.host }}:${{ matrix.port }}" \
+            -servername "${{ matrix.host }}" 2>/dev/null | openssl x509)
+          echo "$CERT" | openssl x509 -noout -subject -enddate
+          if ! echo "$CERT" | openssl x509 -noout -checkend $((MIN_DAYS * 24 * 3600)); then
+            echo "::error::Certificate on ${{ matrix.host }}:${{ matrix.port }} expires within ${MIN_DAYS} days — auto-renewal is likely broken. SSH to the VPS and run: certbot renew --dry-run"
+            exit 1
+          fi

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -117,6 +117,12 @@ Serenada expects Let's Encrypt certificates to be located at `/etc/letsencrypt/l
 3.  The certificates are mounted into the containers via `docker-compose.prod.yml`.
 4.  Run `./deploy.sh` from your local machine. It converts the cert's renewal config to webroot mode (zero-downtime renewals against the live containerized nginx) and installs a post-renewal hook at `/etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh` that reloads nginx (`nginx -s reload`) and signals coturn (`SIGUSR2` to re-read the TLS files) after every successful renewal. **Do not skip this step** — without it, certbot keeps trying to bind ports 80/443 itself, which Docker already owns, and renewals fail silently until the cert expires; coturn would also continue serving the old cert on TURNS:5349 until the next container restart.
 
+    The migration re-runs whenever the renewal config's `authenticator` is not `webroot` **or** its `webroot_path` doesn't match the live certbot-webroot docker volume mountpoint. A config that merely *says* webroot but points at a stale or malformed path fails renewal just as silently — that's what expired `serenada.app` in July 2026 while the authenticator-only check considered it migrated.
+
+    Every deploy finishes the renewal block with `certbot renew --cert-name <domain> --dry-run` — a real HTTP-01 challenge against Let's Encrypt's staging server through the live nginx. If it fails, the deploy fails. This is the on-host guarantee that renewals work end-to-end; do not remove it.
+
+    As an external safety net, the `cert-health` GitHub Actions workflow (`.github/workflows/cert-health.yml`) checks all production endpoints (443 and TURNS 5349 on `serenada.app` and `serenada-app.ru`) daily and fails when a cert has under 21 days left — i.e. when renewal has already been failing for over a week. GitHub emails the workflow author on scheduled-run failures.
+
 ### 4. Deploying the Stack
 
 A convenience script is provided for deployment. It uses `envsubst` to process templates, builds the frontend, syncs files via `rsync`, and restarts services via SSH.

--- a/deploy.sh
+++ b/deploy.sh
@@ -203,11 +203,20 @@ HOOK_EOF
 # when the cert isn't due, leaving the renewal config still pointing at
 # standalone/nginx. Force-renewal guarantees certbot rewrites the lineage
 # config with authenticator=webroot. This block only runs once per VPS (the
-# AUTH check skips it on subsequent deploys), so the extra issuance is a
+# AUTH+path check skips it on subsequent deploys), so the extra issuance is a
 # one-time cost during migration.
+#
+# Checking authenticator alone is NOT enough: a config can say webroot but
+# carry a stale/malformed path (e.g. a hand-edited [webroot] section pointing
+# at a path that only exists inside the nginx container). That exact state
+# expired serenada.app in July 2026 — certbot failed twice daily with
+# "Missing command line flag or config entry" while the authenticator check
+# reported everything as already migrated. So also require webroot_path to
+# match the live docker volume mountpoint.
 AUTH=\$(\$SUDO awk -F' = ' '/^authenticator/{print \$2; exit}' "\$CERT_CONF")
-if [ "\$AUTH" != "webroot" ]; then
-    echo "🔧 Cert was using authenticator=\$AUTH; reconfiguring to webroot..."
+CONF_WEBROOT=\$(\$SUDO awk -F' = ' '/^webroot_path/{print \$2; exit}' "\$CERT_CONF" | tr -d ' ' | sed 's/,\$//')
+if [ "\$AUTH" != "webroot" ] || [ "\$CONF_WEBROOT" != "\$WEBROOT_PATH" ]; then
+    echo "🔧 Cert renewal config invalid (authenticator=\$AUTH, webroot_path=\${CONF_WEBROOT:-unset}); reconfiguring to webroot..."
     DOMAINS=\$(\$SUDO certbot certificates --cert-name "${DOMAIN}" 2>/dev/null \\
         | awk -F': ' '/Domains:/{print \$2; exit}')
     [ -z "\$DOMAINS" ] && DOMAINS="${DOMAIN}"
@@ -238,6 +247,19 @@ if command -v crontab >/dev/null 2>&1; then
     echo "✅ SSL auto-renewal cron job is configured (weekly, zero-downtime)"
 else
     echo "⚠️  crontab not found — install cron (apt install cron) to enable SSL auto-renewal"
+fi
+
+# Prove the renewal path actually works end-to-end (staging ACME server, real
+# HTTP-01 challenge through the live nginx). A misconfigured lineage otherwise
+# fails silently twice a day in certbot.timer until the cert expires — this
+# turns that into a visible deploy failure.
+echo "🧪 Verifying cert renewal end-to-end (certbot renew --dry-run)..."
+if \$SUDO certbot renew --cert-name "${DOMAIN}" --dry-run --quiet; then
+    echo "✅ Renewal dry-run succeeded for ${DOMAIN}"
+else
+    echo "❌ Renewal dry-run FAILED for ${DOMAIN} — auto-renewal is broken."
+    echo "   Debug on the VPS with: certbot renew --cert-name ${DOMAIN} --dry-run"
+    exit 1
 fi
 RENEWAL_EOF
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -243,7 +243,12 @@ fi
 # is harmless if both are enabled.
 if command -v crontab >/dev/null 2>&1; then
     CRON_CMD="0 3 * * 0 certbot renew --quiet"
-    ( \$SUDO crontab -l 2>/dev/null | grep -v 'certbot renew'; echo "\$CRON_CMD" ) | \$SUDO crontab -
+    # '|| true' matters: with no pre-existing crontab (or one with no other
+    # entries), grep exits 1 and set -e would kill the subshell BEFORE the
+    # echo — installing an empty crontab while the deploy still reports
+    # success. That silently left serenada.app without the cron entry.
+    ( \$SUDO crontab -l 2>/dev/null | grep -v 'certbot renew' || true; echo "\$CRON_CMD" ) | \$SUDO crontab -
+    \$SUDO crontab -l | grep -qF "\$CRON_CMD"
     echo "✅ SSL auto-renewal cron job is configured (weekly, zero-downtime)"
 else
     echo "⚠️  crontab not found — install cron (apt install cron) to enable SSL auto-renewal"


### PR DESCRIPTION
## Summary

Production cert for `serenada.app` expired on **2026-07-07 22:50 UTC**. Third cert incident (Jan 2026, Apr 2026 / #89, now). Production is already fixed and verified — this PR is the permanent hardening.

## Root cause

The renewal config on the serenada.app VPS said `authenticator = webroot`, but from a **pre-#89 sed edit** that wrote a malformed `[webroot]` section pointing at `/var/www/certbot` — a path that only exists *inside* the nginx container. `certbot renew` (systemd timer, twice daily) failed for a month with:

```
Missing command line flag or config entry for this setting:
Input the webroot for serenada.app:
```

#89's migration gate only checked `authenticator != webroot`, so it skipped this host as already migrated. The `.ru` host had `authenticator = nginx`, got migrated properly, and renewed fine on Jun 30 — which is why #89 looked complete.

A second latent bug compounded it: with no pre-existing root crontab, `( crontab -l | grep -v 'certbot renew'; echo "$CRON_CMD" ) | crontab -` under `set -e` dies before the `echo` (empty-input `grep` exits 1), silently installing an **empty** crontab while printing ✅.

## Changes

- **deploy.sh** — migration gate now re-runs certbot when the authenticator is not webroot **or** `webroot_path` doesn't match the live certbot-webroot docker volume mountpoint. A config that says webroot but points at a stale path is exactly what expired serenada.app.
- **deploy.sh** — renewal block now ends with `certbot renew --cert-name <domain> --dry-run` (staging ACME, real HTTP-01 through the live nginx). Failure fails the deploy. Silent-until-expiry breakage becomes a loud deploy error.
- **deploy.sh** — `|| true` on the crontab pipeline + verify the entry actually landed.
- **.github/workflows/cert-health.yml** — daily external check of 443 + TURNS 5349 on `serenada.app` and `serenada-app.ru`; fails (GitHub emails the author) when any cert has under 21 days left, i.e. renewal has already been failing for 1+ week. Catches breakage no matter which on-host mechanism rots.
- **DEPLOY.md** — document all of the above.

## Production remediation (already applied on the serenada.app VPS)

- Re-issued via `certbot certonly --webroot -w /var/lib/docker/volumes/serenada_certbot-webroot/_data --force-renewal` → certbot rewrote the lineage config with a proper `[[webroot_map]]`; removed the stale malformed `[webroot]` section.
- New cert valid until **2026-10-06**; deploy hook fired (nginx reloaded, coturn SIGUSR2).
- Verified: HTTPS 200 on :443, TURNS :5349 serves the new cert, `/api/room-id` responds, `certbot renew --cert-name serenada.app --dry-run` passes.
- Weekly cron entry installed (was missing due to the crontab bug above).

## Legacy `connected.dowhile.fun` redirect: retired (2026-07-08)

The legacy redirect domain on the same VPS had been expired since **2026-03-27** and could not renew (`authenticator = standalone` with port 80 owned by Docker, and its nginx port-80 server redirected ACME challenges away). Rather than fix it, the redirect was retired:

- Removed `/opt/serenada/nginx/conf.d/legacy.extra` (backed up locally first; the repo template was already gone) and reloaded nginx.
- `certbot delete --cert-name connected.dowhile.fun` — the only lineage left is `serenada.app`, so `certbot renew` now runs with zero failures.
- HTTP on the old domain now falls through to the default server block and 301s to HTTPS, which serves the serenada.app cert (SNI mismatch warning). Fully cleaning that up means dropping the domain's DNS A record.

## Test plan

- [x] `bash -n deploy.sh`
- [x] Gate logic simulated read-only against the live healthy config (skips) and the broken pre-fix shape (would re-run)
- [x] `certbot renew --cert-name serenada.app --dry-run` passes on the VPS
- [ ] `cert-health` workflow runs green after merge (workflow_dispatch it once)
- [ ] Next `./deploy.sh` run passes the new dry-run gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9Xe3YoEMENSgAdQyn2Uu6
