### PR TITLE
ANDROID-3860 Move terminal media teardown off main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ The coordinator implementation is responsible for:
 - Managing audio focus, modes, and Bluetooth routing.
 - Publishing available devices, current input/output routes, and session events (interruptions, resume, focus changes) to the SDK.
 
+On Android, coordinator handoff is serialized process-wide across Serenada sessions, including
+handoffs between default and custom coordinators. The SDK does not activate the next coordinator
+until the previous coordinator's `deactivateCallSession()` returns. Custom implementations must
+therefore suspend until focus, mode, route, Bluetooth, and callback cleanup is complete instead of
+launching cleanup in the background; blocking system work should run off the main thread.
+
 The session exposes coordinator state for custom UI:
 
 - `availableAudioDevices`: routes published by the active coordinator.

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -60,6 +60,9 @@ import app.serenada.core.call.SignalingMessage
 import app.serenada.core.call.WebRtcEngine
 import app.serenada.core.call.WebRtcResilienceConstants
 import app.serenada.core.call.CameraCaptureController
+import app.serenada.core.call.PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS
+import app.serenada.core.call.defaultAudioTeardownFence
+import app.serenada.core.call.terminalMediaTeardownFence
 import app.serenada.core.call.toContentStatePayload
 import app.serenada.core.network.CoreApiClient
 import app.serenada.core.network.SessionAPIClient
@@ -73,7 +76,6 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -1311,6 +1313,22 @@ class SerenadaSession internal constructor(
 
         acquirePerformanceLocks()
         providerScope.launch {
+            val previousMediaReleased =
+                terminalMediaTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)
+            val previousAudioRestored =
+                defaultAudioTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)
+            if (!previousMediaReleased || !previousAudioRestored) {
+                logger?.log(
+                    SerenadaLogLevel.ERROR,
+                    "Session",
+                    "Previous call teardown timed out before media activation",
+                )
+                handleError(CallError.Unknown("Previous call teardown timed out"))
+                return@launch
+            }
+            if (_state.value.phase != CallPhase.Joining || joinFlowCoordinator.joinAttemptSerial != joinAttemptId) {
+                return@launch
+            }
             try {
                 withTimeout(WebRtcResilienceConstants.AUDIO_COORDINATOR_TIMEOUT_MS) {
                     audioCoordinatorMutex.withLock {
@@ -1327,7 +1345,14 @@ class SerenadaSession internal constructor(
                 handleError(CallError.Unknown(e.message ?: "Audio session activation failed"))
                 return@launch
             }
-            if (!isActive) return@launch
+            if (
+                !isActive ||
+                _state.value.phase != CallPhase.Joining ||
+                joinFlowCoordinator.joinAttemptSerial != joinAttemptId
+            ) {
+                runCatching { audioCoordinator.deactivateCallSession() }
+                return@launch
+            }
             joinFlowCoordinator.scheduleJoinTimeout(roomId, joinAttemptId)
             try {
                 callAudioSessionController.activate()
@@ -2241,9 +2266,9 @@ class SerenadaSession internal constructor(
         joinFlowCoordinator.reset()
         peerNegotiationEngine.resetAll()
         iceFetchGeneration += 1
-        // Host-provided session controllers keep their established Main-thread callback. The
-        // SDK default coordinator is deactivated below on a worker because AudioManager route
-        // restoration can synchronously block Main for hundreds of milliseconds on some devices.
+        // Host-provided session controllers keep their established Main-thread callback. The SDK
+        // default coordinator synchronously detaches Main-owned callbacks inside
+        // deactivateCallSession(), then performs only the blocking AudioManager restore off Main.
         if (callAudioSessionController !== defaultAudioCoordinator) {
             callAudioSessionController.deactivate()
         }
@@ -2251,13 +2276,7 @@ class SerenadaSession internal constructor(
             try {
                 withTimeout(WebRtcResilienceConstants.AUDIO_COORDINATOR_TIMEOUT_MS) {
                     audioCoordinatorMutex.withLock {
-                        if (audioCoordinator === defaultAudioCoordinator) {
-                            withContext(Dispatchers.Default) {
-                                audioCoordinator.deactivateCallSession()
-                            }
-                        } else {
-                            audioCoordinator.deactivateCallSession()
-                        }
+                        audioCoordinator.deactivateCallSession()
                     }
                 }
             } catch (e: TimeoutCancellationException) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -61,7 +61,7 @@ import app.serenada.core.call.WebRtcEngine
 import app.serenada.core.call.WebRtcResilienceConstants
 import app.serenada.core.call.CameraCaptureController
 import app.serenada.core.call.PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS
-import app.serenada.core.call.defaultAudioTeardownFence
+import app.serenada.core.call.audioCoordinatorTeardownFence
 import app.serenada.core.call.terminalMediaTeardownFence
 import app.serenada.core.call.toContentStatePayload
 import app.serenada.core.network.CoreApiClient
@@ -1316,7 +1316,7 @@ class SerenadaSession internal constructor(
             val previousMediaReleased =
                 terminalMediaTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)
             val previousAudioRestored =
-                defaultAudioTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)
+                audioCoordinatorTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)
             if (!previousMediaReleased || !previousAudioRestored) {
                 logger?.log(
                     SerenadaLogLevel.ERROR,
@@ -1350,7 +1350,9 @@ class SerenadaSession internal constructor(
                 _state.value.phase != CallPhase.Joining ||
                 joinFlowCoordinator.joinAttemptSerial != joinAttemptId
             ) {
-                runCatching { audioCoordinator.deactivateCallSession() }
+                val deactivationJob =
+                    audioCoordinatorDeactivationJob ?: beginAudioCoordinatorDeactivation()
+                deactivationJob.join()
                 return@launch
             }
             joinFlowCoordinator.scheduleJoinTimeout(roomId, joinAttemptId)
@@ -2272,21 +2274,7 @@ class SerenadaSession internal constructor(
         if (callAudioSessionController !== defaultAudioCoordinator) {
             callAudioSessionController.deactivate()
         }
-        val deactivationJob = audioCoordinatorScope.launch {
-            try {
-                withTimeout(WebRtcResilienceConstants.AUDIO_COORDINATOR_TIMEOUT_MS) {
-                    audioCoordinatorMutex.withLock {
-                        audioCoordinator.deactivateCallSession()
-                    }
-                }
-            } catch (e: TimeoutCancellationException) {
-                logger?.log(SerenadaLogLevel.WARNING, "Audio", "Audio session deactivation timed out")
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to deactivate audio session: ${e.message}")
-            }
-        }
-        audioCoordinatorDeactivationJob = deactivationJob
+        val deactivationJob = beginAudioCoordinatorDeactivation()
         releasePerformanceLocks()
         stopRemoteVideoStatePolling()
         signalingProvider.disconnect()
@@ -2323,6 +2311,35 @@ class SerenadaSession internal constructor(
         if (clearRecovery) recoveryStorage.clear()
         providerScope.coroutineContext.cancelChildren()
         updateDiagnostics(CallDiagnostics())
+        return deactivationJob
+    }
+
+    private fun beginAudioCoordinatorDeactivation(): Job {
+        val teardownTicket = audioCoordinatorTeardownFence.begin()
+        val deactivationJob = audioCoordinatorScope.launch {
+            try {
+                if (!teardownTicket.awaitTurn(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
+                    logger?.log(
+                        SerenadaLogLevel.WARNING,
+                        "Audio",
+                        "Timed out waiting for the previous audio coordinator teardown",
+                    )
+                }
+                withTimeout(WebRtcResilienceConstants.AUDIO_COORDINATOR_TIMEOUT_MS) {
+                    audioCoordinatorMutex.withLock {
+                        audioCoordinator.deactivateCallSession()
+                    }
+                }
+            } catch (e: TimeoutCancellationException) {
+                logger?.log(SerenadaLogLevel.WARNING, "Audio", "Audio session deactivation timed out")
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to deactivate audio session: ${e.message}")
+            } finally {
+                teardownTicket.complete()
+            }
+        }
+        audioCoordinatorDeactivationJob = deactivationJob
         return deactivationJob
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -855,7 +856,12 @@ class SerenadaSession internal constructor(
 
     // --- Public API ---
 
-    /** Leave the call gracefully. The other participant stays in the room. */
+    /**
+     * Leave the call gracefully. The other participant stays in the room.
+     *
+     * Session state reaches [CallPhase.Idle] before this returns. Terminal native media resource
+     * release may finish asynchronously so it cannot block the main thread.
+     */
     fun leave() {
         assertMainThread()
         if (_state.value.phase == CallPhase.Idle) return
@@ -2235,12 +2241,23 @@ class SerenadaSession internal constructor(
         joinFlowCoordinator.reset()
         peerNegotiationEngine.resetAll()
         iceFetchGeneration += 1
-        callAudioSessionController.deactivate()
+        // Host-provided session controllers keep their established Main-thread callback. The
+        // SDK default coordinator is deactivated below on a worker because AudioManager route
+        // restoration can synchronously block Main for hundreds of milliseconds on some devices.
+        if (callAudioSessionController !== defaultAudioCoordinator) {
+            callAudioSessionController.deactivate()
+        }
         val deactivationJob = audioCoordinatorScope.launch {
             try {
                 withTimeout(WebRtcResilienceConstants.AUDIO_COORDINATOR_TIMEOUT_MS) {
                     audioCoordinatorMutex.withLock {
-                        audioCoordinator.deactivateCallSession()
+                        if (audioCoordinator === defaultAudioCoordinator) {
+                            withContext(Dispatchers.Default) {
+                                audioCoordinator.deactivateCallSession()
+                            }
+                        } else {
+                            audioCoordinator.deactivateCallSession()
+                        }
                     }
                 }
             } catch (e: TimeoutCancellationException) {
@@ -2254,7 +2271,8 @@ class SerenadaSession internal constructor(
         releasePerformanceLocks()
         stopRemoteVideoStatePolling()
         signalingProvider.disconnect()
-        peerSlots.values.forEach { it.closePeerConnection() }
+        // The media engine owns terminal peer teardown. Clearing the session map first makes
+        // late WebRTC callbacks stale while WebRtcEngine releases native resources off Main.
         peerSlots.clear()
         webRtcEngine.release()
         webRtcStatsExecutor?.shutdown()

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/DefaultAudioCoordinator.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/DefaultAudioCoordinator.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.concurrent.Executor
 
 internal class DefaultAudioCoordinator(
@@ -49,6 +51,17 @@ internal class DefaultAudioCoordinator(
     private var bluetoothScoActive = false
     private var pinnedOutputDevice: AudioDevice? = null
     private var pinnedOutputRouteInventory: Set<String>? = null
+
+    private data class Deactivation(
+        val restoreAudioSession: Boolean,
+        val previousAudioMode: Int,
+        val previousSpeakerphoneOn: Boolean,
+        val previousMicrophoneMute: Boolean,
+        val bluetoothScoWasActive: Boolean,
+        val focusWasGranted: Boolean,
+        val focusRequest: AudioFocusRequest?,
+        val ticket: ProcessTeardownFence.Ticket,
+    )
     private val communicationDeviceExecutor = Executor { command ->
         handler.post(command)
     }
@@ -69,6 +82,7 @@ internal class DefaultAudioCoordinator(
     }
 
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        if (!audioSessionActive) return@OnAudioFocusChangeListener
         logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio focus changed: $focusChange")
         when (focusChange) {
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
@@ -112,6 +126,7 @@ internal class DefaultAudioCoordinator(
 
     private val proximitySensorListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
+            if (!audioSessionActive) return
             val maxRange = proximitySensor?.maximumRange ?: return
             val distance = event.values.firstOrNull() ?: return
             val near = distance < maxRange
@@ -157,10 +172,24 @@ internal class DefaultAudioCoordinator(
     }
 
     override fun deactivate() {
-        if (!audioSessionActive) {
-            abandonAudioFocus()
-            return
-        }
+        val deactivation = prepareDeactivation() ?: return
+        finishDeactivation(deactivation)
+    }
+
+    private fun prepareDeactivation(): Deactivation? {
+        val restoreAudioSession = audioSessionActive
+        if (!restoreAudioSession && !audioFocusGranted) return null
+        val ticket = defaultAudioTeardownFence.begin()
+        val deactivation = Deactivation(
+            restoreAudioSession = restoreAudioSession,
+            previousAudioMode = previousAudioMode,
+            previousSpeakerphoneOn = previousSpeakerphoneOn,
+            previousMicrophoneMute = previousMicrophoneMute,
+            bluetoothScoWasActive = bluetoothScoActive,
+            focusWasGranted = audioFocusGranted,
+            focusRequest = audioFocusRequest,
+            ticket = ticket,
+        )
         audioSessionActive = false
         proximityEarpieceEnabled = true
         pinnedOutputDevice = null
@@ -168,20 +197,28 @@ internal class DefaultAudioCoordinator(
         clearPlaybackDuckingFallback()
         stopProximityMonitoring()
         stopAudioDeviceMonitoring()
-        runCatching {
-            setLegacyBluetoothScoRouting(false)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                audioManager.clearCommunicationDevice()
+        bluetoothScoActive = false
+        audioFocusGranted = false
+        audioFocusRequest = null
+        return deactivation
+    }
+
+    private fun finishDeactivation(deactivation: Deactivation) {
+        try {
+            if (!deactivation.ticket.awaitTurn(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
+                logger?.log(
+                    SerenadaLogLevel.WARNING,
+                    "Audio",
+                    "Timed out waiting for the previous audio teardown",
+                )
             }
-            audioManager.isMicrophoneMute = previousMicrophoneMute
-            setSpeakerphoneEnabled(previousSpeakerphoneOn)
-            audioManager.mode = previousAudioMode
-        }.onSuccess {
-            logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio session restored (mode=$previousAudioMode)")
-        }.onFailure { error ->
-            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to restore audio session: ${error.message}")
+            if (deactivation.restoreAudioSession) {
+                restoreAudioSession(deactivation)
+            }
+            abandonAudioFocus(deactivation.focusWasGranted, deactivation.focusRequest)
+        } finally {
+            deactivation.ticket.complete()
         }
-        abandonAudioFocus()
     }
 
     override fun shouldPauseVideoForProximity(isScreenSharing: Boolean): Boolean {
@@ -194,6 +231,9 @@ internal class DefaultAudioCoordinator(
     // MARK: - SerenadaAudioCoordinator Conformance
 
     override suspend fun activateCallSession(intent: AudioIntent) {
+        check(defaultAudioTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
+            "Previous audio session teardown timed out"
+        }
         proximityEarpieceEnabled = intent.enableProximityEarpiece
         if (audioSessionActive) {
             updateProximityMonitoringForIntent()
@@ -207,7 +247,10 @@ internal class DefaultAudioCoordinator(
     }
 
     override suspend fun deactivateCallSession() {
-        deactivate()
+        val deactivation = prepareDeactivation() ?: return
+        withContext(Dispatchers.Default) {
+            finishDeactivation(deactivation)
+        }
     }
 
     override suspend fun applyRouting(device: AudioDevice) {
@@ -625,14 +668,50 @@ internal class DefaultAudioCoordinator(
         logger?.log(SerenadaLogLevel.DEBUG, "Audio", "Audio focus request granted=$granted")
     }
 
-    private fun abandonAudioFocus() {
-        if (!audioFocusGranted) return
-        audioFocusGranted = false
+    @Suppress("DEPRECATION")
+    private fun restoreAudioSession(deactivation: Deactivation) {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                audioManager.clearCommunicationDevice()
+            } else {
+                if (deactivation.bluetoothScoWasActive) {
+                    audioManager.stopBluetoothSco()
+                }
+                audioManager.isBluetoothScoOn = false
+            }
+            audioManager.isMicrophoneMute = deactivation.previousMicrophoneMute
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (deactivation.previousSpeakerphoneOn) {
+                    val speaker = audioManager.availableCommunicationDevices.firstOrNull {
+                        it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+                    }
+                    if (speaker == null || !audioManager.setCommunicationDevice(speaker)) {
+                        logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to restore built-in speaker route")
+                    }
+                } else {
+                    audioManager.clearCommunicationDevice()
+                }
+            } else {
+                audioManager.isSpeakerphoneOn = deactivation.previousSpeakerphoneOn
+            }
+            audioManager.mode = deactivation.previousAudioMode
+        }.onSuccess {
+            logger?.log(
+                SerenadaLogLevel.DEBUG,
+                "Audio",
+                "Audio session restored (mode=${deactivation.previousAudioMode})",
+            )
+        }.onFailure { error ->
+            logger?.log(SerenadaLogLevel.WARNING, "Audio", "Failed to restore audio session: ${error.message}")
+        }
+    }
+
+    private fun abandonAudioFocus(focusWasGranted: Boolean, focusRequest: AudioFocusRequest?) {
+        if (!focusWasGranted) return
         runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val request = audioFocusRequest
-                if (request != null) {
-                    audioManager.abandonAudioFocusRequest(request)
+                if (focusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(focusRequest)
                 }
             } else {
                 @Suppress("DEPRECATION")

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/DefaultAudioCoordinator.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/DefaultAudioCoordinator.kt
@@ -60,7 +60,6 @@ internal class DefaultAudioCoordinator(
         val bluetoothScoWasActive: Boolean,
         val focusWasGranted: Boolean,
         val focusRequest: AudioFocusRequest?,
-        val ticket: ProcessTeardownFence.Ticket,
     )
     private val communicationDeviceExecutor = Executor { command ->
         handler.post(command)
@@ -179,7 +178,6 @@ internal class DefaultAudioCoordinator(
     private fun prepareDeactivation(): Deactivation? {
         val restoreAudioSession = audioSessionActive
         if (!restoreAudioSession && !audioFocusGranted) return null
-        val ticket = defaultAudioTeardownFence.begin()
         val deactivation = Deactivation(
             restoreAudioSession = restoreAudioSession,
             previousAudioMode = previousAudioMode,
@@ -188,7 +186,6 @@ internal class DefaultAudioCoordinator(
             bluetoothScoWasActive = bluetoothScoActive,
             focusWasGranted = audioFocusGranted,
             focusRequest = audioFocusRequest,
-            ticket = ticket,
         )
         audioSessionActive = false
         proximityEarpieceEnabled = true
@@ -204,21 +201,10 @@ internal class DefaultAudioCoordinator(
     }
 
     private fun finishDeactivation(deactivation: Deactivation) {
-        try {
-            if (!deactivation.ticket.awaitTurn(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
-                logger?.log(
-                    SerenadaLogLevel.WARNING,
-                    "Audio",
-                    "Timed out waiting for the previous audio teardown",
-                )
-            }
-            if (deactivation.restoreAudioSession) {
-                restoreAudioSession(deactivation)
-            }
-            abandonAudioFocus(deactivation.focusWasGranted, deactivation.focusRequest)
-        } finally {
-            deactivation.ticket.complete()
+        if (deactivation.restoreAudioSession) {
+            restoreAudioSession(deactivation)
         }
+        abandonAudioFocus(deactivation.focusWasGranted, deactivation.focusRequest)
     }
 
     override fun shouldPauseVideoForProximity(isScreenSharing: Boolean): Boolean {
@@ -231,9 +217,6 @@ internal class DefaultAudioCoordinator(
     // MARK: - SerenadaAudioCoordinator Conformance
 
     override suspend fun activateCallSession(intent: AudioIntent) {
-        check(defaultAudioTeardownFence.awaitPending(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
-            "Previous audio session teardown timed out"
-        }
         proximityEarpieceEnabled = intent.enableProximityEarpiece
         if (audioSessionActive) {
             updateProximityMonitoringForIntent()

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -618,7 +618,26 @@ internal class PeerConnectionSlot(
     }
 
     override fun closePeerConnection(deferDispose: Boolean) {
-        if (isClosing && peerConnection == null) return
+        val pc = detachPeerConnectionForClose() ?: return
+        closePeerConnectionSafely(pc)
+        disposePeerConnectionSafely(pc, deferDispose)
+    }
+
+    /**
+     * Detach session/UI state synchronously, then return only the native work for the terminal
+     * teardown thread. Mid-call replacement continues to use [closePeerConnection] so its close
+     * remains immediate while only native dispose is deferred.
+     */
+    fun prepareTerminalClose(): Runnable? {
+        val pc = detachPeerConnectionForClose() ?: return null
+        return Runnable {
+            closePeerConnectionSafely(pc)
+            disposePeerConnectionSafely(pc, deferDispose = false)
+        }
+    }
+
+    private fun detachPeerConnectionForClose(): PeerConnection? {
+        if (isClosing && peerConnection == null) return null
         isClosing = true
         offerTimeoutTask = null
         iceRestartTask = null
@@ -645,10 +664,7 @@ internal class PeerConnectionSlot(
         lastRealtimeStatsSample = null
         freezeSamples.clear()
         onRemoteVideoTrack(remoteCid, null)
-        pc?.let {
-            closePeerConnectionSafely(it)
-            disposePeerConnectionSafely(it, deferDispose)
-        }
+        return pc
     }
 
     override fun createOffer(
@@ -1549,6 +1565,10 @@ internal class PeerConnectionDisposeQueue(
         }
         pending.add(wrapper)
         handler.postDelayed(wrapper, delayMs)
+    }
+
+    fun post(dispose: () -> Unit) {
+        postDelayed(Runnable(dispose), 0L)
     }
 
     fun flush(shutdownAfterDrain: Boolean = false, onDrained: (() -> Unit)? = null) {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/PeerConnectionSlot.kt
@@ -644,6 +644,11 @@ internal class PeerConnectionSlot(
         isMakingOffer = false
         pendingIceRestart = false
         val pc = peerConnection
+        pc?.receivers?.forEach { receiver ->
+            val audioTrack = receiver.track() as? AudioTrack ?: return@forEach
+            runCatching { audioTrack.setVolume(0.0) }
+            runCatching { audioTrack.setEnabled(false) }
+        }
         peerConnection = null
         val track = remoteVideoTrack
         track?.removeSink(remoteVideoStateSink)
@@ -1567,8 +1572,11 @@ internal class PeerConnectionDisposeQueue(
         handler.postDelayed(wrapper, delayMs)
     }
 
-    fun post(dispose: () -> Unit) {
-        postDelayed(Runnable(dispose), 0L)
+    /** Add terminal work that will run only when [flush] moves it to the dispose thread. */
+    @Synchronized
+    fun enqueueForFlush(dispose: () -> Unit) {
+        check(!isShutdown) { "Dispose queue is shut down" }
+        pending.add(Runnable(dispose))
     }
 
     fun flush(shutdownAfterDrain: Boolean = false, onDrained: (() -> Unit)? = null) {
@@ -1576,18 +1584,27 @@ internal class PeerConnectionDisposeQueue(
             pending.toList().also { pending.clear() }
         }
         if (runnables.isEmpty()) {
-            onDrained?.invoke()
-            if (shutdownAfterDrain) shutdown()
+            try {
+                onDrained?.invoke()
+            } finally {
+                if (shutdownAfterDrain) shutdown()
+            }
             return
         }
         val remaining = AtomicInteger(runnables.size)
         for (runnable in runnables) {
             handler.removeCallbacks(runnable)
             flushHandler.post {
-                runnable.run()
-                if (remaining.decrementAndGet() == 0) {
-                    onDrained?.invoke()
-                    if (shutdownAfterDrain) shutdown()
+                try {
+                    runCatching { runnable.run() }
+                } finally {
+                    if (remaining.decrementAndGet() == 0) {
+                        try {
+                            onDrained?.invoke()
+                        } finally {
+                            if (shutdownAfterDrain) shutdown()
+                        }
+                    }
                 }
             }
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ProcessTeardownFence.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ProcessTeardownFence.kt
@@ -31,11 +31,22 @@ internal class ProcessTeardownFence {
         }
     }
 
+    internal fun hasPending(): Boolean = synchronized(lock) {
+        tail.count != 0L
+    }
+
     internal class Ticket(
         private val predecessor: CountDownLatch,
         private val completion: CountDownLatch,
     ) {
-        fun awaitTurn(timeoutMs: Long): Boolean =
+        suspend fun awaitTurn(timeoutMs: Long): Boolean {
+            if (predecessor.count == 0L) return true
+            return withContext(Dispatchers.Default) {
+                awaitTurnBlocking(timeoutMs)
+            }
+        }
+
+        fun awaitTurnBlocking(timeoutMs: Long): Boolean =
             predecessor.await(timeoutMs, TimeUnit.MILLISECONDS)
 
         fun complete() {
@@ -45,5 +56,5 @@ internal class ProcessTeardownFence {
 }
 
 internal val terminalMediaTeardownFence = ProcessTeardownFence()
-internal val defaultAudioTeardownFence = ProcessTeardownFence()
+internal val audioCoordinatorTeardownFence = ProcessTeardownFence()
 internal const val PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS = 10_000L

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/ProcessTeardownFence.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/ProcessTeardownFence.kt
@@ -1,0 +1,49 @@
+package app.serenada.core.call
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Process-wide FIFO handoff for resources that outlive a single [app.serenada.core.SerenadaSession].
+ *
+ * A teardown reserves its place synchronously before `leave()` returns. The next session can then
+ * suspend without blocking Main until every teardown that was already reserved has completed.
+ */
+internal class ProcessTeardownFence {
+    private val lock = Any()
+    private var tail = CountDownLatch(0)
+
+    fun begin(): Ticket {
+        val completion = CountDownLatch(1)
+        val predecessor = synchronized(lock) {
+            tail.also { tail = completion }
+        }
+        return Ticket(predecessor, completion)
+    }
+
+    suspend fun awaitPending(timeoutMs: Long): Boolean {
+        val pending = synchronized(lock) { tail }
+        if (pending.count == 0L) return true
+        return withContext(Dispatchers.Default) {
+            pending.await(timeoutMs, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    internal class Ticket(
+        private val predecessor: CountDownLatch,
+        private val completion: CountDownLatch,
+    ) {
+        fun awaitTurn(timeoutMs: Long): Boolean =
+            predecessor.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+        fun complete() {
+            completion.countDown()
+        }
+    }
+}
+
+internal val terminalMediaTeardownFence = ProcessTeardownFence()
+internal val defaultAudioTeardownFence = ProcessTeardownFence()
+internal const val PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS = 10_000L

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SerenadaAudioCoordinator.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SerenadaAudioCoordinator.kt
@@ -116,11 +116,16 @@ sealed class AudioCoordinatorEvent {
  */
 interface SerenadaAudioCoordinator {
     /**
-     * Activate audio for a Serenada call.
+     * Activate audio for a Serenada call. Serenada invokes this on Main after every previously
+     * started Serenada audio-coordinator deactivation has completed.
      */
     suspend fun activateCallSession(intent: AudioIntent)
 
-    /** Deactivate call audio and release coordinator-owned route or focus state. */
+    /**
+     * Deactivate call audio and release coordinator-owned route or focus state. Do not return
+     * until that cleanup is complete. Implementations should be idempotent and move blocking
+     * system calls off Main.
+     */
     suspend fun deactivateCallSession()
 
     /** Apply a user-selected audio route. */

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -362,6 +362,7 @@ internal class WebRtcEngine(
     private fun detachLocalMediaForRelease(): LocalMediaResources {
         cameraController.resetCameraState()
         localVideoTrack?.setEnabled(false)
+        localContentVideoTrack?.setEnabled(false)
         localAudioTrack?.setEnabled(false)
         localVideoTrack?.let { track ->
             localSinks.forEach { sink -> track.removeSink(sink) }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -390,17 +390,17 @@ internal class WebRtcEngine(
     }
 
     private fun releaseLocalMedia(resources: LocalMediaResources) {
-        screenShareController.reset()
-        cameraController.disposeVideoCapturer()
-        resources.videoTrack?.dispose()
-        resources.contentVideoTrack?.dispose()
+        runCatching { screenShareController.reset() }
+        runCatching { cameraController.disposeVideoCapturer() }
+        runCatching { resources.videoTrack?.dispose() }
+        runCatching { resources.contentVideoTrack?.dispose() }
         // Tear down the primer before disposing its audio track — closing the
         // PC first releases the sender's reference to the track.
-        audioPipelinePrimer.stop()
-        resources.audioTrack?.dispose()
-        resources.videoSource?.dispose()
-        resources.contentVideoSource?.dispose()
-        resources.audioSource?.dispose()
+        runCatching { audioPipelinePrimer.stop() }
+        runCatching { resources.audioTrack?.dispose() }
+        runCatching { resources.videoSource?.dispose() }
+        runCatching { resources.contentVideoSource?.dispose() }
+        runCatching { resources.audioSource?.dispose() }
     }
 
     override fun release() {
@@ -409,15 +409,27 @@ internal class WebRtcEngine(
         val peerTeardowns = peerSlots.mapNotNull { slot -> slot.prepareTerminalClose() }
         peerSlots.clear()
         val localMedia = detachLocalMediaForRelease()
+        val teardownTicket = terminalMediaTeardownFence.begin()
         // Capturer/track/source disposal, PeerConnection.close/dispose, and the final
         // factory/ADM release synchronously wait on media and libwebrtc threads on some devices.
         // Sinks and session-visible state have already been detached on Main, so the remaining
         // native teardown can run without racing renderer unmounts or stale session callbacks.
-        peerConnectionDisposeQueue.post {
-            peerTeardowns.forEach(Runnable::run)
-            releaseLocalMedia(localMedia)
-            runCatching { peerConnectionFactory.dispose() }
-            runCatching { audioDeviceModule.release() }
+        peerConnectionDisposeQueue.enqueueForFlush {
+            try {
+                if (!teardownTicket.awaitTurn(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
+                    logger?.log(
+                        SerenadaLogLevel.WARNING,
+                        "WebRTC",
+                        "Timed out waiting for the previous terminal media teardown",
+                    )
+                }
+                peerTeardowns.forEach { teardown -> runCatching { teardown.run() } }
+                releaseLocalMedia(localMedia)
+                runCatching { peerConnectionFactory.dispose() }
+                runCatching { audioDeviceModule.release() }
+            } finally {
+                teardownTicket.complete()
+            }
         }
         peerConnectionDisposeQueue.flush(shutdownAfterDrain = true)
         // eglBase is owned by SerenadaSession and outlives the engine — do not release it here.

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -57,6 +57,15 @@ internal class WebRtcEngine(
         val degradationPreference: RtpParameters.DegradationPreference?
     )
 
+    private data class LocalMediaResources(
+        val videoTrack: VideoTrack?,
+        val videoSource: org.webrtc.VideoSource?,
+        val contentVideoTrack: VideoTrack?,
+        val contentVideoSource: org.webrtc.VideoSource?,
+        val audioTrack: AudioTrack?,
+        val audioSource: AudioSource?,
+    )
+
     private val appContext = context.applicationContext
     private val audioDeviceModule: AudioDeviceModule = createAudioDeviceModule(appContext)
     private val peerConnectionFactory: PeerConnectionFactory
@@ -350,37 +359,66 @@ internal class WebRtcEngine(
         videoSource = null
     }
 
-    fun stopLocalMedia() {
+    private fun detachLocalMediaForRelease(): LocalMediaResources {
         cameraController.resetCameraState()
-        screenShareController.reset()
         localVideoTrack?.setEnabled(false)
         localAudioTrack?.setEnabled(false)
+        localVideoTrack?.let { track ->
+            localSinks.forEach { sink -> track.removeSink(sink) }
+        }
+        localContentVideoTrack?.let { track ->
+            localContentSinks.forEach { sink -> track.removeSink(sink) }
+        }
+        val resources = LocalMediaResources(
+            videoTrack = localVideoTrack,
+            videoSource = videoSource,
+            contentVideoTrack = localContentVideoTrack,
+            contentVideoSource = localContentVideoSource,
+            audioTrack = localAudioTrack,
+            audioSource = audioSource,
+        )
+        localVideoTrack = null
+        videoSource = null
+        localContentVideoTrack = null
+        localContentVideoSource = null
+        localAudioTrack = null
+        audioSource = null
+        localSinks.clear()
+        localContentSinks.clear()
+        return resources
+    }
+
+    private fun releaseLocalMedia(resources: LocalMediaResources) {
+        screenShareController.reset()
         cameraController.disposeVideoCapturer()
-        disposeLocalVideoTrack()
-        disposeLocalContentVideoTrack()
+        resources.videoTrack?.dispose()
+        resources.contentVideoTrack?.dispose()
         // Tear down the primer before disposing its audio track — closing the
         // PC first releases the sender's reference to the track.
         audioPipelinePrimer.stop()
-        localAudioTrack?.dispose()
-        audioSource?.dispose()
-        audioSource = null
-        localAudioTrack = null
+        resources.audioTrack?.dispose()
+        resources.videoSource?.dispose()
+        resources.contentVideoSource?.dispose()
+        resources.audioSource?.dispose()
     }
 
     override fun release() {
         if (released) return
         released = true
-        peerSlots.toList().forEach { slot ->
-            slot.closePeerConnection()
-        }
+        val peerTeardowns = peerSlots.mapNotNull { slot -> slot.prepareTerminalClose() }
         peerSlots.clear()
-        stopLocalMedia()
-        localSinks.clear()
-        localContentSinks.clear()
-        peerConnectionDisposeQueue.flush(shutdownAfterDrain = true) {
+        val localMedia = detachLocalMediaForRelease()
+        // Capturer/track/source disposal, PeerConnection.close/dispose, and the final
+        // factory/ADM release synchronously wait on media and libwebrtc threads on some devices.
+        // Sinks and session-visible state have already been detached on Main, so the remaining
+        // native teardown can run without racing renderer unmounts or stale session callbacks.
+        peerConnectionDisposeQueue.post {
+            peerTeardowns.forEach(Runnable::run)
+            releaseLocalMedia(localMedia)
             runCatching { peerConnectionFactory.dispose() }
             runCatching { audioDeviceModule.release() }
         }
+        peerConnectionDisposeQueue.flush(shutdownAfterDrain = true)
         // eglBase is owned by SerenadaSession and outlives the engine — do not release it here.
     }
 

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/WebRtcEngine.kt
@@ -416,7 +416,7 @@ internal class WebRtcEngine(
         // native teardown can run without racing renderer unmounts or stale session callbacks.
         peerConnectionDisposeQueue.enqueueForFlush {
             try {
-                if (!teardownTicket.awaitTurn(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
+                if (!teardownTicket.awaitTurnBlocking(PROCESS_TEARDOWN_HANDOFF_TIMEOUT_MS)) {
                     logger?.log(
                         SerenadaLogLevel.WARNING,
                         "WebRTC",

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
@@ -578,6 +578,25 @@ class SerenadaSessionContractTest {
         assertEquals("Local media must not start while activation is still suspended", 0, factory.fakeMedia.startLocalMediaCalls)
     }
 
+    @Test
+    fun `leave while audio activation is suspended does not start stale media`() {
+        val coordinator = BlockingAudioCoordinator()
+        factory.tearDown()
+        factory = TestSessionFactory(defaultVideoEnabled = false, audioCoordinator = coordinator)
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+
+        factory.startSession()
+        ShadowLooper.idleMainLooper()
+        factory.session.leave()
+        coordinator.completeActivation()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals(CallPhase.Idle, factory.session.state.value.phase)
+        assertEquals(0, factory.fakeMedia.startLocalMediaCalls)
+        assertTrue(coordinator.deactivateCalls > 0)
+    }
+
     // ── Reconnect backoff ───────────────────────────────────────────
 
     @Test
@@ -854,13 +873,21 @@ private class BlockingAudioCoordinator : SerenadaAudioCoordinator {
     private val activation = CompletableDeferred<Unit>()
     var activateCalls = 0
         private set
+    var deactivateCalls = 0
+        private set
+
+    fun completeActivation() {
+        activation.complete(Unit)
+    }
 
     override suspend fun activateCallSession(intent: AudioIntent) {
         activateCalls += 1
         activation.await()
     }
 
-    override suspend fun deactivateCallSession() {}
+    override suspend fun deactivateCallSession() {
+        deactivateCalls += 1
+    }
     override suspend fun applyRouting(device: AudioDevice) {}
     override suspend fun setMicMuted(muted: Boolean) {}
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaSessionContractTest.kt
@@ -597,6 +597,55 @@ class SerenadaSessionContractTest {
         assertTrue(coordinator.deactivateCalls > 0)
     }
 
+    @Test
+    fun `next custom coordinator waits for previous custom deactivation`() {
+        val firstCoordinator = BlockingDeactivationAudioCoordinator()
+        val secondCoordinator = MutableAudioCoordinator()
+        val firstFactory = TestSessionFactory(
+            roomId = "first-room",
+            defaultVideoEnabled = false,
+            audioCoordinator = firstCoordinator,
+        )
+        val secondFactory = TestSessionFactory(
+            roomId = "second-room",
+            defaultVideoEnabled = false,
+            audioCoordinator = secondCoordinator,
+        )
+        Shadows.shadowOf(RuntimeEnvironment.getApplication())
+            .grantPermissions(android.Manifest.permission.RECORD_AUDIO)
+
+        try {
+            firstFactory.startSession()
+            ShadowLooper.idleMainLooper()
+            assertEquals(1, firstCoordinator.activateCalls)
+
+            firstFactory.session.leave()
+            ShadowLooper.idleMainLooper()
+            assertEquals(1, firstCoordinator.deactivateCalls)
+
+            secondFactory.startSession()
+            ShadowLooper.idleMainLooper()
+            assertEquals(
+                "The next custom coordinator must not activate during prior custom cleanup",
+                0,
+                secondCoordinator.activateCalls,
+            )
+
+            firstCoordinator.completeDeactivation()
+            val deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+            while (secondCoordinator.activateCalls == 0 && System.nanoTime() < deadlineNs) {
+                ShadowLooper.idleMainLooper()
+                Thread.sleep(10)
+            }
+
+            assertEquals(1, secondCoordinator.activateCalls)
+        } finally {
+            firstCoordinator.completeDeactivation()
+            secondFactory.tearDown()
+            firstFactory.tearDown()
+        }
+    }
+
     // ── Reconnect backoff ───────────────────────────────────────────
 
     @Test
@@ -897,19 +946,56 @@ private class BlockingAudioCoordinator : SerenadaAudioCoordinator {
     override val events: SharedFlow<AudioCoordinatorEvent> = MutableSharedFlow()
 }
 
+private class BlockingDeactivationAudioCoordinator : SerenadaAudioCoordinator {
+    private val deactivation = CompletableDeferred<Unit>()
+    var activateCalls = 0
+        private set
+    var deactivateCalls = 0
+        private set
+
+    fun completeDeactivation() {
+        deactivation.complete(Unit)
+    }
+
+    override suspend fun activateCallSession(intent: AudioIntent) {
+        activateCalls += 1
+    }
+
+    override suspend fun deactivateCallSession() {
+        deactivateCalls += 1
+        deactivation.await()
+    }
+
+    override suspend fun applyRouting(device: AudioDevice) {}
+    override suspend fun setMicMuted(muted: Boolean) {}
+
+    override val availableDevices: StateFlow<List<AudioDevice>> = MutableStateFlow(emptyList())
+    override val effectiveInputDevice: StateFlow<AudioDevice?> = MutableStateFlow(null)
+    override val effectiveOutputDevice: StateFlow<AudioDevice?> = MutableStateFlow(null)
+    override val events: SharedFlow<AudioCoordinatorEvent> = MutableSharedFlow()
+}
+
 private class MutableAudioCoordinator : SerenadaAudioCoordinator {
     private val _availableDevices = MutableStateFlow<List<AudioDevice>>(emptyList())
     override val availableDevices: StateFlow<List<AudioDevice>> = _availableDevices
     override val effectiveInputDevice: StateFlow<AudioDevice?> = MutableStateFlow(null)
     override val effectiveOutputDevice: StateFlow<AudioDevice?> = MutableStateFlow(null)
     override val events: SharedFlow<AudioCoordinatorEvent> = MutableSharedFlow()
+    var activateCalls = 0
+        private set
+    var deactivateCalls = 0
+        private set
 
     fun publishAvailableDevices(devices: List<AudioDevice>) {
         _availableDevices.value = devices
     }
 
-    override suspend fun activateCallSession(intent: AudioIntent) {}
-    override suspend fun deactivateCallSession() {}
+    override suspend fun activateCallSession(intent: AudioIntent) {
+        activateCalls += 1
+    }
+    override suspend fun deactivateCallSession() {
+        deactivateCalls += 1
+    }
     override suspend fun applyRouting(device: AudioDevice) {}
     override suspend fun setMicMuted(muted: Boolean) {}
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionDisposeQueueTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionDisposeQueueTest.kt
@@ -1,0 +1,41 @@
+package app.serenada.core.call
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PeerConnectionDisposeQueueTest {
+
+    @Test
+    fun `flush drains posted terminal teardown on the dispose thread`() {
+        val queue = PeerConnectionDisposeQueue(Handler(Looper.getMainLooper()))
+        val drained = CountDownLatch(1)
+        val calls = mutableListOf<String>()
+        var teardownThread = ""
+        var completionThread = ""
+
+        queue.post {
+            teardownThread = Thread.currentThread().name
+            calls += "teardown"
+        }
+        queue.flush(shutdownAfterDrain = true) {
+            completionThread = Thread.currentThread().name
+            calls += "complete"
+            drained.countDown()
+        }
+
+        assertTrue("dispose queue did not drain", drained.await(5, TimeUnit.SECONDS))
+        assertEquals(listOf("teardown", "complete"), calls)
+        assertEquals("serenada-pc-dispose", teardownThread)
+        assertEquals(teardownThread, completionThread)
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionDisposeQueueTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionDisposeQueueTest.kt
@@ -23,7 +23,7 @@ class PeerConnectionDisposeQueueTest {
         var teardownThread = ""
         var completionThread = ""
 
-        queue.post {
+        queue.enqueueForFlush {
             teardownThread = Thread.currentThread().name
             calls += "teardown"
         }
@@ -37,5 +37,33 @@ class PeerConnectionDisposeQueueTest {
         assertEquals(listOf("teardown", "complete"), calls)
         assertEquals("serenada-pc-dispose", teardownThread)
         assertEquals(teardownThread, completionThread)
+    }
+
+    @Test
+    fun `flush preserves delayed disposal before terminal teardown`() {
+        val queue = PeerConnectionDisposeQueue(Handler(Looper.getMainLooper()))
+        val drained = CountDownLatch(1)
+        val calls = mutableListOf<String>()
+
+        queue.postDelayed(Runnable { calls += "deferred" }, 60_000)
+        queue.enqueueForFlush { calls += "terminal" }
+        queue.flush(shutdownAfterDrain = true) { drained.countDown() }
+
+        assertTrue("dispose queue did not drain", drained.await(5, TimeUnit.SECONDS))
+        assertEquals(listOf("deferred", "terminal"), calls)
+    }
+
+    @Test
+    fun `throwing disposal does not prevent remaining work or drain`() {
+        val queue = PeerConnectionDisposeQueue(Handler(Looper.getMainLooper()))
+        val drained = CountDownLatch(1)
+        val calls = mutableListOf<String>()
+
+        queue.enqueueForFlush { error("dispose failed") }
+        queue.enqueueForFlush { calls += "after-error" }
+        queue.flush(shutdownAfterDrain = true) { drained.countDown() }
+
+        assertTrue("dispose queue did not drain", drained.await(5, TimeUnit.SECONDS))
+        assertEquals(listOf("after-error"), calls)
     }
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionSlotOnTrackMidTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionSlotOnTrackMidTest.kt
@@ -2,6 +2,7 @@ package app.serenada.core.call
 
 import android.os.Handler
 import android.os.Looper
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -174,5 +175,20 @@ class PeerConnectionSlotOnTrackMidTest {
             "content track must not be surfaced as the remote camera track",
             h.reportedCameraTrack,
         )
+    }
+
+    @Test
+    fun `terminal close detaches state before native close and dispose run`() {
+        val h = Harness()
+
+        val nativeTeardown = checkNotNull(h.slot.prepareTerminalClose())
+
+        assertEquals("native close must be deferred", 0, h.fakePc.closeCalls)
+        assertEquals("native dispose must be deferred", 0, h.fakePc.disposeCalls)
+
+        nativeTeardown.run()
+
+        assertEquals(1, h.fakePc.closeCalls)
+        assertEquals(1, h.fakePc.disposeCalls)
     }
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionSlotOnTrackMidTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/PeerConnectionSlotOnTrackMidTest.kt
@@ -182,6 +182,7 @@ class PeerConnectionSlotOnTrackMidTest {
         val h = Harness()
 
         val nativeTeardown = checkNotNull(h.slot.prepareTerminalClose())
+        assertNull("terminal close must be idempotent", h.slot.prepareTerminalClose())
 
         assertEquals("native close must be deferred", 0, h.fakePc.closeCalls)
         assertEquals("native dispose must be deferred", 0, h.fakePc.disposeCalls)

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/ProcessTeardownFenceTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/ProcessTeardownFenceTest.kt
@@ -1,0 +1,54 @@
+package app.serenada.core.call
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProcessTeardownFenceTest {
+
+    @Test
+    fun `pending handoff waits until reserved teardown completes`() = runBlocking {
+        val fence = ProcessTeardownFence()
+        val ticket = fence.begin()
+        val started = CountDownLatch(1)
+        val completed = CountDownLatch(1)
+
+        val worker = Thread {
+            started.countDown()
+            Thread.sleep(50)
+            ticket.complete()
+            completed.countDown()
+        }.apply { start() }
+
+        assertTrue(started.await(1, TimeUnit.SECONDS))
+        assertTrue(fence.awaitPending(1_000))
+        assertTrue(completed.await(1, TimeUnit.SECONDS))
+        worker.join()
+    }
+
+    @Test
+    fun `handoff times out while teardown remains pending`() = runBlocking {
+        val fence = ProcessTeardownFence()
+        val ticket = fence.begin()
+
+        assertFalse(fence.awaitPending(1))
+
+        ticket.complete()
+        assertTrue(fence.awaitPending(1_000))
+    }
+
+    @Test
+    fun `teardown tickets preserve fifo order`() {
+        val fence = ProcessTeardownFence()
+        val first = fence.begin()
+        val second = fence.begin()
+
+        assertFalse(second.awaitTurn(1))
+        first.complete()
+        assertTrue(second.awaitTurn(1_000))
+        second.complete()
+    }
+}

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/ProcessTeardownFenceTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/ProcessTeardownFenceTest.kt
@@ -46,9 +46,9 @@ class ProcessTeardownFenceTest {
         val first = fence.begin()
         val second = fence.begin()
 
-        assertFalse(second.awaitTurn(1))
+        assertFalse(second.awaitTurnBlocking(1))
         first.complete()
-        assertTrue(second.awaitTurn(1_000))
+        assertTrue(second.awaitTurnBlocking(1_000))
         second.complete()
     }
 }

--- a/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/fakes/TestSessionFactory.kt
@@ -5,6 +5,7 @@ import app.serenada.core.SerenadaSession
 import app.serenada.core.call.LocalCameraMode
 import app.serenada.core.call.SerenadaAudioCoordinator
 import app.serenada.core.call.SessionClock
+import app.serenada.core.call.audioCoordinatorTeardownFence
 import okhttp3.OkHttpClient
 import org.json.JSONObject
 import org.webrtc.PeerConnection
@@ -235,6 +236,14 @@ internal class TestSessionFactory(
 
     fun tearDown() {
         session.close()
+        val deadlineNs = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2)
+        while (audioCoordinatorTeardownFence.hasPending() && System.nanoTime() < deadlineNs) {
+            ShadowLooper.idleMainLooper()
+            Thread.sleep(5)
+        }
         ShadowLooper.idleMainLooper()
+        check(!audioCoordinatorTeardownFence.hasPending()) {
+            "Audio coordinator teardown did not complete during test cleanup"
+        }
     }
 }

--- a/client-android/serenada-core/src/test/java/org/webrtc/FakeWebRtcTransceivers.kt
+++ b/client-android/serenada-core/src/test/java/org/webrtc/FakeWebRtcTransceivers.kt
@@ -100,6 +100,11 @@ internal class FakePeerConnection(
     private val transceiverList: MutableList<RtpTransceiver>,
 ) : PeerConnection(NativePeerConnectionFactory { 0L }) {
 
+    var closeCalls = 0
+        private set
+    var disposeCalls = 0
+        private set
+
     override fun getTransceivers(): MutableList<RtpTransceiver> = transceiverList
     override fun getSenders(): MutableList<RtpSender> = mutableListOf()
     override fun getReceivers(): MutableList<RtpReceiver> = mutableListOf()
@@ -113,8 +118,8 @@ internal class FakePeerConnection(
     override fun connectionState(): PeerConnectionState = PeerConnectionState.CONNECTED
     override fun iceConnectionState(): IceConnectionState = IceConnectionState.CONNECTED
     override fun setConfiguration(config: RTCConfiguration): Boolean = true
-    override fun close() { /* no native */ }
-    override fun dispose() { /* no native */ }
+    override fun close() { closeCalls += 1 }
+    override fun dispose() { disposeCalls += 1 }
 }
 
 /**

--- a/docs/sdk/sdk-api-reference.md
+++ b/docs/sdk/sdk-api-reference.md
@@ -129,6 +129,13 @@ Android and iOS expose a pluggable audio coordination surface for hosts that nee
 
 The SDK's default audio coordinator is internal implementation detail. To use default behavior, leave `audioCoordinator` unset. To customize behavior, implement `SerenadaAudioCoordinator` and inject it through `SerenadaConfig`.
 
+On Android, coordinator lifecycle handoff is process-wide across all sessions and applies equally to
+default and custom coordinator instances. `activateCallSession()` runs on the main thread only after
+previous coordinator teardown has completed. `deactivateCallSession()` must be idempotent and must
+suspend until its focus, mode, route, Bluetooth, and callback cleanup is finished. Implementations
+should move blocking work off the main thread; fire-and-forget teardown is not supported because its
+work would outlive the SDK's handoff boundary.
+
 `AudioCoordinatorEvent.externalAudioStarted` / `ExternalAudioStarted` applies the configured external-audio mute and ducking policy. Use `playbackDuckingStarted` / `PlaybackDuckingStarted` for duck-only interruptions that should lower playback without muting capture.
 
 `isMicMuted` is composed from user mute, external-audio mute, and input-route availability. `isMicMutedByExternalAudio` lets host UIs distinguish coordinator-driven external audio from a manual user mute.

--- a/docs/sdk/sdk-integration-android.md
+++ b/docs/sdk/sdk-integration-android.md
@@ -295,6 +295,26 @@ val serenada = SerenadaCore(
 
 Custom coordinators implement `SerenadaAudioCoordinator`. They activate and deactivate call audio, apply route selections, publish `availableDevices`, `effectiveInputDevice`, `effectiveOutputDevice`, and emit `AudioCoordinatorEvent.ExternalAudioStarted` / `ExternalAudioEnded` when host-owned audio should temporarily mute local capture or duck playback. For duck-only interruptions that should not mute capture, emit `PlaybackDuckingStarted` / `PlaybackDuckingEnded`.
 
+### Coordinator lifecycle and teardown
+
+Serenada serializes audio-coordinator handoff process-wide across all `SerenadaSession` instances.
+Before calling `activateCallSession()`, the SDK waits for every previously started
+`deactivateCallSession()` to finish. This applies when both sessions use the default coordinator,
+both use custom coordinator instances, or ownership moves between default and custom coordinators.
+
+Android invokes coordinator activation and deactivation from the main thread. A custom coordinator
+must:
+
+- Keep `activateCallSession()` and `deactivateCallSession()` safe to call from the main thread.
+- Make `deactivateCallSession()` idempotent and suspend until audio focus, mode, route, Bluetooth,
+  and callback cleanup is complete.
+- Move blocking system calls or host-audio-queue work off the main thread, then return only after
+  that work has finished.
+
+Do not launch teardown work and return immediately. Once `deactivateCallSession()` returns, the SDK
+considers the process-wide audio resources available to the next session. Existing custom
+coordinators that already await their complete cleanup require no changes.
+
 The concrete default coordinator is internal SDK behavior, not a supported public class to instantiate. Leave `audioCoordinator = null` to use it.
 
 Custom UIs can observe and control the active coordinator through the session:


### PR DESCRIPTION
## Summary

- detach session-visible peer and local-media state synchronously during `leave()`
- move terminal camera/media disposal, peer connection close/dispose, and factory/audio-device release to the existing `serenada-pc-dispose` worker
- move default SDK audio-session deactivation off Main while preserving Main-thread behavior for host-provided audio coordinators
- add coverage for deferred terminal peer teardown and dispose-queue ordering

## Root cause

Terminal `SerenadaSession.leave()` synchronously performed native WebRTC and audio teardown on Main. Camera stop/dispose, peer connection close/dispose, and factory/audio-device release can wait on native media threads for hundreds of milliseconds, starving UI frames and exposing a black call-exit frame in Zello Android.

## Impact

`leave()` still transitions the session to `CallPhase.Idle` synchronously, but terminal native resource release may complete asynchronously. This keeps renderer/session state deterministic without blocking the host application's main thread.

## Validation

- `./gradlew :serenada-core:testDebugUnitTest`
- `./gradlew :serenada-core:lintDebug`
- `./gradlew :app:assembleDebug`
- physical-device video teardown on Galaxy S8 (Android 9) and A065 (Android 16): no teardown-time skipped-frame warnings
- locally published SDK integrated into Zello Android 7.13 debug on both devices
- Zello gated and ungated end-to-end video-call teardown recordings: no black exit frame and no teardown-time skipped-frame warning

A separate S8 activation-time frame skip was observed before call connection; it is outside the terminal teardown path changed here.

Jira: [ANDROID-3860](https://zelloptt.atlassian.net/browse/ANDROID-3860)