### PR TITLE
IOS-4505: Fix legacy screen share invisible to remote when started from a video-off call

### DIFF
--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -273,6 +273,11 @@ public final class SerenadaSession: ObservableObject {
     private var cameraPermissionRequestInFlight = false
     private var isScreenShareStartPending = false
     private var screenShareStartRequestSerial: Int64 = 0
+    /// Legacy path only: the user's video preference captured at screen-share
+    /// start, restored on stop so ending a share returns video to its pre-share
+    /// state (e.g. a call that began audio-only goes back to video-off) instead
+    /// of leaving the camera live.
+    private var preScreenShareVideoPreferred = false
     private var isVideoPausedByProximity = false
     private var reconnectRecoveryPending = false
     // True between transport reconnect and the first authoritative room_state
@@ -746,6 +751,9 @@ public final class SerenadaSession: ObservableObject {
     /// broadcast confirms.
     private func startScreenShareLegacy() {
         let wasVideoPreferred = userPreferredVideoEnabled
+        // Remember the pre-share preference so stopScreenShare can restore it
+        // (the camera is force-enabled below for the duration of the share).
+        preScreenShareVideoPreferred = wasVideoPreferred
         userPreferredVideoEnabled = true
         let requestSerial = beginScreenShareStartRequest()
         let startedRequest = webRtcEngine.startScreenShare { [weak self] started in
@@ -761,6 +769,14 @@ public final class SerenadaSession: ObservableObject {
                 }
                 self.broadcastLocalContentState(active: true, contentType: ContentTypeWire.screenShare)
                 self.applyLocalVideoPreference()
+                // Legacy screen share reuses the single camera video track, and the
+                // remote renders that surface only when the peer's advertised
+                // `videoEnabled` is true. Starting a share from a video-off call
+                // force-enables the local track but, without this, never tells the
+                // peer — so the receiver sees frames' m-line but renders nothing.
+                // `toggleVideo()` (the manual path) broadcasts media state; the
+                // screen-share start path must do the same.
+                self.broadcastLocalMediaState()
             }
         }
         if !startedRequest {
@@ -2591,7 +2607,13 @@ public final class SerenadaSession: ObservableObject {
                 }
                 self.commitSnapshot { _, d in d.isScreenSharing = false; d.cameraZoomFactor = 1 }
                 self.broadcastLocalContentState(active: false)
+                // Restore the pre-share video preference (start force-enabled it),
+                // then broadcast so the peer learns the new videoEnabled state.
+                // Without the broadcast a call that began audio-only would leave
+                // the camera live locally and the peer still believing video is on.
+                self.userPreferredVideoEnabled = self.preScreenShareVideoPreferred
                 self.applyLocalVideoPreference()
+                self.broadcastLocalMediaState()
             }
         }
         webRtcEngine.setOnZoomFactorChanged { [weak self] z in

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -278,6 +278,10 @@ public final class SerenadaSession: ObservableObject {
     /// state (e.g. a call that began audio-only goes back to video-off) instead
     /// of leaving the camera live.
     private var preScreenShareVideoPreferred = false
+    /// Legacy path only: set when the user explicitly toggles video during a
+    /// share. Suppresses the pre-share restore on stop so a deliberate in-share
+    /// choice (e.g. turning the camera off while sharing) survives the share.
+    private var userChangedVideoDuringScreenShare = false
     private var isVideoPausedByProximity = false
     private var reconnectRecoveryPending = false
     // True between transport reconnect and the first authoritative room_state
@@ -723,6 +727,11 @@ public final class SerenadaSession: ObservableObject {
         if enabled && !ensureCameraPermissionForVideoEnable(broadcastMediaStateOnGrant: broadcastMediaState) {
             return
         }
+        // An explicit toggle during a live/pending share is a deliberate choice
+        // that must outlive the share, so stop won't restore the pre-share value.
+        if diagnostics.isScreenSharing || isScreenShareStartPending {
+            userChangedVideoDuringScreenShare = true
+        }
         userPreferredVideoEnabled = enabled
         applyLocalVideoPreference()
         if broadcastMediaState {
@@ -754,6 +763,7 @@ public final class SerenadaSession: ObservableObject {
         // Remember the pre-share preference so stopScreenShare can restore it
         // (the camera is force-enabled below for the duration of the share).
         preScreenShareVideoPreferred = wasVideoPreferred
+        userChangedVideoDuringScreenShare = false
         userPreferredVideoEnabled = true
         let requestSerial = beginScreenShareStartRequest()
         let startedRequest = webRtcEngine.startScreenShare { [weak self] started in
@@ -2607,11 +2617,14 @@ public final class SerenadaSession: ObservableObject {
                 }
                 self.commitSnapshot { _, d in d.isScreenSharing = false; d.cameraZoomFactor = 1 }
                 self.broadcastLocalContentState(active: false)
-                // Restore the pre-share video preference (start force-enabled it),
-                // then broadcast so the peer learns the new videoEnabled state.
-                // Without the broadcast a call that began audio-only would leave
-                // the camera live locally and the peer still believing video is on.
-                self.userPreferredVideoEnabled = self.preScreenShareVideoPreferred
+                // Restore the pre-share video preference (start force-enabled it)
+                // UNLESS the user explicitly changed video during the share, in
+                // which case that deliberate choice wins. Then broadcast so the
+                // peer learns the resulting videoEnabled state — a call that began
+                // audio-only returns to video-off instead of leaving the camera live.
+                if !self.userChangedVideoDuringScreenShare {
+                    self.userPreferredVideoEnabled = self.preScreenShareVideoPreferred
+                }
                 self.applyLocalVideoPreference()
                 self.broadcastLocalMediaState()
             }


### PR DESCRIPTION
## Summary

Legacy screen share was invisible to the remote participant when the share was started from a call that began with video off. The sharer saw their own screen locally, but the receiver rendered a blank surface even though media was flowing.

**JIRA Ticket**: [IOS-4505](https://zelloptt.atlassian.net/browse/IOS-4505)

## Root cause

Legacy screen share reuses the single camera video track, and the remote renders that surface only when the peer's advertised `videoEnabled` is true. `startScreenShareLegacy()` force-enables the local video track but never broadcasts the local media state, so the peer never learns video turned on. The manual video toggle (`toggleVideo()`) does broadcast media state, which is why enabling video before starting a share is a working manual workaround.

## Fix

- Broadcast local media state on legacy screen-share start, so the peer renders the shared surface.
- Capture the pre-share video preference and, on stop, restore it and re-broadcast media state, so a call that began audio-only returns to video-off (camera not left live) and the peer is notified.

Both stop routes (the in-app control and stopping the broadcast from the system UI) funnel through the same `onScreenShareStopped` handler, so the restore fires either way. The independent-content path is unaffected: it rides a separate content track and never preempts the camera.

## Scope

One file, `SerenadaSession.swift`. No public API changes.

## Testing

Root cause confirmed on device: starting a share from a video-off call leaves the receiver blank, and manually enabling video first (which broadcasts media state via `toggleVideo()`) makes the receiver render. This change applies that same media-state broadcast automatically on start and restores state on stop. On-device verification of the fixed build is in progress.

Surfaced while integrating screen sharing into the Zello iOS client (IOS-4505).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
