### PR TITLE
Fix coturn recovery after host reboot

### DIFF
--- a/.github/workflows/cert-health.yml
+++ b/.github/workflows/cert-health.yml
@@ -32,11 +32,19 @@ jobs:
     steps:
       - name: Check ${{ matrix.host }}:${{ matrix.port }} cert has >= 21 days left
         run: |
-          set -o pipefail
           MIN_DAYS=21
-          CERT=$(echo | timeout 30 openssl s_client \
+          if ! TLS_OUTPUT=$(echo | timeout 30 openssl s_client \
             -connect "${{ matrix.host }}:${{ matrix.port }}" \
-            -servername "${{ matrix.host }}" 2>/dev/null | openssl x509)
+            -servername "${{ matrix.host }}" 2>&1); then
+            echo "$TLS_OUTPUT"
+            echo "::error::Unable to establish TLS connection to ${{ matrix.host }}:${{ matrix.port }}"
+            exit 1
+          fi
+          if ! CERT=$(echo "$TLS_OUTPUT" | openssl x509); then
+            echo "$TLS_OUTPUT"
+            echo "::error::TLS endpoint ${{ matrix.host }}:${{ matrix.port }} did not provide a readable certificate"
+            exit 1
+          fi
           echo "$CERT" | openssl x509 -noout -subject -enddate
           if ! echo "$CERT" | openssl x509 -noout -checkend $((MIN_DAYS * 24 * 3600)); then
             echo "::error::Certificate on ${{ matrix.host }}:${{ matrix.port }} expires within ${MIN_DAYS} days — auto-renewal is likely broken. SSH to the VPS and run: certbot renew --dry-run"

--- a/deploy.sh
+++ b/deploy.sh
@@ -188,7 +188,10 @@ fi
 #!/bin/bash
 set -e
 docker exec serenada-nginx nginx -s reload || true
-docker kill -s USR2 serenada-coturn || true
+# Send SIGUSR2 from inside the container. `docker kill` marks the container
+# manually stopped even for non-terminating signals, which prevents an
+# `unless-stopped` container from returning after a host reboot.
+docker exec serenada-coturn sh -c 'kill -USR2 1' || true
 HOOK_EOF
 \$SUDO chmod +x /etc/letsencrypt/renewal-hooks/deploy/serenada-reload.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   coturn:
     image: coturn/coturn:latest
     container_name: serenada-coturn
-    restart: unless-stopped
+    restart: always
     volumes:
       - ./coturn/turnserver.dev.conf:/etc/coturn/turnserver.conf
     command:


### PR DESCRIPTION
## Summary

- reload coturn certificates by signaling PID 1 from inside the container instead of using `docker kill`
- make coturn use `restart: always` so a stale manual-stop flag cannot strand it after a host reboot
- make `cert-health` distinguish connection failures from missing or expiring certificates

## Root cause

The certificate renewal hook used `docker kill -s USR2 serenada-coturn`. Docker records even non-terminating `docker kill` signals as a manual stop. When the `serenada-app.ru` VPS was shut down by its hypervisor on July 28, Docker therefore skipped the coturn container under its `unless-stopped` policy while restarting nginx and the app server.

## Production impact

`serenada-app.ru` coturn was restored, and the corrected hook plus reboot-safe restart policy were applied to both production VPSs. This PR makes those fixes durable for future deployments.

## Validation

- `bash -n deploy.sh`
- `git diff --check`
- parsed `.github/workflows/cert-health.yml`
- rendered the production Compose configuration and confirmed coturn resolves to `restart: always`
- executed the corrected renewal hook on both production VPSs; coturn stayed running with unchanged PIDs
- externally verified ports 3478 and 5349 plus certificate validity for both production hosts
- manually dispatched `cert-health`; all four jobs passed: https://github.com/agatx/serenada/actions/runs/30456347365