### PR TITLE
VoIP analytics fixes

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CallQualityTracker.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CallQualityTracker.kt
@@ -136,9 +136,7 @@ internal class CallQualityTracker(
             return
         }
 
-        // next == Connected -> recovery. countDisconnects is credited here,
-        // alongside countReconnects, rather than at dropout-open, so a live
-        // read mid-blip doesn't show a premature count.
+        // A recovered dropout contributes one disconnect and one reconnect.
         val openSince = dropoutOpenSinceMs ?: return
         val downtimeMs = max(0L, nowMs - openSince)
         totalDropoutDurationMs += downtimeMs
@@ -168,9 +166,7 @@ internal class CallQualityTracker(
     fun finalize(nowMs: Long) {
         if (finalized) return
         if (dropoutOpenSinceMs != null) {
-            // Unresolved at finalize (call ended while still disconnected) --
-            // the dropout's fate is now certain: a real, unrecovered link
-            // failure, so unlike a peer-departure close, it is still counted.
+            // A dropout still open at finalization is an unrecovered disconnect.
             closeDropoutSilently(nowMs)
             countDisconnects += 1
         }

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/CallQualityTracker.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/CallQualityTracker.kt
@@ -131,16 +131,18 @@ internal class CallQualityTracker(
             if (dropoutOpenSinceMs == null) {
                 dropoutOpenSinceMs = nowMs
                 dropoutTrigger = trigger
-                countDisconnects += 1
                 recompute()
             }
             return
         }
 
-        // next == Connected -> recovery.
+        // next == Connected -> recovery. countDisconnects is credited here,
+        // alongside countReconnects, rather than at dropout-open, so a live
+        // read mid-blip doesn't show a premature count.
         val openSince = dropoutOpenSinceMs ?: return
         val downtimeMs = max(0L, nowMs - openSince)
         totalDropoutDurationMs += downtimeMs
+        countDisconnects += 1
         countReconnects += 1
         val reason = dropoutTrigger
         dropoutOpenSinceMs = null
@@ -166,7 +168,11 @@ internal class CallQualityTracker(
     fun finalize(nowMs: Long) {
         if (finalized) return
         if (dropoutOpenSinceMs != null) {
+            // Unresolved at finalize (call ended while still disconnected) --
+            // the dropout's fate is now certain: a real, unrecovered link
+            // failure, so unlike a peer-departure close, it is still counted.
             closeDropoutSilently(nowMs)
+            countDisconnects += 1
         }
         recompute()
         finalized = true

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/CallQualityTrackerTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/CallQualityTrackerTest.kt
@@ -169,9 +169,9 @@ class CallQualityTrackerTest {
         assertEquals(before, t.summarize())
     }
 
-    // #1 — phantom reconnect on remote-leave.
+    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
     @Test
-    fun `no phantom reconnected when peer leaves mid-dropout`() {
+    fun `no phantom reconnected or disconnected when peer leaves mid-dropout`() {
         val t = tracker()
         t.onPhaseTransition(CallPhase.InCall, 1000)
         t.onConnectionStatusTransition(ConnectionStatus.Recovering, DropoutTrigger.NETWORK_LOST, 2000)
@@ -179,9 +179,31 @@ class CallQualityTrackerTest {
         t.onPhaseTransition(CallPhase.Waiting, 3000)
         t.onConnectionStatusTransition(ConnectionStatus.Connected, DropoutTrigger.UNKNOWN, 3000)
         val s = t.summarize()!!
-        assertEquals(1, s.countDisconnects)
+        // The departing peer's own connection tearing down is a teardown
+        // artifact, not a real link failure -- it must not count as a
+        // disconnect (this was the off-by-one: every call ends via someone
+        // leaving, so this inflated countDisconnects on every clean call).
+        assertEquals(0, s.countDisconnects)
         assertEquals(0, s.countReconnects)
         assertEquals(1000L, s.totalDropoutDurationMs)
+        assertTrue(events.isEmpty())
+    }
+
+    // Contrast with the teardown-artifact case above: here the dropout is
+    // still open when the call ends directly at finalize() -- no
+    // onPhaseTransition close in between -- so its fate is certain: a real,
+    // unrecovered link failure. Numbers mirror a real-device capture
+    // (countDisconnects=1, countReconnects=0, totalDropoutDurationMs=8379).
+    @Test
+    fun `unresolved dropout still open at finalize counts as a disconnect`() {
+        val t = tracker()
+        t.onPhaseTransition(CallPhase.InCall, 1000)
+        t.onConnectionStatusTransition(ConnectionStatus.Recovering, DropoutTrigger.NETWORK_LOST, 2000)
+        t.finalize(10_000)
+        val s = t.summarize()!!
+        assertEquals(1, s.countDisconnects)
+        assertEquals(0, s.countReconnects)
+        assertEquals(8_000, s.totalDropoutDurationMs)
         assertTrue(events.isEmpty())
     }
 

--- a/client-android/serenada-core/src/test/java/app/serenada/core/call/CallQualityTrackerTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/call/CallQualityTrackerTest.kt
@@ -169,7 +169,6 @@ class CallQualityTrackerTest {
         assertEquals(before, t.summarize())
     }
 
-    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
     @Test
     fun `no phantom reconnected or disconnected when peer leaves mid-dropout`() {
         val t = tracker()
@@ -179,21 +178,14 @@ class CallQualityTrackerTest {
         t.onPhaseTransition(CallPhase.Waiting, 3000)
         t.onConnectionStatusTransition(ConnectionStatus.Connected, DropoutTrigger.UNKNOWN, 3000)
         val s = t.summarize()!!
-        // The departing peer's own connection tearing down is a teardown
-        // artifact, not a real link failure -- it must not count as a
-        // disconnect (this was the off-by-one: every call ends via someone
-        // leaving, so this inflated countDisconnects on every clean call).
+        // Peer-departure teardown is not a link failure and must not
+        // contribute to the disconnect or reconnect counts.
         assertEquals(0, s.countDisconnects)
         assertEquals(0, s.countReconnects)
         assertEquals(1000L, s.totalDropoutDurationMs)
         assertTrue(events.isEmpty())
     }
 
-    // Contrast with the teardown-artifact case above: here the dropout is
-    // still open when the call ends directly at finalize() -- no
-    // onPhaseTransition close in between -- so its fate is certain: a real,
-    // unrecovered link failure. Numbers mirror a real-device capture
-    // (countDisconnects=1, countReconnects=0, totalDropoutDurationMs=8379).
     @Test
     fun `unresolved dropout still open at finalize counts as a disconnect`() {
         val t = tracker()
@@ -207,7 +199,6 @@ class CallQualityTrackerTest {
         assertTrue(events.isEmpty())
     }
 
-    // #9 — skip samples while a dropout is open.
     @Test
     fun `skips stats samples while a dropout is open`() {
         val t = tracker()
@@ -224,8 +215,7 @@ class CallQualityTrackerTest {
         assertEquals(2, s.qualitySampleCount)
     }
 
-    // #14 — only samples with a real quality contribution count. A
-    // baseline-only loss sample and a reset-skipped sample contribute nothing.
+    // Baseline-only loss samples and reset-skipped samples contribute nothing.
     @Test
     fun `counts only samples with a real quality contribution`() {
         val t = tracker()

--- a/client-ios/SerenadaCore/Sources/Call/CallQualityTracker.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CallQualityTracker.swift
@@ -118,16 +118,18 @@ final class CallQualityTracker {
             if dropoutOpenSinceMs == nil {
                 dropoutOpenSinceMs = nowMs
                 dropoutTrigger = trigger
-                countDisconnects += 1
                 recompute()
             }
             return
         }
 
-        // next == .connected -> recovery.
+        // next == .connected -> recovery. countDisconnects is credited here,
+        // alongside countReconnects, rather than at dropout-open, so a live
+        // read mid-blip doesn't show a premature count.
         guard let openSince = dropoutOpenSinceMs else { return }
         let downtimeMs = max(0, nowMs - openSince)
         totalDropoutDurationMs += downtimeMs
+        countDisconnects += 1
         countReconnects += 1
         let reason = dropoutTrigger
         dropoutOpenSinceMs = nil
@@ -149,7 +151,11 @@ final class CallQualityTracker {
     func finalize(nowMs: Int64) {
         guard !finalized else { return }
         if dropoutOpenSinceMs != nil {
+            // Unresolved at finalize (call ended while still disconnected) --
+            // the dropout's fate is now certain: a real, unrecovered link
+            // failure, so unlike a peer-departure close, it is still counted.
             closeDropoutSilently(nowMs: nowMs)
+            countDisconnects += 1
         }
         recompute()
         finalized = true

--- a/client-ios/SerenadaCore/Sources/Call/CallQualityTracker.swift
+++ b/client-ios/SerenadaCore/Sources/Call/CallQualityTracker.swift
@@ -123,9 +123,7 @@ final class CallQualityTracker {
             return
         }
 
-        // next == .connected -> recovery. countDisconnects is credited here,
-        // alongside countReconnects, rather than at dropout-open, so a live
-        // read mid-blip doesn't show a premature count.
+        // A recovered dropout contributes one disconnect and one reconnect.
         guard let openSince = dropoutOpenSinceMs else { return }
         let downtimeMs = max(0, nowMs - openSince)
         totalDropoutDurationMs += downtimeMs
@@ -151,9 +149,7 @@ final class CallQualityTracker {
     func finalize(nowMs: Int64) {
         guard !finalized else { return }
         if dropoutOpenSinceMs != nil {
-            // Unresolved at finalize (call ended while still disconnected) --
-            // the dropout's fate is now certain: a real, unrecovered link
-            // failure, so unlike a peer-departure close, it is still counted.
+            // A dropout still open at finalization is an unrecovered disconnect.
             closeDropoutSilently(nowMs: nowMs)
             countDisconnects += 1
         }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/CallQualityTrackerTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/CallQualityTrackerTests.swift
@@ -158,8 +158,8 @@ final class CallQualityTrackerTests: XCTestCase {
         XCTAssertEqual(t.summarize(), before)
     }
 
-    // #1 — phantom reconnect on remote-leave.
-    func testNoPhantomReconnectedWhenPeerLeavesMidDropout() {
+    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
+    func testNoPhantomReconnectedOrDisconnectedWhenPeerLeavesMidDropout() {
         let t = makeTracker()
         t.onPhaseTransition(.inCall, nowMs: 1000)
         t.onConnectionStatusTransition(.recovering, trigger: .networkLost, nowMs: 2000)
@@ -167,9 +167,29 @@ final class CallQualityTrackerTests: XCTestCase {
         t.onPhaseTransition(.waiting, nowMs: 3000)
         t.onConnectionStatusTransition(.connected, trigger: .unknown, nowMs: 3000)
         let s = t.summarize()!
-        XCTAssertEqual(s.countDisconnects, 1)
+        // The departing peer's own connection tearing down is a teardown
+        // artifact, not a real link failure -- it must not count as a
+        // disconnect (this was the off-by-one: every call ends via someone
+        // leaving, so this inflated countDisconnects on every clean call).
+        XCTAssertEqual(s.countDisconnects, 0)
         XCTAssertEqual(s.countReconnects, 0)
         XCTAssertEqual(s.totalDropoutDurationMs, 1000)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    // Contrast with the teardown-artifact case above: here the dropout is
+    // still open when the call ends directly at finalize() -- no
+    // onPhaseTransition close in between -- so its fate is certain: a real,
+    // unrecovered link failure.
+    func testUnresolvedDropoutStillOpenAtFinalizeCountsAsADisconnect() {
+        let t = makeTracker()
+        t.onPhaseTransition(.inCall, nowMs: 1000)
+        t.onConnectionStatusTransition(.recovering, trigger: .networkLost, nowMs: 2000)
+        t.finalize(nowMs: 10_000)
+        let s = t.summarize()!
+        XCTAssertEqual(s.countDisconnects, 1)
+        XCTAssertEqual(s.countReconnects, 0)
+        XCTAssertEqual(s.totalDropoutDurationMs, 8_000)
         XCTAssertTrue(events.isEmpty)
     }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/CallQualityTrackerTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/CallQualityTrackerTests.swift
@@ -158,7 +158,6 @@ final class CallQualityTrackerTests: XCTestCase {
         XCTAssertEqual(t.summarize(), before)
     }
 
-    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
     func testNoPhantomReconnectedOrDisconnectedWhenPeerLeavesMidDropout() {
         let t = makeTracker()
         t.onPhaseTransition(.inCall, nowMs: 1000)
@@ -167,20 +166,14 @@ final class CallQualityTrackerTests: XCTestCase {
         t.onPhaseTransition(.waiting, nowMs: 3000)
         t.onConnectionStatusTransition(.connected, trigger: .unknown, nowMs: 3000)
         let s = t.summarize()!
-        // The departing peer's own connection tearing down is a teardown
-        // artifact, not a real link failure -- it must not count as a
-        // disconnect (this was the off-by-one: every call ends via someone
-        // leaving, so this inflated countDisconnects on every clean call).
+        // Peer-departure teardown is not a link failure and must not
+        // contribute to the disconnect or reconnect counts.
         XCTAssertEqual(s.countDisconnects, 0)
         XCTAssertEqual(s.countReconnects, 0)
         XCTAssertEqual(s.totalDropoutDurationMs, 1000)
         XCTAssertTrue(events.isEmpty)
     }
 
-    // Contrast with the teardown-artifact case above: here the dropout is
-    // still open when the call ends directly at finalize() -- no
-    // onPhaseTransition close in between -- so its fate is certain: a real,
-    // unrecovered link failure.
     func testUnresolvedDropoutStillOpenAtFinalizeCountsAsADisconnect() {
         let t = makeTracker()
         t.onPhaseTransition(.inCall, nowMs: 1000)
@@ -193,7 +186,6 @@ final class CallQualityTrackerTests: XCTestCase {
         XCTAssertTrue(events.isEmpty)
     }
 
-    // #9 — skip samples while a dropout is open.
     func testSkipsStatsSamplesWhileDropoutOpen() {
         let t = makeTracker()
         t.onPhaseTransition(.inCall, nowMs: 1000)
@@ -209,8 +201,7 @@ final class CallQualityTrackerTests: XCTestCase {
         XCTAssertEqual(s.qualitySampleCount, 2)
     }
 
-    // #14 — only samples with a real quality contribution count. A
-    // baseline-only loss sample and a reset-skipped sample contribute nothing.
+    // Baseline-only loss samples and reset-skipped samples contribute nothing.
     func testCountsOnlySamplesWithARealQualityContribution() {
         let t = makeTracker()
         t.onPhaseTransition(.inCall, nowMs: 1000)

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTelemetryTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTelemetryTests.swift
@@ -1,11 +1,9 @@
 @testable import SerenadaCore
 import XCTest
 
-/// Session-level telemetry integration test — exercises the
-/// hand-ported wiring (CallQualityTracker feed from phase + connection-status
-/// transitions, ConnectionEvent dispatch, finalize-before-teardown ordering)
-/// end-to-end through the real `SerenadaSession`, not the tracker in isolation.
-/// This is where the #1 phantom-reconnect risk lives.
+/// Exercises the `CallQualityTracker` feed from phase and connection-status
+/// transitions, `ConnectionEvent` dispatch, and finalize-before-teardown
+/// ordering through `SerenadaSession`.
 @MainActor
 final class SerenadaSessionTelemetryTests: XCTestCase {
 
@@ -47,7 +45,6 @@ final class SerenadaSessionTelemetryTests: XCTestCase {
         XCTAssertEqual(summary?.countReconnects, 1)
     }
 
-    // #1 — phantom reconnect on remote-leave.
     func testPeerLeavingMidDropoutDoesNotEmitPhantomReconnected() async {
         let delegate = RecordingDelegate()
         let harness = SessionTestHarness(delegate: delegate)
@@ -70,7 +67,7 @@ final class SerenadaSessionTelemetryTests: XCTestCase {
         }
         XCTAssertTrue(reconnects.isEmpty)
         let summary = harness.session.qualitySummary
-        // Peer-departure teardown artifact -- not a real link failure.
+        // Peer-departure teardown is not a link failure.
         XCTAssertEqual(summary?.countDisconnects, 0)
         XCTAssertEqual(summary?.countReconnects, 0)
     }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTelemetryTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaSessionTelemetryTests.swift
@@ -70,7 +70,8 @@ final class SerenadaSessionTelemetryTests: XCTestCase {
         }
         XCTAssertTrue(reconnects.isEmpty)
         let summary = harness.session.qualitySummary
-        XCTAssertEqual(summary?.countDisconnects, 1)
+        // Peer-departure teardown artifact -- not a real link failure.
+        XCTAssertEqual(summary?.countDisconnects, 0)
         XCTAssertEqual(summary?.countReconnects, 0)
     }
 

--- a/client/packages/core/src/media/CallQualityTracker.ts
+++ b/client/packages/core/src/media/CallQualityTracker.ts
@@ -160,9 +160,7 @@ export class CallQualityTracker {
             return;
         }
 
-        // next === 'connected' → recovery. countDisconnects is credited here,
-        // alongside countReconnects, rather than at dropout-open, so a live
-        // read mid-blip doesn't show a premature count.
+        // A recovered dropout contributes one disconnect and one reconnect.
         if (this.dropoutOpenSinceMs !== null) {
             const downtimeMs = Math.max(0, now - this.dropoutOpenSinceMs);
             this.totalDropoutDurationMs += downtimeMs;
@@ -195,9 +193,7 @@ export class CallQualityTracker {
     finalize(now: number): void {
         if (this.finalized) return;
         if (this.dropoutOpenSinceMs !== null) {
-            // Unresolved at finalize (call ended while still disconnected) —
-            // the dropout's fate is now certain: a real, unrecovered link
-            // failure, so unlike a peer-departure close, it is still counted.
+            // A dropout still open at finalization is an unrecovered disconnect.
             this.closeDropoutSilently(now);
             this.countDisconnects += 1;
         }

--- a/client/packages/core/src/media/CallQualityTracker.ts
+++ b/client/packages/core/src/media/CallQualityTracker.ts
@@ -155,16 +155,18 @@ export class CallQualityTracker {
             if (this.dropoutOpenSinceMs === null) {
                 this.dropoutOpenSinceMs = now;
                 this.dropoutTrigger = trigger;
-                this.countDisconnects += 1;
                 this.recompute();
             }
             return;
         }
 
-        // next === 'connected' → recovery.
+        // next === 'connected' → recovery. countDisconnects is credited here,
+        // alongside countReconnects, rather than at dropout-open, so a live
+        // read mid-blip doesn't show a premature count.
         if (this.dropoutOpenSinceMs !== null) {
             const downtimeMs = Math.max(0, now - this.dropoutOpenSinceMs);
             this.totalDropoutDurationMs += downtimeMs;
+            this.countDisconnects += 1;
             this.countReconnects += 1;
             const reason = this.dropoutTrigger;
             this.dropoutOpenSinceMs = null;
@@ -193,7 +195,11 @@ export class CallQualityTracker {
     finalize(now: number): void {
         if (this.finalized) return;
         if (this.dropoutOpenSinceMs !== null) {
+            // Unresolved at finalize (call ended while still disconnected) —
+            // the dropout's fate is now certain: a real, unrecovered link
+            // failure, so unlike a peer-departure close, it is still counted.
             this.closeDropoutSilently(now);
+            this.countDisconnects += 1;
         }
         this.recompute();
         this.finalized = true;

--- a/client/packages/core/test/SerenadaSessionTelemetry.test.ts
+++ b/client/packages/core/test/SerenadaSessionTelemetry.test.ts
@@ -102,7 +102,8 @@ describe('SerenadaSession telemetry surface', () => {
         const reconnects = harness.connectionEvents.filter((e) => e.kind === 'reconnected');
         expect(reconnects).toHaveLength(0);
         const summary = harness.session.callQualitySummary;
-        expect(summary?.countDisconnects).toBe(1);
+        // Peer-departure teardown artifact — not a real link failure.
+        expect(summary?.countDisconnects).toBe(0);
         expect(summary?.countReconnects).toBe(0);
     });
 

--- a/client/packages/core/test/SerenadaSessionTelemetry.test.ts
+++ b/client/packages/core/test/SerenadaSessionTelemetry.test.ts
@@ -90,7 +90,6 @@ describe('SerenadaSession telemetry surface', () => {
         expect(reconnects.length).toBeGreaterThanOrEqual(1);
     });
 
-    // #1 — phantom reconnect on remote-leave (full session wiring).
     it('does not emit a phantom reconnected when the peer leaves mid-dropout', () => {
         enterInCall();
         // Link degrades while in-call (peer drops off the network).
@@ -102,13 +101,13 @@ describe('SerenadaSession telemetry surface', () => {
         const reconnects = harness.connectionEvents.filter((e) => e.kind === 'reconnected');
         expect(reconnects).toHaveLength(0);
         const summary = harness.session.callQualitySummary;
-        // Peer-departure teardown artifact — not a real link failure.
+        // Peer-departure teardown is not a link failure.
         expect(summary?.countDisconnects).toBe(0);
         expect(summary?.countReconnects).toBe(0);
     });
 
-    // #11 — host that destroys from its reconnected handler doesn't get a
-    // post-teardown state delivered.
+    // A host that destroys the session from its reconnected handler must not
+    // receive post-teardown state.
     it('survives leave()/destroy() called from a reconnected handler', () => {
         enterInCall();
         const statesAfter: number[] = [];

--- a/client/packages/core/test/media/CallQualityTracker.test.ts
+++ b/client/packages/core/test/media/CallQualityTracker.test.ts
@@ -184,8 +184,8 @@ describe('CallQualityTracker', () => {
         expect(tracker.summarize()).toEqual(before);
     });
 
-    // #1 — phantom reconnect on remote-leave.
-    it('does NOT emit a phantom reconnected when the peer leaves mid-dropout', () => {
+    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
+    it('does NOT emit a phantom reconnected or count a disconnect when the peer leaves mid-dropout', () => {
         const { tracker, events } = makeTracker();
         tracker.onPhaseTransition('inCall', 1000);
         // Link degrades (peer drops off the network).
@@ -195,10 +195,29 @@ describe('CallQualityTracker', () => {
         tracker.onPhaseTransition('waiting', 3000);
         tracker.onConnectionStatusTransition('connected', 'unknown', 3000);
         const s = tracker.summarize();
-        expect(s?.countDisconnects).toBe(1);
-        // The link never recovered — no reconnect, no reconnected event.
+        // The departing peer's own connection tearing down is a teardown
+        // artifact, not a real link failure — it must not count as a
+        // disconnect (this was the off-by-one: every call ends via someone
+        // leaving, so this inflated countDisconnects on every clean call).
+        expect(s?.countDisconnects).toBe(0);
         expect(s?.countReconnects).toBe(0);
-        expect(s?.totalDropoutDurationMs).toBe(1000); // 2000→3000 counted once
+        expect(s?.totalDropoutDurationMs).toBe(1000);
+        expect(events).toEqual([]);
+    });
+
+    // Contrast with the teardown-artifact case above: here the dropout is
+    // still open when the call ends directly at finalize() — no
+    // onPhaseTransition close in between — so its fate is certain: a real,
+    // unrecovered link failure.
+    it('counts a disconnect when the dropout is still open at finalize (no peer-departure close)', () => {
+        const { tracker, events } = makeTracker();
+        tracker.onPhaseTransition('inCall', 1000);
+        tracker.onConnectionStatusTransition('recovering', 'networkLost', 2000);
+        tracker.finalize(10_000);
+        const s = tracker.summarize();
+        expect(s?.countDisconnects).toBe(1);
+        expect(s?.countReconnects).toBe(0);
+        expect(s?.totalDropoutDurationMs).toBe(8_000);
         expect(events).toEqual([]);
     });
 

--- a/client/packages/core/test/media/CallQualityTracker.test.ts
+++ b/client/packages/core/test/media/CallQualityTracker.test.ts
@@ -184,7 +184,6 @@ describe('CallQualityTracker', () => {
         expect(tracker.summarize()).toEqual(before);
     });
 
-    // #1 / ANDROID-3835 bug 2 — phantom reconnect AND phantom disconnect on remote-leave.
     it('does NOT emit a phantom reconnected or count a disconnect when the peer leaves mid-dropout', () => {
         const { tracker, events } = makeTracker();
         tracker.onPhaseTransition('inCall', 1000);
@@ -195,20 +194,14 @@ describe('CallQualityTracker', () => {
         tracker.onPhaseTransition('waiting', 3000);
         tracker.onConnectionStatusTransition('connected', 'unknown', 3000);
         const s = tracker.summarize();
-        // The departing peer's own connection tearing down is a teardown
-        // artifact, not a real link failure — it must not count as a
-        // disconnect (this was the off-by-one: every call ends via someone
-        // leaving, so this inflated countDisconnects on every clean call).
+        // Peer-departure teardown is not a link failure and must not
+        // contribute to the disconnect or reconnect counts.
         expect(s?.countDisconnects).toBe(0);
         expect(s?.countReconnects).toBe(0);
         expect(s?.totalDropoutDurationMs).toBe(1000);
         expect(events).toEqual([]);
     });
 
-    // Contrast with the teardown-artifact case above: here the dropout is
-    // still open when the call ends directly at finalize() — no
-    // onPhaseTransition close in between — so its fate is certain: a real,
-    // unrecovered link failure.
     it('counts a disconnect when the dropout is still open at finalize (no peer-departure close)', () => {
         const { tracker, events } = makeTracker();
         tracker.onPhaseTransition('inCall', 1000);
@@ -221,7 +214,6 @@ describe('CallQualityTracker', () => {
         expect(events).toEqual([]);
     });
 
-    // #9 — skip samples while a dropout is open.
     it('skips stats samples while a dropout is open (no degraded-shoulder skew)', () => {
         const { tracker } = makeTracker();
         tracker.onPhaseTransition('inCall', 1000);
@@ -240,9 +232,8 @@ describe('CallQualityTracker', () => {
         expect(s?.qualitySampleCount).toBe(2);
     });
 
-    // #14 — only samples with a real quality contribution count. A
-    // baseline-only loss sample (no delta yet) and a reset-skipped sample
-    // (delta < 0) with no rtt/jitter gauges contribute nothing.
+    // Baseline-only loss samples and reset-skipped samples without RTT or
+    // jitter gauges contribute nothing.
     it('counts only samples with a real quality contribution', () => {
         const { tracker } = makeTracker();
         tracker.onPhaseTransition('inCall', 1000);


### PR DESCRIPTION
`count_disconnects` was overcounted by one on almost every call because a dropout was counted as soon as it opened. A dropout can also happen during a normal call end when the remote peer leaves, so this case was being included in the disconnect count.

The fix moves the increment to dropout close:

Recovered dropout -> counted together with countReconnects
Peer leaves -> closed without counting a disconnect
Still disconnected at finalize() -> counted as a real disconnect

Applied across Android, iOS, and web with matching tests. Verified on a real device.