### PR TITLE
Fix screen sharing visibility for legacy peers

### DIFF
--- a/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/SerenadaSession.kt
@@ -371,6 +371,9 @@ class SerenadaSession internal constructor(
             currentRoomState = roomState
             hostCid = roomState.hostCid
             updateParticipants(roomState)
+            if (config.enableIndependentContentVideo && _diagnostics.value.isScreenSharing) {
+                broadcastLocalMediaState()
+            }
         },
         onError = { callError, serverCode ->
             joinFlowCoordinator.clearJoinTimeout()
@@ -991,6 +994,7 @@ class SerenadaSession internal constructor(
         }
         updateDiagnostics(_diagnostics.value.copy(isScreenSharing = true))
         broadcastLocalContentState(true, ContentTypeWire.SCREEN_SHARE)
+        broadcastLocalMediaState()
     }
 
     /** Stop screen sharing and return to camera. */
@@ -1015,6 +1019,9 @@ class SerenadaSession internal constructor(
             } else {
                 broadcastLocalContentState(false)
             }
+            // Clear any targeted legacy compatibility state with the camera's
+            // real post-share value.
+            broadcastLocalMediaState()
         }
     }
 
@@ -1463,6 +1470,7 @@ class SerenadaSession internal constructor(
                             } else {
                                 broadcastLocalContentState(false)
                             }
+                            broadcastLocalMediaState()
                         } else {
                             broadcastLocalContentState(false)
                         }
@@ -1815,10 +1823,34 @@ class SerenadaSession internal constructor(
     }
 
     private fun broadcastLocalMediaState() {
+        val audioEnabled = _state.value.localAudioEnabled
+        val videoEnabled = _state.value.localVideoEnabled
         signalingMessageRouter.broadcastMediaState(
-            audioEnabled = _state.value.localAudioEnabled,
-            videoEnabled = _state.value.localVideoEnabled,
+            audioEnabled = audioEnabled,
+            videoEnabled = videoEnabled,
         )
+
+        // Independent senders keep camera state truthful for capable peers,
+        // while a legacy peer receives the screen track on its single camera
+        // sender. Legacy renderers gate that surface on videoEnabled, so a
+        // camera-off share needs an ephemeral peer-targeted compatibility state.
+        if (!config.enableIndependentContentVideo ||
+            !_diagnostics.value.isScreenSharing ||
+            videoEnabled
+        ) return
+        val localCid = clientId ?: return
+        currentRoomState?.participants?.forEach { participant ->
+            if (participant.cid != localCid &&
+                remoteVideoMediaEnabled(participant.cid) &&
+                !remoteSupportsIndependentContentVideo(participant.cid)
+            ) {
+                signalingMessageRouter.sendMediaState(
+                    audioEnabled = audioEnabled,
+                    videoEnabled = true,
+                    toCid = participant.cid,
+                )
+            }
+        }
     }
 
     /**

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingMessageRouter.kt
@@ -71,11 +71,19 @@ internal class SignalingMessageRouter(
     }
 
     fun broadcastMediaState(audioEnabled: Boolean, videoEnabled: Boolean) {
+        sendMediaStateInternal(audioEnabled, videoEnabled, null)
+    }
+
+    fun sendMediaState(audioEnabled: Boolean, videoEnabled: Boolean, toCid: String) {
+        sendMediaStateInternal(audioEnabled, videoEnabled, toCid)
+    }
+
+    private fun sendMediaStateInternal(audioEnabled: Boolean, videoEnabled: Boolean, toCid: String?) {
         val payload = JSONObject().apply {
             put("audioEnabled", audioEnabled)
             put("videoEnabled", videoEnabled)
         }
-        sendMessage("participant_media_state", payload, null)
+        sendMessage("participant_media_state", payload, toCid)
     }
 
     // --- Direct-dispatch methods for provider events ---
@@ -124,7 +132,7 @@ internal class SignalingMessageRouter(
                 onContentStateReceived(fromCid, active, contentType, revision)
             }
             "participant_media_state" -> {
-                val parsed = message.payload.toMediaStatePayload() ?: return
+                val parsed = message.payload.toMediaStatePayload(fallbackFromCid = message.from) ?: return
                 onMediaStateReceived(parsed.fromCid, parsed.audioEnabled, parsed.videoEnabled)
             }
             "offer", "answer", "ice", "media_restart_request" -> {

--- a/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
+++ b/client-android/serenada-core/src/main/java/app/serenada/core/call/SignalingPayloads.kt
@@ -146,9 +146,9 @@ internal fun JSONObject?.toContentStatePayload(): ContentStatePayload? {
     )
 }
 
-internal fun JSONObject?.toMediaStatePayload(): MediaStatePayload? {
+internal fun JSONObject?.toMediaStatePayload(fallbackFromCid: String? = null): MediaStatePayload? {
     this ?: return null
-    val fromCid = optString("from").ifBlank { return null }
+    val fromCid = optString("from").ifBlank { fallbackFromCid?.takeIf(String::isNotBlank) ?: return null }
     return MediaStatePayload(
         fromCid = fromCid,
         audioEnabled = if (has("audioEnabled")) optBoolean("audioEnabled") else null,

--- a/client-android/serenada-core/src/test/java/app/serenada/core/IndependentContentVideoTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/IndependentContentVideoTest.kt
@@ -117,6 +117,25 @@ class IndependentContentVideoTest {
     }
 
     @Test
+    fun `custom-provider media state uses PeerMessage sender when payload omits from`() {
+        factory.advanceToInCallWithTurn(localCid = "local", remoteCid = "remote")
+
+        factory.fakeProvider.simulateMessage(
+            from = "remote",
+            type = "participant_media_state",
+            payload = JSONObject().apply {
+                put("audioEnabled", true)
+                put("videoEnabled", false)
+            },
+        )
+        ShadowLooper.idleMainLooper()
+
+        val remote = factory.session.state.value.remoteParticipants.single()
+        assertFalse(remote.videoEnabled)
+        assertFalse(remote.cameraEnabled)
+    }
+
+    @Test
     fun `remote content_state inactive clears content`() {
         factory.advanceToInCallWithTurn(localCid = "local", remoteCid = "remote")
         factory.fakeProvider.simulateMessage(

--- a/client-android/serenada-core/src/test/java/app/serenada/core/IndependentScreenShareContractTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/IndependentScreenShareContractTest.kt
@@ -42,6 +42,7 @@ class IndependentScreenShareContractTest {
 
     private fun newFactory(
         enableIndependentContentVideo: Boolean = true,
+        defaultVideoEnabled: Boolean = true,
         videoMediaEnabled: Boolean = true,
         cameraModes: List<LocalCameraMode>? = null,
     ): TestSessionFactory {
@@ -52,6 +53,7 @@ class IndependentScreenShareContractTest {
             )
         return TestSessionFactory(
             enableIndependentContentVideo = enableIndependentContentVideo,
+            defaultVideoEnabled = defaultVideoEnabled,
             videoMediaEnabled = videoMediaEnabled,
             cameraModes = cameraModes,
         )
@@ -280,6 +282,57 @@ class IndependentScreenShareContractTest {
 
         assertEquals(true, factory.fakeMedia.createdSlotSupportsIndependent["remote-capable"])
         assertEquals(false, factory.fakeMedia.createdSlotSupportsIndependent["remote-legacy"])
+    }
+
+    @Test
+    fun `camera-off share targets custom provider media state only to legacy peer`() {
+        factory = newFactory(
+            enableIndependentContentVideo = true,
+            defaultVideoEnabled = false,
+        )
+        factory.fakeProvider.enqueueIceServers(Result.success(emptyList()))
+        factory.grantPermissionsAndStart()
+        factory.openSignaling()
+        factory.simulateJoinedResponse(
+            cid = "local-cid-1",
+            participants = listOf("local-cid-1" to 1L),
+            hostCid = "local-cid-1",
+        )
+        factory.simulateRoomStateWithCapabilities(
+            participants = listOf(
+                SignalingProviderParticipant(peerId = "local-cid-1", joinedAt = 1L),
+                SignalingProviderParticipant(
+                    peerId = "remote-capable",
+                    joinedAt = 2L,
+                    capabilities = SignalingProviderParticipantCapabilities(independentContentVideo = true),
+                    mediaPolicy = SignalingProviderParticipantMediaPolicy(videoMediaEnabled = true),
+                ),
+                SignalingProviderParticipant(
+                    peerId = "remote-legacy",
+                    joinedAt = 3L,
+                    mediaPolicy = SignalingProviderParticipantMediaPolicy(videoMediaEnabled = true),
+                ),
+            ),
+            hostCid = "local-cid-1",
+        )
+
+        factory.session.startScreenShare(Intent())
+        ShadowLooper.idleMainLooper()
+
+        val mediaStates = factory.fakeProvider.sentMessages("participant_media_state")
+        val actualState = mediaStates.last { it.isBroadcast }
+        assertEquals(false, actualState.payload?.optBoolean("videoEnabled"))
+        val targeted = mediaStates.filterNot { it.isBroadcast }
+        assertEquals(listOf("remote-legacy"), targeted.map { it.peerId })
+        assertEquals(true, targeted.single().payload?.optBoolean("videoEnabled"))
+
+        factory.session.stopScreenShare()
+        ShadowLooper.idleMainLooper()
+        assertEquals(
+            false,
+            factory.fakeProvider.sentMessages("participant_media_state")
+                .last { it.isBroadcast }.payload?.optBoolean("videoEnabled"),
+        )
     }
 
     // ── Mode matrix (flag on) ───────────────────────────────────────

--- a/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
+++ b/client-android/serenada-core/src/test/java/app/serenada/core/SerenadaServerProviderTest.kt
@@ -746,14 +746,24 @@ class SerenadaServerProviderTest {
             type = "offer",
             payload = JSONObject().apply { put("sdp", "offer-sdp") },
         )
+        provider.sendToPeer(
+            peerId = "legacy-peer",
+            type = "participant_media_state",
+            payload = JSONObject().apply {
+                put("audioEnabled", true)
+                put("videoEnabled", true)
+            },
+        )
         provider.broadcast(
             type = "content_state",
             payload = JSONObject().apply { put("active", true) },
         )
 
-        assertEquals(listOf("offer", "content_state"), signaling.sentMessages.map { it.type })
+        assertEquals(listOf("offer", "participant_media_state", "content_state"), signaling.sentMessages.map { it.type })
         assertEquals("peer-1", signaling.sentMessages.first().to)
         assertEquals("offer-sdp", signaling.sentMessages.first().payload?.optString("sdp"))
+        assertEquals("legacy-peer", signaling.sentMessages[1].to)
+        assertTrue(signaling.sentMessages[1].payload?.optBoolean("videoEnabled") == true)
         assertNull(signaling.sentMessages.last().to)
         assertTrue(signaling.sentMessages.last().payload?.optBoolean("active") == true)
     }

--- a/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
+++ b/client-ios/SerenadaCore/Sources/Call/SignalingMessageRouter.swift
@@ -177,7 +177,10 @@ final class SignalingMessageRouter {
             let revision = parseContentRevision(from: message.payload?["revision"])
             onContentState(ContentStatePayload(fromCid: fromCid, sid: message.sid, active: active, contentType: contentType, revision: revision))
         case "participant_media_state":
-            let payload = MediaStatePayload(from: message.payload.map { .object($0) })
+            let payload = MediaStatePayload(
+                from: message.payload.map { .object($0) },
+                fallbackFromCid: message.from
+            )
             onParticipantMediaState(payload)
         case "offer", "answer", "ice", "media_restart_request":
             var payload = message.payload ?? [:]
@@ -235,11 +238,19 @@ final class SignalingMessageRouter {
     }
 
     func broadcastMediaState(audioEnabled: Bool, videoEnabled: Bool) {
+        sendMediaState(audioEnabled: audioEnabled, videoEnabled: videoEnabled, to: nil)
+    }
+
+    func sendMediaState(audioEnabled: Bool, videoEnabled: Bool, to cid: String) {
+        sendMediaState(audioEnabled: audioEnabled, videoEnabled: videoEnabled, to: Optional(cid))
+    }
+
+    private func sendMediaState(audioEnabled: Bool, videoEnabled: Bool, to cid: String?) {
         let payload: [String: JSONValue] = [
             "audioEnabled": .bool(audioEnabled),
             "videoEnabled": .bool(videoEnabled),
         ]
-        sendMessage("participant_media_state", .object(payload), nil)
+        sendMessage("participant_media_state", .object(payload), cid)
     }
 
     // MARK: - Parsing Helpers

--- a/client-ios/SerenadaCore/Sources/SerenadaSession.swift
+++ b/client-ios/SerenadaCore/Sources/SerenadaSession.swift
@@ -819,6 +819,7 @@ public final class SerenadaSession: ObservableObject {
                 guard started else { return }
                 self.commitSnapshot { _, d in d.isScreenSharing = true }
                 self.broadcastLocalContentState(active: true, contentType: ContentTypeWire.screenShare)
+                self.broadcastLocalMediaState()
             }
         }
         if !startedRequest {
@@ -1314,6 +1315,9 @@ public final class SerenadaSession: ObservableObject {
         }
         hostCid = roomState.hostCid
         updateParticipants(roomState)
+        if config.enableIndependentContentVideo, diagnostics.isScreenSharing {
+            broadcastLocalMediaState()
+        }
     }
 
     private func handleSignalingPayload(_ message: SignalingMessage) {
@@ -1336,10 +1340,29 @@ public final class SerenadaSession: ObservableObject {
     }
 
     private func broadcastLocalMediaState() {
-        signalingMessageRouter?.broadcastMediaState(
-            audioEnabled: state.localParticipant.audioEnabled,
-            videoEnabled: state.localParticipant.videoEnabled
-        )
+        let audioEnabled = state.localParticipant.audioEnabled
+        let videoEnabled = state.localParticipant.videoEnabled
+        signalingMessageRouter?.broadcastMediaState(audioEnabled: audioEnabled, videoEnabled: videoEnabled)
+
+        // Independent senders keep camera state truthful for capable peers,
+        // while a legacy peer receives the screen track on its single camera
+        // sender. Legacy renderers gate that surface on videoEnabled, so a
+        // camera-off share needs an ephemeral peer-targeted compatibility state.
+        // The built-in server deliberately does not persist targeted media state;
+        // custom providers carry the same target through sendToPeer.
+        guard config.enableIndependentContentVideo,
+              diagnostics.isScreenSharing,
+              !videoEnabled,
+              let clientId else { return }
+        for participant in currentRoomState?.participants ?? [] where participant.cid != clientId {
+            guard remoteVideoMediaEnabled(participant.cid),
+                  !remoteSupportsIndependentContentVideo(participant.cid) else { continue }
+            signalingMessageRouter?.sendMediaState(
+                audioEnabled: audioEnabled,
+                videoEnabled: true,
+                to: participant.cid
+            )
+        }
     }
 
     private func seedLocalContentRevision(from roomState: RoomState) {
@@ -2621,6 +2644,9 @@ public final class SerenadaSession: ObservableObject {
                     } else {
                         self.broadcastLocalContentState(active: false)
                     }
+                    // Clear any targeted legacy compatibility state with the
+                    // camera's real post-share value.
+                    self.broadcastLocalMediaState()
                     return
                 }
                 self.commitSnapshot { _, d in d.isScreenSharing = false; d.cameraZoomFactor = 1 }

--- a/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
+++ b/client-ios/SerenadaCore/Sources/Signaling/SignalingPayloads.swift
@@ -278,11 +278,11 @@ struct MediaStatePayload {
     let audioEnabled: Bool?
     let videoEnabled: Bool?
 
-    init(from payload: JSONValue?) {
+    init(from payload: JSONValue?, fallbackFromCid: String? = nil) {
         guard let obj = payload?.objectValue else {
-            fromCid = nil; audioEnabled = nil; videoEnabled = nil; return
+            fromCid = fallbackFromCid; audioEnabled = nil; videoEnabled = nil; return
         }
-        fromCid = obj["from"]?.stringValue
+        fromCid = obj["from"]?.stringValue ?? fallbackFromCid
         audioEnabled = obj["audioEnabled"]?.boolValue
         videoEnabled = obj["videoEnabled"]?.boolValue
     }

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IndependentContentMediaTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IndependentContentMediaTests.swift
@@ -13,12 +13,14 @@ import XCTest
 final class IndependentContentMediaTests: XCTestCase {
 
     private func independentConfig(
+        defaultVideoEnabled: Bool = true,
         videoMediaEnabled: Bool = true,
         enable: Bool = true,
         screenShareMode: ScreenShareMode = .inAppOnly
     ) -> SerenadaConfig {
         SerenadaConfig(
             signalingProvider: FakeSignalingProvider(),
+            defaultVideoEnabled: defaultVideoEnabled,
             videoMediaEnabled: videoMediaEnabled,
             enableIndependentContentVideo: enable,
             screenShareMode: screenShareMode
@@ -370,6 +372,52 @@ final class IndependentContentMediaTests: XCTestCase {
 
         XCTAssertEqual(harness.fakeMedia.createdSlotSupportsIndependentContentVideo["remote-capable"], true)
         XCTAssertEqual(harness.fakeMedia.createdSlotSupportsIndependentContentVideo["remote-legacy"], false)
+        harness.tearDown()
+    }
+
+    func testCameraOffShareUsesTargetedCustomProviderStateOnlyForLegacyPeer() async {
+        let harness = SessionTestHarness(config: independentConfig(defaultVideoEnabled: false))
+        harness.fakeMedia.startScreenShareResult = true
+        harness.fakeProvider.iceServerResults = [.success([
+            IceServerConfig(urls: ["turn:turn.example.com:3478"], username: "u", credential: "p")
+        ])]
+        await harness.advancePastPermissions()
+        await harness.waitForLocalMedia()
+        harness.openSignaling()
+        harness.fakeProvider.simulateJoined(
+            peerId: "local-cid-1",
+            participants: [
+                SignalingProviderParticipant(peerId: "local-cid-1", joinedAt: 1),
+                SignalingProviderParticipant(
+                    peerId: "remote-capable", joinedAt: 2,
+                    capabilities: SignalingProviderParticipantCapabilities(independentContentVideo: true),
+                    mediaPolicy: SignalingProviderParticipantMediaPolicy(videoMediaEnabled: true)
+                ),
+                SignalingProviderParticipant(
+                    peerId: "remote-legacy", joinedAt: 3,
+                    mediaPolicy: SignalingProviderParticipantMediaPolicy(videoMediaEnabled: true)
+                )
+            ],
+            hostPeerId: "local-cid-1"
+        )
+        await harness.yieldToMainActor()
+
+        harness.session.startScreenShare()
+        await harness.yieldToMainActor()
+
+        let actualState = harness.fakeProvider.broadcastMessages(ofType: "participant_media_state").last?.payload
+        XCTAssertEqual(actualState?["videoEnabled"]?.boolValue, false, "capable peers keep the truthful camera-off state")
+        let targeted = harness.fakeProvider.sentPeerMessages(ofType: "participant_media_state")
+        XCTAssertEqual(targeted.map(\.peerId), ["remote-legacy"])
+        XCTAssertEqual(targeted.last?.payload?["videoEnabled"]?.boolValue, true, "legacy peer presents the swapped screen track")
+
+        harness.session.stopScreenShare()
+        await harness.yieldToMainActor()
+        XCTAssertEqual(
+            harness.fakeProvider.broadcastMessages(ofType: "participant_media_state").last?.payload?["videoEnabled"]?.boolValue,
+            false,
+            "stop clears the compatibility override with the real camera state"
+        )
         harness.tearDown()
     }
 

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IndependentContentStateTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/IndependentContentStateTests.swift
@@ -349,11 +349,12 @@ final class IndependentContentStateTests: XCTestCase {
         harness.fakeProvider.simulateMessage(
             from: "remote-cid-1",
             type: "participant_media_state",
-            payload: ["from": .string("remote-cid-1"), "audioEnabled": .bool(true), "videoEnabled": .bool(true)]
+            payload: ["audioEnabled": .bool(true), "videoEnabled": .bool(false)]
         )
         await harness.yieldToMainActor()
 
         let remote = harness.session.state.remoteParticipants.first(where: { $0.cid == "remote-cid-1" })
+        XCTAssertEqual(remote?.videoEnabled, false, "custom-provider PeerMessage.from identifies the sender")
         XCTAssertEqual(remote?.cameraEnabled, remote?.videoEnabled,
                        "Phase 1: remote cameraEnabled mirrors videoEnabled")
         harness.tearDown()

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/SerenadaServerProviderTests.swift
@@ -534,11 +534,18 @@ final class SerenadaServerProviderTests: XCTestCase {
 
     func testSendToPeerAndBroadcastForwardRawMessages() {
         provider.sendToPeer("peer-1", type: "offer", payload: ["sdp": .string("offer-sdp")])
+        provider.sendToPeer(
+            "legacy-peer",
+            type: "participant_media_state",
+            payload: ["audioEnabled": .bool(true), "videoEnabled": .bool(true)]
+        )
         provider.broadcast(type: "content_state", payload: ["active": .bool(true)])
 
-        XCTAssertEqual(signaling.sentMessages.map(\.type), ["offer", "content_state"])
+        XCTAssertEqual(signaling.sentMessages.map(\.type), ["offer", "participant_media_state", "content_state"])
         XCTAssertEqual(signaling.sentMessages.first?.to, "peer-1")
         XCTAssertEqual(signaling.sentMessages.first?.payload?.objectValue?["sdp"]?.stringValue, "offer-sdp")
+        XCTAssertEqual(signaling.sentMessages[1].to, "legacy-peer")
+        XCTAssertEqual(signaling.sentMessages[1].payload?.objectValue?["videoEnabled"]?.boolValue, true)
         XCTAssertNil(signaling.sentMessages.last?.to)
         XCTAssertEqual(signaling.sentMessages.last?.payload?.objectValue?["active"]?.boolValue, true)
     }

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -205,12 +205,7 @@ function upsertParticipant(
     }
     const participants = dedupeParticipants([
         ...(roomState?.participants ?? []),
-        {
-            cid: event.peerId,
-            joinedAt: event.joinedAt,
-            displayName: event.displayName,
-            peerId: event.appPeerId,
-        },
+        toRoomParticipant(event),
     ], localPeerId);
     return {
         hostCid: resolveHostCid(participants, roomState?.hostCid ?? null, localPeerId),
@@ -337,6 +332,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
     private readonly remoteContentStates = new Map<string, TrackedRemoteContent>();
     private readonly availableCameraModes: ConfigurableCameraMode[];
     private userPreferredVideoEnabled: boolean;
+    private lastObservedScreenSharing = false;
 
     // Wall-clock ms when the local transport last dropped while a roomState
     // was present (i.e. mid-call). Cleared on reconnect.
@@ -417,11 +413,15 @@ export class SerenadaSession implements SerenadaSessionHandle {
         );
         this.statsCollector = deps.statsCollector ?? new CallStatsCollector(config.logger);
         this.qualityTracker = new CallQualityTracker((event) => this.dispatchConnectionEvent(event));
+        this.lastObservedScreenSharing = this.media.isScreenSharing;
 
         this.bindProviderEvents();
         this.media.setOnChange(() => {
             if (this.isInactive) {
                 return;
+            }
+            if (this.observeScreenShareState()) {
+                this.broadcastLocalMediaState();
             }
             this.rebuildState();
         });
@@ -588,6 +588,7 @@ export class SerenadaSession implements SerenadaSessionHandle {
         if (this.config.videoMediaEnabled === false) return;
         const wasScreenSharing = this.media.isScreenSharing;
         await this.media.startScreenShare();
+        this.observeScreenShareState();
         if (!this.isInactive && !wasScreenSharing && this.media.isScreenSharing) {
             this.broadcastLocalMediaState();
             this.rebuildState();
@@ -598,8 +599,11 @@ export class SerenadaSession implements SerenadaSessionHandle {
     async stopScreenShare(): Promise<void> {
         const wasScreenSharing = this.media.isScreenSharing;
         await this.media.stopScreenShare();
+        const shouldBroadcastStop = this.observeScreenShareState();
         if (!this.isInactive && wasScreenSharing && !this.media.isScreenSharing) {
-            this.broadcastLocalMediaState();
+            if (shouldBroadcastStop) {
+                this.broadcastLocalMediaState();
+            }
             this.rebuildState();
         }
     }
@@ -1147,6 +1151,19 @@ export class SerenadaSession implements SerenadaSessionHandle {
             this.broadcastLocalMediaState();
             this.rebuildState();
         }
+    }
+
+    /**
+     * Track screen-share transitions observed through either the public session
+     * API or MediaEngine's change callback. Returning true exactly once for a
+     * stop lets browser-native capture termination clear peer compatibility
+     * state without duplicating the app-driven stop broadcast.
+     */
+    private observeScreenShareState(): boolean {
+        const isScreenSharing = this.media.isScreenSharing;
+        const didStop = this.lastObservedScreenSharing && !isScreenSharing;
+        this.lastObservedScreenSharing = isScreenSharing;
+        return didStop;
     }
 
     private broadcastLocalMediaState(): void {

--- a/client/packages/core/src/SerenadaSession.ts
+++ b/client/packages/core/src/SerenadaSession.ts
@@ -774,6 +774,9 @@ export class SerenadaSession implements SerenadaSessionHandle {
         this.maybeStartMediaLivenessTimer();
         this.flushPostReconnectResync('snapshot');
         this.rebuildState();
+        if (this.config.enableIndependentContentVideo === true && this.media.isScreenSharing) {
+            this.broadcastLocalMediaState();
+        }
     };
 
     private readonly handlePeerJoined = (event: PeerEvent): void => {
@@ -1155,10 +1158,28 @@ export class SerenadaSession implements SerenadaSessionHandle {
         // the camera) — derive from track presence so we never advertise
         // camera-on while reacquire is pending or has failed. Pre-media-start
         // (no stream) we fall back to the user's stated preference.
-        this.signaling.broadcast('participant_media_state', {
-            audioEnabled: audioTrack?.enabled ?? (this.config.defaultAudioEnabled !== false),
-            videoEnabled: stream ? !!videoTrack && videoTrack.enabled : this.userPreferredVideoEnabled,
-        });
+        const audioEnabled = audioTrack?.enabled ?? (this.config.defaultAudioEnabled !== false);
+        const videoEnabled = stream ? !!videoTrack && videoTrack.enabled : this.userPreferredVideoEnabled;
+        this.signaling.broadcast('participant_media_state', { audioEnabled, videoEnabled });
+
+        // Independent senders keep camera state truthful for capable peers,
+        // while a legacy peer receives the screen track on its single camera
+        // sender. Legacy renderers gate that surface on videoEnabled, so a
+        // camera-off share needs an ephemeral peer-targeted compatibility state.
+        if (this.config.enableIndependentContentVideo !== true ||
+            !this.media.isScreenSharing ||
+            videoEnabled
+        ) return;
+        for (const participant of this.roomState?.participants ?? []) {
+            if (participant.cid === this.clientId ||
+                !this.getRemoteVideoMediaEnabled(participant.cid) ||
+                this.getRemoteIndependentContentVideo(participant.cid)
+            ) continue;
+            this.signaling.sendToPeer(participant.cid, 'participant_media_state', {
+                audioEnabled,
+                videoEnabled: true,
+            });
+        }
     }
 
     private handleRemoteMediaState(message: PeerMessage): void {

--- a/client/packages/core/src/SignalingProvider.ts
+++ b/client/packages/core/src/SignalingProvider.ts
@@ -56,13 +56,12 @@ export interface RoomStateEvent {
     maxParticipants?: number;
 }
 
-export interface PeerEvent {
-    peerId: string;
-    joinedAt?: number;
-    displayName?: string;
-    /** Host-supplied stable identity — see {@link JoinOptions.appPeerId}. */
-    appPeerId?: string;
-}
+/**
+ * Incremental participant event. Providers should include the same capability,
+ * media-policy, and presentation metadata they expose in room snapshots so a
+ * consumer can act on the event before the following `roomStateUpdated`.
+ */
+export type PeerEvent = SignalingProviderParticipant;
 
 export interface PeerMessage {
     from: string;
@@ -135,6 +134,12 @@ export interface SignalingProvider {
     joinRoom(roomId: string, options?: JoinOptions): void;
     leaveRoom(): void;
     endRoom(): void;
+    /**
+     * Deliver a message only to `peerId`. In particular, a targeted
+     * `participant_media_state` is ephemeral compatibility state: providers
+     * and their relays must not broadcast it, persist it, or replay it in room
+     * snapshots.
+     */
     sendToPeer(peerId: string, type: string, payload: unknown): void;
     broadcast(type: string, payload: unknown): void;
     getIceServers(): Promise<RTCIceServer[]>;

--- a/client/packages/core/test/SerenadaServerProvider.test.ts
+++ b/client/packages/core/test/SerenadaServerProvider.test.ts
@@ -141,7 +141,12 @@ describe('SerenadaServerProvider', () => {
                 hostCid: 'peer-b',
                 participants: [
                     { cid: 'local-cid', joinedAt: 1 },
-                    { cid: 'peer-b', joinedAt: 3 },
+                    {
+                        cid: 'peer-b',
+                        joinedAt: 3,
+                        capabilities: { independentContentVideo: true },
+                        mediaPolicy: { videoMediaEnabled: true },
+                    },
                 ],
             },
         });
@@ -165,12 +170,22 @@ describe('SerenadaServerProvider', () => {
             hostPeerId: 'local-cid',
             maxParticipants: undefined,
         });
-        expect(peerJoined).toHaveBeenCalledWith({ peerId: 'peer-b', joinedAt: 3 });
+        expect(peerJoined).toHaveBeenCalledWith(expect.objectContaining({
+            peerId: 'peer-b',
+            joinedAt: 3,
+            capabilities: { independentContentVideo: true },
+            mediaPolicy: { videoMediaEnabled: true },
+        }));
         expect(peerLeft).toHaveBeenCalledWith({ peerId: 'peer-a', joinedAt: 2 });
         expect(roomStateUpdated).toHaveBeenCalledWith({
             participants: [
                 { peerId: 'local-cid', joinedAt: 1 },
-                { peerId: 'peer-b', joinedAt: 3 },
+                expect.objectContaining({
+                    peerId: 'peer-b',
+                    joinedAt: 3,
+                    capabilities: { independentContentVideo: true },
+                    mediaPolicy: { videoMediaEnabled: true },
+                }),
             ],
             hostPeerId: 'peer-b',
             maxParticipants: undefined,

--- a/client/packages/core/test/SerenadaServerProvider.test.ts
+++ b/client/packages/core/test/SerenadaServerProvider.test.ts
@@ -413,6 +413,10 @@ describe('SerenadaServerProvider', () => {
         const engine = mockEngineInstances[0] as InstanceType<typeof MockSignalingEngine>;
 
         provider.sendToPeer('peer-1', 'offer', { sdp: 'offer-sdp' });
+        provider.sendToPeer('legacy-peer', 'participant_media_state', {
+            audioEnabled: true,
+            videoEnabled: true,
+        });
         provider.broadcast('content_state', { active: true });
 
         expect(engine.sendMessageCalls).toEqual([
@@ -420,6 +424,11 @@ describe('SerenadaServerProvider', () => {
                 type: 'offer',
                 payload: { sdp: 'offer-sdp' },
                 to: 'peer-1',
+            },
+            {
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: true },
+                to: 'legacy-peer',
             },
             {
                 type: 'content_state',

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -1506,6 +1506,62 @@ describe('SerenadaSession', () => {
             expect(harness.state.localParticipant?.videoEnabled).toBe(true);
         });
 
+        it('targets camera-off screen-share compatibility only to a legacy peer through a custom provider', async () => {
+            harness = new TestSessionHarness({
+                config: {
+                    defaultVideoEnabled: false,
+                    enableIndependentContentVideo: true,
+                },
+            });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [
+                    { cid: 'me' },
+                    {
+                        cid: 'peer-capable',
+                        capabilities: { independentContentVideo: true },
+                        mediaPolicy: { videoMediaEnabled: true },
+                    },
+                    {
+                        cid: 'peer-legacy',
+                        mediaPolicy: { videoMediaEnabled: true },
+                    },
+                ],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.signaling.broadcastCalls.length = 0;
+            harness.signaling.sendToPeerCalls.length = 0;
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = true;
+                // Independent content leaves the camera stream audio-only.
+                harness.media.localStream = createMediaStream({ audio: true });
+            });
+
+            await harness.session.startScreenShare();
+
+            expect(harness.signaling.broadcastCalls).toContainEqual({
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: false },
+            });
+            expect(harness.signaling.sendToPeerCalls).toEqual([{
+                peerId: 'peer-legacy',
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: true },
+            }]);
+            expect(harness.state.localParticipant?.videoEnabled).toBe(false);
+
+            harness.media.stopScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = false;
+            });
+            await harness.session.stopScreenShare();
+
+            expect(harness.signaling.broadcastCalls.at(-1)).toEqual({
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: false },
+            });
+        });
+
         it('allows screen share when camera modes are empty', async () => {
             harness = new TestSessionHarness({
                 config: { cameraModes: [] },

--- a/client/packages/core/test/SerenadaSession.test.ts
+++ b/client/packages/core/test/SerenadaSession.test.ts
@@ -1552,14 +1552,89 @@ describe('SerenadaSession', () => {
             expect(harness.state.localParticipant?.videoEnabled).toBe(false);
 
             harness.media.stopScreenShare = vi.fn(async () => {
-                harness.media.isScreenSharing = false;
+                harness.media.emit({ isScreenSharing: false });
             });
+            const broadcastsBeforeStop = harness.signaling.broadcastCalls.length;
             await harness.session.stopScreenShare();
 
-            expect(harness.signaling.broadcastCalls.at(-1)).toEqual({
+            expect(harness.signaling.broadcastCalls.slice(broadcastsBeforeStop)).toEqual([{
                 type: 'participant_media_state',
                 payload: { audioEnabled: true, videoEnabled: false },
+            }]);
+        });
+
+        it('clears the legacy compatibility state when browser-native screen sharing stops', async () => {
+            harness = new TestSessionHarness({
+                config: {
+                    defaultVideoEnabled: false,
+                    enableIndependentContentVideo: true,
+                },
             });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({
+                clientId: 'me',
+                participants: [{ cid: 'me' }, { cid: 'peer-legacy' }],
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.emit({ isScreenSharing: true });
+            });
+
+            await harness.session.startScreenShare();
+            expect(harness.signaling.sendToPeerCalls.at(-1)).toEqual({
+                peerId: 'peer-legacy',
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: true },
+            });
+
+            harness.signaling.broadcastCalls.length = 0;
+            harness.signaling.sendToPeerCalls.length = 0;
+            // Models MediaEngine's displayTrack.onended callback after the user
+            // presses the browser's native "Stop sharing" control.
+            harness.media.emit({ isScreenSharing: false });
+
+            expect(harness.signaling.broadcastCalls).toEqual([{
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: false },
+            }]);
+            expect(harness.signaling.sendToPeerCalls).toEqual([]);
+        });
+
+        it('uses peerJoined capability metadata before targeting a screen-share override', async () => {
+            harness = new TestSessionHarness({
+                config: {
+                    defaultVideoEnabled: false,
+                    enableIndependentContentVideo: true,
+                },
+            });
+            harness.media.startLocalMediaResult = createMediaStream({ audio: true });
+            harness.simulateJoined({ clientId: 'me', participants: [{ cid: 'me' }] });
+            await vi.advanceTimersByTimeAsync(0);
+            harness.media.startScreenShare = vi.fn(async () => {
+                harness.media.isScreenSharing = true;
+            });
+            await harness.session.startScreenShare();
+            harness.signaling.broadcastCalls.length = 0;
+            harness.signaling.sendToPeerCalls.length = 0;
+
+            harness.signaling.emitPeerJoined({
+                peerId: 'peer-capable',
+                capabilities: { independentContentVideo: true },
+                mediaPolicy: { videoMediaEnabled: true },
+            });
+
+            expect(harness.signaling.broadcastCalls).toEqual([{
+                type: 'participant_media_state',
+                payload: { audioEnabled: true, videoEnabled: false },
+            }]);
+            expect(harness.signaling.sendToPeerCalls).toEqual([]);
+            expect(harness.media.updateRoomStateCalls.at(-1)?.state?.participants).toContainEqual(
+                expect.objectContaining({
+                    cid: 'peer-capable',
+                    capabilities: { independentContentVideo: true },
+                    mediaPolicy: { videoMediaEnabled: true },
+                }),
+            );
         });
 
         it('allows screen share when camera modes are empty', async () => {

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -848,10 +848,13 @@ camera remains off.
 **Server behavior**
 - Stores the audio/video state in the room per-CID so late joiners receive the latest values via the participant list in `joined`/`room_state`.
 - Relays the message to other room participants as a peer message (with a `from` field) instead of broadcasting `room_state`. This avoids participant reordering and full UI rebuilds on every toggle.
-- When top-level `to` is present, relays only to that active CID and does not
-  persist the payload. Targeted compatibility state therefore cannot overwrite
-  the sender's authoritative camera state in later `joined`/`room_state`
-  snapshots.
+- When top-level `to` is present, the relay **MUST** deliver the message only to
+  that active CID and **MUST NOT** persist, broadcast, or replay the payload in
+  `joined`/`room_state` snapshots. Clients depend on this behavior: treating a
+  targeted compatibility state as authoritative media state is a protocol
+  violation that can expose a false camera-on state to capable peers and late
+  joiners. This requirement applies equally to the built-in server and custom
+  signaling-provider backends.
 
 **Client behavior**
 - On receiving a relayed `participant_media_state`, update the cached audio/video state for the sender. Only fields present in the payload should be updated; missing fields leave the previous value intact.

--- a/docs/serenada_protocol_v1.md
+++ b/docs/serenada_protocol_v1.md
@@ -823,6 +823,12 @@ Sent by a client to announce its current audio/video enabled state. The server s
 
 Clients should broadcast this message after joining, when a new peer joins, and whenever the local audio or video enabled state changes.
 
+Clients may also include a top-level `to` CID to send an ephemeral per-peer
+compatibility state. This is used when a capable sender routes an independent
+content track onto a legacy peer's single video sender: that peer temporarily
+needs `videoEnabled: true` to present the screen track even when the sender's
+camera remains off.
+
 ```json
 {
   "v": 1,
@@ -842,6 +848,10 @@ Clients should broadcast this message after joining, when a new peer joins, and 
 **Server behavior**
 - Stores the audio/video state in the room per-CID so late joiners receive the latest values via the participant list in `joined`/`room_state`.
 - Relays the message to other room participants as a peer message (with a `from` field) instead of broadcasting `room_state`. This avoids participant reordering and full UI rebuilds on every toggle.
+- When top-level `to` is present, relays only to that active CID and does not
+  persist the payload. Targeted compatibility state therefore cannot overwrite
+  the sender's authoritative camera state in later `joined`/`room_state`
+  snapshots.
 
 **Client behavior**
 - On receiving a relayed `participant_media_state`, update the cached audio/video state for the sender. Only fields present in the payload should be updated; missing fields leave the previous value intact.

--- a/server/independent_content_test.go
+++ b/server/independent_content_test.go
@@ -244,6 +244,85 @@ func TestOmittedRejoinPreservesStoredCapabilitiesAndMediaPolicy(t *testing.T) {
 	}
 }
 
+// --- targeted media-state compatibility -------------------------------------
+
+func TestTargetedMediaStateRelaysOnlyToTargetWithoutPersisting(t *testing.T) {
+	rid := mustTestRoomID(t)
+	hub := newHub(4)
+
+	a := fakeClient(hub)
+	hub.registerClient(a)
+	hub.handleMessage(a, joinPayload(rid, 4, 4))
+	aJoined := captureJoined(t, a)
+
+	b := fakeClient(hub)
+	hub.registerClient(b)
+	hub.handleMessage(b, joinPayload(rid, 4, 4))
+	bJoined := captureJoined(t, b)
+
+	c := fakeClient(hub)
+	hub.registerClient(c)
+	hub.handleMessage(c, joinPayload(rid, 4, 4))
+	captureJoined(t, c)
+	drainMessages(a)
+	drainMessages(b)
+	drainMessages(c)
+
+	// The sender's real camera state is broadcast and persisted.
+	actualPayload, _ := json.Marshal(map[string]interface{}{
+		"audioEnabled": true,
+		"videoEnabled": false,
+	})
+	hub.handleMessage(a, mustMarshal(Message{
+		V: 1, Type: "participant_media_state", RID: rid, Payload: actualPayload,
+	}))
+	drainMessages(b)
+	drainMessages(c)
+
+	// During independent screen share, only the legacy peer gets an ephemeral
+	// videoEnabled=true override so it presents the swapped single video track.
+	compatPayload, _ := json.Marshal(map[string]interface{}{
+		"audioEnabled": true,
+		"videoEnabled": true,
+	})
+	hub.handleMessage(a, mustMarshal(Message{
+		V: 1, Type: "participant_media_state", RID: rid, To: bJoined.CID, Payload: compatPayload,
+	}))
+
+	var targetedState struct {
+		From         string `json:"from"`
+		VideoEnabled bool   `json:"videoEnabled"`
+	}
+	var sawTargeted bool
+	for _, message := range drainMessages(b) {
+		if message.Type != "participant_media_state" {
+			continue
+		}
+		if err := json.Unmarshal(message.Payload, &targetedState); err == nil {
+			sawTargeted = targetedState.From == aJoined.CID && targetedState.VideoEnabled
+		}
+	}
+	if !sawTargeted {
+		t.Fatal("expected targeted videoEnabled=true media state on legacy peer")
+	}
+	for _, message := range drainMessages(c) {
+		if message.Type == "participant_media_state" {
+			t.Fatal("targeted media state leaked to a non-target peer")
+		}
+	}
+
+	// The targeted compatibility value must not replace the authoritative
+	// camera-off state stored for late joiners.
+	d := fakeClient(hub)
+	hub.registerClient(d)
+	hub.handleMessage(d, joinPayload(rid, 4, 4))
+	dJoined := captureJoined(t, d)
+	aEntry := findParticipant(dJoined.Participants, aJoined.CID)
+	if aEntry == nil || aEntry.VideoEnabled == nil || *aEntry.VideoEnabled {
+		t.Fatalf("expected persisted camera state videoEnabled=false, got %+v", aEntry)
+	}
+}
+
 // --- content_state revision relay + persist ----------------------------------
 
 func TestContentStateRevisionRelayedVerbatim(t *testing.T) {

--- a/server/signaling.go
+++ b/server/signaling.go
@@ -1773,11 +1773,19 @@ func (h *Hub) handleMediaState(c *Client, msg Message) {
 	if p == nil || p.Client != c {
 		return
 	}
-	if payload.AudioEnabled != nil {
-		p.AudioEnabled = payload.AudioEnabled
-	}
-	if payload.VideoEnabled != nil {
-		p.VideoEnabled = payload.VideoEnabled
+	// Broadcast media state is authoritative and persisted for late joiners.
+	// A targeted state is an ephemeral per-peer compatibility override (for
+	// example, making an independent screen-share track visible to a legacy
+	// receiver that gates its single video surface on videoEnabled). Persisting
+	// that override would falsely advertise the sender's camera state to capable
+	// peers and future room snapshots.
+	if msg.To == "" {
+		if payload.AudioEnabled != nil {
+			p.AudioEnabled = payload.AudioEnabled
+		}
+		if payload.VideoEnabled != nil {
+			p.VideoEnabled = payload.VideoEnabled
+		}
 	}
 
 	// Relay as peer message (like offer/answer/ice) instead of broadcasting
@@ -1800,9 +1808,10 @@ func (h *Hub) handleMediaState(c *Client, msg Message) {
 		Payload: newPayload,
 	}
 	for client, cid := range room.byClient {
-		if cid != c.cid {
-			client.sendMessage(relayMsg)
+		if cid == c.cid || (msg.To != "" && msg.To != cid) {
+			continue
 		}
+		client.sendMessage(relayMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep the sender's authoritative camera state separate from the temporary legacy screen-share presentation state
- send a targeted `videoEnabled: true` compatibility override only to peers that do not support independent content video
- apply the behavior consistently across iOS, Android, and web, including custom signaling provider receive paths
- make targeted `participant_media_state` messages ephemeral on the built-in server and document the protocol behavior

## Why

When a sender shared content with its camera off, capable peers used the independent content track correctly. Legacy peers received the screen track through their single video sender, but their UI could still hide it because the sender's authoritative media state remained `videoEnabled: false`.

The compatibility override must be peer-specific: broadcasting or persisting `videoEnabled: true` would falsely advertise that the sender's camera is enabled to capable peers and late joiners.

## Verification

- Production E2E against `https://serenada.app` with four real WebSocket clients:
  - room creation and all joins succeeded
  - authoritative camera-off state reached both legacy and capable peers
  - targeted compatibility state reached the selected legacy peer
  - targeted state did not reach a capable non-target peer
  - a late joiner still received the persisted camera-off state
- Server: `go test ./...`
- Web core: 516 tests passed
- Web production build: `npm run build`
- Android core unit tests: `:serenada-core:testDebugUnitTest`
- iOS focused unit tests: 68 tests passed across independent content and server-provider suites
- Signaling protocol and resilience constant checks
- `git diff --check`
