### PR TITLE
Fix iOS WebRTC sender track identity checks

### DIFF
--- a/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
+++ b/client-ios/SerenadaCore/Sources/Call/PeerConnectionSlot.swift
@@ -467,19 +467,21 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
     /// role is bound and the sender does not already carry the right track, so
     /// pending content attaches regardless of how it became pending (owner,
     /// answerer, late-join, replaceTrack-reject retry). Idempotent via the
-    /// `sender.track !== track` guard.
+    /// semantic sender-track comparison.
     private func attachBoundVideoTracks() {
         if let camera = cameraTransceiver {
             ensureRoleSendCapable(camera)
-            if camera.sender.track !== localVideoTrack {
+            if !senderTrack(camera.sender.track, matches: localVideoTrack) {
                 camera.sender.track = localVideoTrack
             }
         }
         // Reconcile the content sender to match the current local content track:
         // attach when a track is set (pending or live), detach (track = nil)
-        // when it has been cleared on stop. The `sender.track !== track`
-        // idempotence guard makes a re-entry a no-op.
-        if let content = contentTransceiver, content.sender.track !== localContentTrack {
+        // when it has been cleared on stop. Semantic comparison makes a re-entry
+        // a no-op even though libwebrtc returns a fresh Objective-C track wrapper
+        // on every sender.track read.
+        if let content = contentTransceiver,
+           !senderTrack(content.sender.track, matches: localContentTrack) {
             if let track = localContentTrack {
                 ensureRoleSendCapable(content)
                 replaceContentTrackWithFallback(content, track: track)
@@ -501,7 +503,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
     /// renegotiation fallback.
     private func replaceContentTrackWithFallback(_ content: RTCRtpTransceiver, track: RTCVideoTrack) {
         content.sender.track = track
-        if content.sender.track === track {
+        if senderTrack(content.sender.track, matches: track) {
             applyContentSenderParameters(content)
             return
         }
@@ -511,6 +513,23 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
             "[\(remoteCid)] Failed to set content sender track; renegotiating"
         )
         onRenegotiationNeeded(remoteCid)
+    }
+
+    /// `RTCRtpSender.track` returns a fresh Objective-C wrapper on each read.
+    /// Compare the underlying WebRTC tracks semantically as required by the
+    /// WebRTC API, while preserving nil as the detached-track state.
+    private func senderTrack(
+        _ senderTrack: RTCMediaStreamTrack?,
+        matches expectedTrack: RTCMediaStreamTrack?
+    ) -> Bool {
+        switch (senderTrack, expectedTrack) {
+        case (nil, nil):
+            return true
+        case let (senderTrack?, expectedTrack?):
+            return senderTrack.isEqual(expectedTrack)
+        default:
+            return false
+        }
     }
 
     private func ensureRoleSendCapable(_ transceiver: RTCRtpTransceiver) {
@@ -578,7 +597,7 @@ internal final class PeerConnectionSlot: PeerConnectionSlotProtocol {
             if mediaType == .audio {
                 applyOpusRedCodecPreferences(to: transceiver)
             }
-            if transceiver.sender.track !== track {
+            if !senderTrack(transceiver.sender.track, matches: track) {
                 transceiver.sender.track = track
             }
             let targetDirection: RTCRtpTransceiverDirection = (track != nil) ? .sendRecv : .recvOnly

--- a/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RemoteVideoTransceiverRoutingTests.swift
+++ b/client-ios/SerenadaCore/Tests/SerenadaCoreTests/RemoteVideoTransceiverRoutingTests.swift
@@ -87,6 +87,7 @@ final class RemoteVideoTransceiverRoutingTests: XCTestCase {
     /// callback, with the camera/content roles bound from one wrapper access.
     private func makeBoundSlot(
         _ peer: NegotiatedPeer,
+        onRenegotiationNeeded: @escaping (String) -> Void = { _ in },
         onRemoteCamera: @escaping (RTCVideoTrack?) -> Void
     ) -> PeerConnectionSlot {
         let slot = PeerConnectionSlot(
@@ -101,7 +102,7 @@ final class RemoteVideoTransceiverRoutingTests: XCTestCase {
             onConnectionStateChange: { _, _ in },
             onIceConnectionStateChange: { _, _ in },
             onSignalingStateChange: { _, _ in },
-            onRenegotiationNeeded: { _ in }
+            onRenegotiationNeeded: onRenegotiationNeeded
         )
         // Bind roles to the wrappers from ONE access — exactly what the production
         // binding caches. Later receive wrappers will be DIFFERENT objects.
@@ -114,6 +115,38 @@ final class RemoteVideoTransceiverRoutingTests: XCTestCase {
     }
 
     // MARK: - The regression
+
+    /// `RTCRtpSender.track` returns a fresh Objective-C wrapper on every read.
+    /// Assigning the content track with the camera off must recognize the
+    /// semantically equal wrapper and must not request fallback renegotiation.
+    func testContentSenderTrackAssignmentDoesNotRenegotiateForFreshWrapper() throws {
+        let peer = try makeNegotiatedPeer()
+        var renegotiationRequests: [String] = []
+        let slot = makeBoundSlot(
+            peer,
+            onRenegotiationNeeded: { renegotiationRequests.append($0) },
+            onRemoteCamera: { _ in }
+        )
+        let localContentTrack = peer.makeVideoTrack("local-content")
+
+        slot.attachLocalTracks(
+            cameraTrack: nil,
+            contentTrack: localContentTrack,
+            supportsIndependentContentVideo: true
+        )
+
+        let senderTrack = try XCTUnwrap(peer.contentWrapper.sender.track)
+        XCTAssertFalse(senderTrack === localContentTrack, "sender.track should return a fresh wrapper")
+        XCTAssertTrue(
+            senderTrack.isEqual(localContentTrack),
+            "fresh wrapper must represent the assigned content track"
+        )
+        XCTAssertTrue(
+            renegotiationRequests.isEmpty,
+            "successful assignment must not request fallback renegotiation"
+        )
+        slot.closePeerConnection()
+    }
 
     /// Inbound CAMERA track delivered on a fresh wrapper (distinct object, same
     /// mid "0" as the bound camera transceiver) must route to CAMERA. Before the


### PR DESCRIPTION
## Summary

- compare iOS WebRTC sender tracks with semantic equality instead of Objective-C wrapper identity
- avoid fallback renegotiation when `RTCRtpSender.track` returns a fresh wrapper for the track that was just assigned
- add regression coverage using real libwebrtc sender-track wrapper behavior

## Context

Follow-up to #151. The legacy screen-sharing path was correct, but the iOS sender verification could still treat equivalent WebRTC wrappers as different and unnecessarily renegotiate.

## Validation

- `RemoteVideoTransceiverRoutingTests`: 7 tests passed, including the fresh-wrapper regression
- physical iPhone-to-Desktop screen sharing with the iPhone camera off: passed
- no dependency changes

